### PR TITLE
Use  not `create_network_from_weights_hunyuan_video` but `create_arch_network_from_weights`  in `merge_lora.py`

### DIFF
--- a/merge_lora.py
+++ b/merge_lora.py
@@ -45,7 +45,7 @@ def main():
 
             logger.info(f"Loading LoRA weights from {lora_weight} with multiplier {lora_multiplier}")
             weights_sd = load_file(lora_weight)
-            network = lora.create_network_from_weights_hunyuan_video(
+            network = lora.create_arch_network_from_weights(
                 lora_multiplier, weights_sd, unet=transformer, for_inference=True
             )
             logger.info("Merging LoRA weights to DiT model")


### PR DESCRIPTION
When executing `merge_lora.py`, there has something error as below:

> AttributeError: module 'networks.lora' has no attribute 'create_network_from_weights_hunyuan_video'


In `networks.lora`, `create_arch_network_from_weights` is defined, but `create_network_from_weights_hunyuan_video` **is not**. 

This patch updates the function call to use the existing and appropriate `create_arch_network_from_weights`.

Let me know if there's any context I'm missing!

