### PR TITLE
Add support for torch.compile and fast fp8 for generation

### DIFF
--- a/hunyuan_model/fp8_optimization.py
+++ b/hunyuan_model/fp8_optimization.py
@@ -1,0 +1,39 @@
+#based on ComfyUI's and MinusZoneAI's fp8_linear optimization
+#further borrowed from HunyuanVideoWrapper for Musubi Tuner
+import torch
+import torch.nn as nn
+
+def fp8_linear_forward(cls, original_dtype, input):
+    weight_dtype = cls.weight.dtype
+    if weight_dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
+        if len(input.shape) == 3:
+            target_dtype = torch.float8_e5m2 if weight_dtype == torch.float8_e4m3fn else torch.float8_e4m3fn
+            inn = input.reshape(-1, input.shape[2]).to(target_dtype)
+            w = cls.weight.t()
+
+            scale = torch.ones((1), device=input.device, dtype=torch.float32)
+            bias = cls.bias.to(original_dtype) if cls.bias is not None else None
+
+            if bias is not None:
+                o = torch._scaled_mm(inn, w, out_dtype=original_dtype, bias=bias, scale_a=scale, scale_b=scale)
+            else:
+                o = torch._scaled_mm(inn, w, out_dtype=original_dtype, scale_a=scale, scale_b=scale)
+
+            if isinstance(o, tuple):
+                o = o[0]
+
+            return o.reshape((-1, input.shape[1], cls.weight.shape[0]))
+        else:
+            return cls.original_forward(input.to(original_dtype))
+    else:
+        return cls.original_forward(input)
+
+def convert_fp8_linear(module, original_dtype, params_to_keep={}):
+    setattr(module, "fp8_matmul_enabled", True)
+   
+    for name, module in module.named_modules():
+        if not any(keyword in name for keyword in params_to_keep):
+            if isinstance(module, nn.Linear):
+                original_forward = module.forward
+                setattr(module, "original_forward", original_forward)
+                setattr(module, "forward", lambda input, m=module: fp8_linear_forward(m, original_dtype, input))


### PR DESCRIPTION
This PR adds support to hv_generate_video.py for torch.compile and fast fp8 math. Torch.compile improves speed and memory consumption on pretty much any hardware and the compile times of around a minute are well worth it when dealing with 10+ minute generations. FP8 acceleration is supported on RTX 4xxx (and probably 5xxx?) and is a very nice boon to speed with no quality hit. Combined they net me a speed boost of around 30% on my RTX 4070 TI Super, with slightly less memory usage as well. 

The fp8_optimization.py and implementation of that is ported from HunyuanVideoWrapper(with attribution in the comments). The torch.compile implementation is my own and targets only the single and double blocks since compiling other parts of the transformer isn't very beneficial but takes longer.

I tested this in various combinations on my own hardware and it seems to work very well and match or outperform the performance I get in ComfyUI! Hope it's helpful, cheers!