### PR TITLE
Add CAME optimizer, a confidence guided, memory efficient optimizer

### DIFF
--- a/hv_train_network.py
+++ b/hv_train_network.py
@@ -695,6 +695,20 @@ class NetworkTrainer:
             optimizer_class = transformers.optimization.Adafactor
             optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
+        elif optimizer_type == "CAME".lower():
+            logger.info(f"use CAME optimizer | {optimizer_kwargs}")
+            try:
+                import came_pytorch
+            except ImportError:
+                raise ImportError("No came-pytorch / came-pytorchがインストールされていないようです")
+            try:
+                optimizer_class = came_pytorch.CAME
+            except AttributeError:
+                raise AttributeError(
+                    "No CAME. Please install came-pytorch. / CAMEが定義されていません。came-pytorchがインストールされていないようです。"
+                )
+            optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
+
         elif optimizer_type == "AdamW".lower():
             logger.info(f"use AdamW optimizer | {optimizer_kwargs}")
             optimizer_class = torch.optim.AdamW


### PR DESCRIPTION
This simple PR adds the CAME optimizer ( https://github.com/yangluo7/CAME/ ) following previous examples in musubi-tuner and sdscripts. CAME is a confidence guided, memory efficient optimizer that 's useful in my tests. Default optimizer args that I use are:

```
--optimizer_args weight_decay=0.01 eps=(1e-30,1e-16) betas=(0.9,0.999,0.9999)
```