### PR TITLE
fix Wan2.1 cached image latents shape

### DIFF
--- a/wan_cache_latents.py
+++ b/wan_cache_latents.py
@@ -71,7 +71,7 @@ def encode_and_save_batch(vae: WanVAE, clip: Optional[CLIPModel], batch: list[It
             y = vae.encode(images_resized)
         y = torch.stack(y, dim=0)  # B, C, F, H, W
 
-        y = y[:, :F]  # may be not needed
+        y = y[:, :, :F]  # may be not needed
         y = y.to(vae.dtype)  # convert to bfloat16
         y = torch.concat([msk, y], dim=1)  # B, 4 + C, F, H, W
 


### PR DESCRIPTION
The channel dimension of the latents was mistakenly sliced, causing errors in training data with a short number of frames.