### PR TITLE
fix: rope None at MMSingleStreamBlock

### DIFF
--- a/hunyuan_model/models.py
+++ b/hunyuan_model/models.py
@@ -836,7 +836,7 @@ class HYVideoDiffusionTransformer(nn.Module):  # ModelMixin, ConfigMixin):
                     cu_seqlens_kv,
                     max_seqlen_q,
                     max_seqlen_kv,
-                    (freqs_cos, freqs_sin),
+                    freqs_cis,
                 ]
                 if self.blocks_to_swap:
                     self.offloader_single.wait_for_block(block_idx)


### PR DESCRIPTION
Error occurs when rope is None at MMSingleStreamBlock, which causes None type doesn't have shape error. MMDoubleStreamBlock is fixed and the single hasn't.