### PR TITLE
fix: take keep_cache as an argument instead of referencing it from args

### DIFF
--- a/cache_text_encoder_outputs.py
+++ b/cache_text_encoder_outputs.py
@@ -100,14 +100,14 @@ def process_text_encoder_batches(
 
 
 def post_process_cache_files(
-    datasets: list[BaseDataset], all_cache_files_for_dataset: list[set], all_cache_paths_for_dataset: list[set]
+    datasets: list[BaseDataset], all_cache_files_for_dataset: list[set], all_cache_paths_for_dataset: list[set], keep_cache: bool
 ):
     for i, dataset in enumerate(datasets):
         all_cache_files = all_cache_files_for_dataset[i]
         all_cache_paths = all_cache_paths_for_dataset[i]
         for cache_file in all_cache_files:
             if cache_file not in all_cache_paths:
-                if args.keep_cache:
+                if keep_cache:
                     logger.info(f"Keep cache file not in the dataset: {cache_file}")
                 else:
                     os.remove(cache_file)
@@ -181,7 +181,7 @@ def main(args):
     del text_encoder_2
 
     # remove cache files not in dataset
-    post_process_cache_files(datasets, all_cache_files_for_dataset, all_cache_paths_for_dataset)
+    post_process_cache_files(datasets, all_cache_files_for_dataset, all_cache_paths_for_dataset, args.keep_cache)
 
 
 def setup_parser_common():


### PR DESCRIPTION
Thank you for releasing `musubi-tuner`!

When I extracted `post_process_cache_files` into a function in https://github.com/kohya-ss/musubi-tuner/pull/110,
it seems that the reference to `args` in the old cache deletion process had not been corrected, so this is the fix.

<details>
<summary>日本語</summary>
`musubi-tuner` の公開、ありがとうございます！

https://github.com/kohya-ss/musubi-tuner/pull/110 において `post_process_cache_files` を関数に切り出した際、
古いキャッシュの削除処理の中で `args` を参照しているのが修正されていなかったようですので、その修正です。
</detials>