### PR TITLE
fix: update attention mask handling for `--split_attn`

### DIFF
--- a/src/musubi_tuner/fpack_generate_video.py
+++ b/src/musubi_tuner/fpack_generate_video.py
@@ -825,6 +825,7 @@ def prepare_text_inputs(
 
     if not (shared_models and "text_encoder1" in shared_models):  # if loaded locally
         del tokenizer1, text_encoder1, tokenizer2, text_encoder2
+        gc.collect()  # transformer==4.54.1 seems to need this to free memory
     else:  # if shared, move back to original device (likely CPU)
         if text_encoder1:
             text_encoder1.to(text_encoder1_original_device)
@@ -1895,6 +1896,7 @@ def process_batch_prompts(prompts_data: List[Dict], args: argparse.Namespace) ->
 
     # Models should be removed from device after prepare_text_inputs
     del tokenizer1_batch, text_encoder1_batch, tokenizer2_batch, text_encoder2_batch, temp_shared_models_txt, conds_cache_batch
+    gc.collect()  # transformer==4.54.1 seems to need this to free memory
     clean_memory_on_device(device)
 
     # 3. Load DiT Model once

--- a/src/musubi_tuner/frame_pack/hunyuan_video_packed_inference.py
+++ b/src/musubi_tuner/frame_pack/hunyuan_video_packed_inference.py
@@ -219,18 +219,18 @@ class HunyuanVideoTransformer3DModelPackedInference(HunyuanVideoTransformer3DMod
                 # If they are not same, then their impls are wrong. Ours are always the correct one.
                 text_len = encoder_attention_mask.sum().item()
                 encoder_hidden_states = encoder_hidden_states[:, :text_len]
-                attention_mask = None, None, None, None
+                attention_mask = None, None, None, None, None
             else:
                 img_seq_len = hidden_states.shape[1]
                 txt_seq_len = encoder_hidden_states.shape[1]
 
-                cu_seqlens_q = get_cu_seqlens(encoder_attention_mask, img_seq_len)
+                cu_seqlens_q, seq_len = get_cu_seqlens(encoder_attention_mask, img_seq_len)
                 cu_seqlens_kv = cu_seqlens_q
                 max_seqlen_q = img_seq_len + txt_seq_len
                 max_seqlen_kv = max_seqlen_q
 
-                attention_mask = cu_seqlens_q, cu_seqlens_kv, max_seqlen_q, max_seqlen_kv
-                del cu_seqlens_q, cu_seqlens_kv, max_seqlen_q, max_seqlen_kv  # free memory
+                attention_mask = cu_seqlens_q, cu_seqlens_kv, max_seqlen_q, max_seqlen_kv, seq_len
+                del cu_seqlens_q, cu_seqlens_kv, max_seqlen_q, max_seqlen_kv, seq_len  # free memory
         del encoder_attention_mask  # free memory
 
         if self.enable_teacache:


### PR DESCRIPTION
This fixes a bug where the attention mask was not applied correctly when the batch size for the training was 2 or more and `--split_attn` was specified.