### PR TITLE
feat: Fix support for schedulefree optimizer

### DIFF
--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -541,7 +541,7 @@ class NetworkTrainer:
     def is_schedulefree_optimizer(self, optimizer: torch.optim.Optimizer, args: argparse.Namespace) -> bool:
         return args.optimizer_type.lower().endswith("schedulefree".lower())  # or args.optimizer_schedulefree_wrapper
 
-    def get_dummy_scheduler(optimizer: torch.optim.Optimizer) -> Any:
+    def get_dummy_scheduler(self,optimizer: torch.optim.Optimizer) -> Any:
         # dummy scheduler for schedulefree optimizer. supports only empty step(), get_last_lr() and optimizers.
         # this scheduler is used for logging only.
         # this isn't be wrapped by accelerator because of this class is not a subclass of torch.optim.lr_scheduler._LRScheduler
@@ -2105,6 +2105,10 @@ class NetworkTrainer:
         logger.info(f"DiT dtype: {transformer.dtype}, device: {transformer.device}")
 
         clean_memory_on_device(accelerator.device)
+
+        # ADD THIS LINE for schedulefree
+        if hasattr(optimizer, 'train'):
+            optimizer.train()
 
         for epoch in range(epoch_to_start, num_train_epochs):
             accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")


### PR DESCRIPTION
### 1.1 発生していたエラー

1. **TypeError: NetworkTrainer.get_dummy_scheduler() takes 1 positional argument but 2 were given**
2. **Exception: Optimizer was not in train mode when step is called**

これらのエラーにより、RAdamScheduleFreeオプティマイザでの学習が実行できない状態でした。

### 1.2 エラーログ詳細

```
File "D:\Musubi\musubi-tuner\src\musubi_tuner\hv_train_network.py", line 566, in get_lr_scheduler
    return self.get_dummy_scheduler(optimizer)
TypeError: NetworkTrainer.get_dummy_scheduler() takes 1 positional argument but 2 were given
```

```
Exception: Optimizer was not in train mode when step is called. Please insert .train() and .eval() calls on the optimizer. See documentation for details.
```

### 2.1 修正の目的

1. **get_dummy_scheduler関数**: `self`パラメータが欠落していたため、メソッド呼び出し時に引数数エラーが発生していました。
2. **trainモード初期化**: schedulefreeオプティマイザは初期化時にevalモードで作成されるため、学習開始前にtrainモードに切り替える必要がありました。

### 3.1 改修の効果

**2つのエラーを解決**: 
- `get_dummy_scheduler`の引数エラー → `self`パラメータ追加で解決
- `Optimizer was not in train mode`エラー → 初期化時のtrainモード設定で解決

**既存機能との連携**: 既存のoptimizer_eval_fn/train_fn機能が正常動作 
**他オプティマイザへの影響**: hasattr条件分岐により、AdamW等には影響ないと考えています