### PR TITLE
Fix bugs when qwen-image use lycoris

### DIFF
--- a/src/musubi_tuner/qwen_image_generate_image.py
+++ b/src/musubi_tuner/qwen_image_generate_image.py
@@ -296,7 +296,17 @@ def load_dit_model(
     # merge LoRA weights
     if args.lycoris:
         if args.lora_weight is not None and len(args.lora_weight) > 0:
-            merge_lora_weights(lora_qwen_image, model, args, device)
+            merge_lora_weights(
+                lora_qwen_image,
+                model,
+                args.lora_weight,
+                args.lora_multiplier,
+                args.include_patterns,
+                args.exclude_patterns,
+                device,
+                lycoris=True,
+                save_merged_model=args.save_merged_model,
+            )
 
         if args.fp8_scaled:
             # load state dict as-is and optimize to fp8


### PR DESCRIPTION
Additionally, I found that an error occurs when `args.fp8_scale=true`.

```
Traceback (most recent call last):
  File "D:\musubi-tuner-scripts\musubi-tuner\qwen_image_generate_image.py", line 4, in <module>
    main()
  File "D:\musubi-tuner-scripts\musubi-tuner\src\musubi_tuner\qwen_image_generate_image.py", line 1211, in main
    returned_vae, latent = generate(args, gen_settings)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\musubi-tuner-scripts\musubi-tuner\src\musubi_tuner\qwen_image_generate_image.py", line 595, in generate
    model = load_dit_model(args, device, dit_weight_dtype)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\musubi-tuner-scripts\musubi-tuner\src\musubi_tuner\qwen_image_generate_image.py", line 284, in load_dit_model
    model = qwen_image_model.load_qwen_image_model(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\musubi-tuner-scripts\musubi-tuner\src\musubi_tuner\qwen_image\qwen_image_model.py", line 1218, in load_qwen_image_model
    assert (not fp8_scaled and dit_weight_dtype is not None) or (fp8_scaled and dit_weight_dtype is None)
```

Another issue is that when using lycoris with `fp8=true and fp8_scale=false`
Since the device is on the CPU, the FP8 operator cannot be used...