### PR TITLE
Add REX learning rate scheduler

### DIFF
--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -613,6 +613,85 @@ class NetworkTrainer:
             # logger.info(f"adafactor scheduler init lr {initial_lr}")
             return wrap_check_needless_num_warmup_steps(transformers.optimization.AdafactorSchedule(optimizer, initial_lr))
 
+        if name.lower() == "rex":
+            class RexLR(torch.optim.lr_scheduler.LRScheduler):
+                """
+                Reflected Exponential (REX) learning rate scheduler (https://arxiv.org/abs/2107.04197)
+                Modified from: https://github.com/IvanVassi/REX_LR
+
+                Args:
+                    optimizer (torch.optim.Optimizer): The optimizer to schedule the learning rate for
+                    max_lr (float): The maximum learning rate
+                    min_lr (float): The minimum learning rate
+                    num_steps (int): The total number of training steps
+                    num_warmup_steps (int): The number of warmup steps
+                    last_epoch (int): The index of the last step
+                """
+
+                def __init__(self, optimizer, max_lr, min_lr=0.0, num_steps=0, num_warmup_steps=0, last_epoch=-1):
+                    if min_lr > max_lr:
+                        raise ValueError(
+                            f"Value of \"min_lr\" should be less than value of \"max_lr\". "
+                            f"Got min_lr={min_lr} and max_lr={max_lr}"
+                        )
+                    if num_warmup_steps > num_steps:
+                        raise ValueError(
+                            f"num_warmup_steps ({num_warmup_steps}) must be less than "
+                            f"or equal to num_steps ({num_steps})"
+                        )
+
+                    self.min_lr = min_lr
+                    self.max_lr = max_lr
+                    self.num_steps = num_steps
+                    self.num_warmup_steps = num_warmup_steps
+                    self.last_epoch = last_epoch
+
+                    # Ensure each parameter group has an "initial_lr" key to avoid issues when resuming
+                    for group in optimizer.param_groups:
+                        group.setdefault("initial_lr", group["lr"])
+
+                    super().__init__(optimizer, last_epoch)
+
+                def get_lr(self):
+                    # Single warmup step
+                    if self.num_warmup_steps == 1 and self.last_epoch == 1:
+                        return [self.min_lr for _ in self.base_lrs]
+                    # Multiple warmup steps; increase lr linearly from min_lr to max_lr
+                    elif self.num_warmup_steps > 1 and self.last_epoch >= 1 and self.last_epoch <= (self.num_warmup_steps - 1):
+                        return [
+                            self.min_lr + (self.max_lr - self.min_lr) * (self.last_epoch - 1) / (self.num_warmup_steps - 1)
+                            for _ in self.base_lrs
+                        ]
+
+                    # Post-warmup phase: adjust step relative to the end of warmup
+                    step_after = self.last_epoch - self.num_warmup_steps
+                    remaining_steps = self.num_steps - self.num_warmup_steps
+
+                    # Avoid LR spiking
+                    if step_after >= remaining_steps or step_after == -1 or remaining_steps <= 0:
+                        return [self.min_lr for _ in self.base_lrs]
+
+                    # Calculate REX curve for current step
+                    rex_z = (remaining_steps - (step_after % remaining_steps)) / remaining_steps
+                    rex_factor = (  # The paper uses 0.5+0.5, but IvanVassi used 0.1+0.9 which feels better
+                        self.min_lr / self.max_lr
+                        + (1.0 - self.min_lr / self.max_lr) * (rex_z / (0.1 + 0.9 * rex_z))
+                    )
+
+                    return [base_lr * rex_factor for base_lr in self.base_lrs]
+
+            return RexLR(
+                optimizer,
+                max_lr=args.learning_rate,
+                min_lr=(  # Will start and end with min_lr, use non-zero min_lr by default
+                    args.learning_rate * min_lr_ratio if min_lr_ratio is not None
+                    else args.learning_rate * 0.01
+                ),
+                num_steps=num_training_steps,
+                num_warmup_steps=num_warmup_steps,
+                **lr_scheduler_kwargs,
+            )
+
         if name == DiffusersSchedulerType.PIECEWISE_CONSTANT.value:
             name = DiffusersSchedulerType(name)
             schedule_func = DIFFUSERS_TYPE_TO_SCHEDULER_FUNCTION[name]
@@ -2478,7 +2557,7 @@ def setup_parser_common() -> argparse.ArgumentParser:
         "--lr_scheduler",
         type=str,
         default="constant",
-        help="scheduler to use for learning rate / 学習率のスケジューラ: linear, cosine, cosine_with_restarts, polynomial, constant (default), constant_with_warmup, adafactor",
+        help="scheduler to use for learning rate / 学習率のスケジューラ: linear, cosine, cosine_with_restarts, polynomial, constant (default), constant_with_warmup, adafactor, rex",
     )
     parser.add_argument(
         "--lr_warmup_steps",


### PR DESCRIPTION
This adds the REX learning rate scheduler from [**REX: Revisiting Budgeted Training with an Improved Schedule**](https://arxiv.org/abs/2107.04197). The implementation was modified from [IvanVassi/REX_LR](https://github.com/IvanVassi/REX_LR).

Use `--lr_scheduler rex` to choose it. Supports `--lr_scheduler_min_lr_ratio` and `--lr_warmup_steps`.

`--lr_scheduler_min_lr_ratio 0.01` is used by default, as without it the first step (if using warmup) and last step will use 0 learning rate.

Example with `--lr_scheduler rex --learning_rate 1e-4 --lr_scheduler_min_lr_ratio 0.01 --lr_warmup_steps 10 --max_train_steps 100`, comparing the paper's values (`0.5+0.5`) and the values IvanVassi's implementation used (`0.1+0.9`). This PR is using `0.1+0.9`.
<img width="1089" height="617" alt="rex-comparison" src="https://github.com/user-attachments/assets/a7bf1386-a451-45e0-bcaa-99fabe98a218" />