### PR TITLE
Add more video formatting options

### DIFF
--- a/dataset/image_video_dataset.py
+++ b/dataset/image_video_dataset.py
@@ -49,7 +49,28 @@ try:
 except:
     pass
 
-VIDEO_EXTENSIONS = [".mp4", ".avi", ".mov", ".webm", ".MP4", ".AVI", ".MOV", ".WEBM"]  # some of them are not tested
+VIDEO_EXTENSIONS = [
+    ".mp4",
+    ".webm",
+    ".avi",
+    ".mkv",
+    ".mov",
+    ".flv",
+    ".wmv",
+    ".m4v",
+    ".mpg",
+    ".mpeg",
+    ".MP4",
+    ".WEBM",
+    ".AVI",
+    ".MKV",
+    ".MOV",
+    ".FLV",
+    ".WMV",
+    ".M4V",
+    ".MPG",
+    ".MPEG",
+]  # some of them are not tested
 
 ARCHITECTURE_HUNYUAN_VIDEO = "hv"
 


### PR DESCRIPTION
MKV, FLV, and WMV are more common, so they are increased.
MPEG、M4V has not been tested yet.

pyav is based on FFmpeg packaging, these formats should be supported.