### PR TITLE
Add metadata to video using FFmpeg

### DIFF
--- a/hv_generate_video.py
+++ b/hv_generate_video.py
@@ -445,9 +445,9 @@ def parse_args():
         "--attn_mode", type=str, default="torch", choices=["flash", "torch", "sageattn", "xformers", "sdpa"], help="attention mode"
     )
     parser.add_argument("--split_attn", action="store_true", help="use split attention")
-    parser.add_argument("--vae_chunk_size", type=int, default=None, help="chunk size for CausalConv3d in VAE")
+    parser.add_argument("--vae_chunk_size", type=int, default=32, help="chunk size for CausalConv3d in VAE")
     parser.add_argument(
-        "--vae_spatial_tile_sample_min_size", type=int, default=None, help="spatial tile sample min size for VAE, default 256"
+        "--vae_spatial_tile_sample_min_size", type=int, default=128, help="spatial tile sample min size for VAE, default 256"
     )
     parser.add_argument("--blocks_to_swap", type=int, default=None, help="number of blocks to swap in the model")
     parser.add_argument("--img_in_txt_in_offloading", action="store_true", help="offload img_in and txt_in to cpu")


### PR DESCRIPTION
This update adds the --add_video_metadata option (default is False) to include the metadata of a generation in the final video output. 

**This works by:**
1. Generating the video.
2. Wrapping the metadata in a JSON.
3. Checking if FFmpeg exists and appending the metadata to the "comment" field in a temp file.
4. Removing the original, renaming the temp file to the original name.

**Why?**🤔
1. key/value pairs can be added arbitrarily but there may be compatibility issues with other software which might discard this.
2. PyAV seems to lack a way of adding metadata before generating the file (I may be mistaken)
3. If you need this, I assume FFmpeg is part of the path anyways and doesn't load any 3rd party libraries that require updates to the requirements.txt