### PR TITLE
lora exclude_patterns add modulation

### DIFF
--- a/networks/lora_wan.py
+++ b/networks/lora_wan.py
@@ -34,7 +34,7 @@ def create_arch_network(
         exclude_patterns = ast.literal_eval(exclude_patterns)
 
     # exclude if 'img_mod', 'txt_mod' or 'modulation' in the name
-    exclude_patterns.append(r".*(patch_embedding|text_embedding|time_embedding|time_projection|norm|head).*")
+    exclude_patterns.append(r".*(patch_embedding|text_embedding|time_embedding|time_projection|norm|head|modulation).*")
 
     kwargs["exclude_patterns"] = exclude_patterns
 


### PR DESCRIPTION
Because VRAM used by 14B is too much, I want to remove some modules.
It seems that the default excluded modulation is missing.

It is evident that the code of hunyuan lora train excludes modulation
https://github.com/kohya-ss/musubi-tuner/blob/ae14079929d1fc0915197704afc2ab734b857638/networks/lora.py#L317

It is also the case to refer to another repository
https://github.com/tdrussell/diffusion-pipe/blob/1b6d2fd056e690d4184b3260b37d2b6b1f58b8f4/models/wan.py#L22

Additionally, is it necessary to freeze the bias?