### PR TITLE
Require torch >= 2.5.1 for sdpa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ toml==0.10.2
 tqdm==4.67.1
 transformers==4.46.3
 voluptuous==0.15.2
+torch>=2.5.1
 
 # optional dependencies
 # ascii-magic==2.3.0


### PR DESCRIPTION
According to https://github.com/kijai/ComfyUI-HunyuanVideoWrapper/issues/126 and also my own testing. Torch 2.5.1 is required to not get black videos when using sdpa attn_mode.