### PR TITLE
bugfix: fix mask initialization for wan flf2v inference

### DIFF
--- a/src/musubi_tuner/wan_generate_video.py
+++ b/src/musubi_tuner/wan_generate_video.py
@@ -1142,7 +1142,10 @@ def prepare_i2v_inputs(
         msk[:, 0] = 1
         if has_end_image:
             # this process is confirmed by official code for FLF2V
-            msk[:, -1] = 1
+            if config.flf2v:
+                msk[-1, -1] = 1
+            else:
+                msk[:, -1] = 1
 
         # encode image to latent space
         with accelerator.autocast(), torch.no_grad():


### PR DESCRIPTION
This PR fixes a bug in `prepare_i2v_inputs` where the mask assignment for the last frame was incorrect for flf2v.

# Explanation

Take generating 13 frames of video as an example, the mask is initialized as:
```
[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] (1x1, 0x11, 1x1).
```

Since the first frame is encoded separately, then the first element of the mask is repeated 4 times, resulting in:
```
[1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] (1x4, 0x11, 1x1).
```

Then the mask is reshaped to fit the temporal stride of VAE:
```
[[1, 0, 0, 0],
 [1, 0, 0, 0],
 [1, 0, 0, 0],
 [1, 0, 0, 1]].
```

However, in this codebase, by using `msk[:, -1] = 1`, the mask is initialized as:
```
[[1, 0, 0, 1],
 [1, 0, 0, 1],
 [1, 0, 0, 1],
 [1, 0, 0, 1]],
```
which is incorrect for flf2v inference. This is only correct when the last frame is also encoded separately.

# Conclusion

Let's look at the code snippet below to have a clear view of the mask initialization:

```
# encode image to latent space
with accelerator.autocast(), torch.no_grad():
    if not config.flf2v or not has_end_image:
        # padding to match the required number of frames
        padding_frames = frames - 1  # the first frame is image
        img_resized = torch.concat([img_resized, torch.zeros(3, padding_frames, height, width, device=device)], dim=1)
        y = vae.encode([img_resized])[0]

        if has_end_image:
            y_end = vae.encode([end_img_resized])[0]
          # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          # In this branch, the end image is encoded separately, in this case,
          # we should use `msk[:, -1] = 1`
            y = torch.concat([y, y_end], dim=1)  # add end frame
    else:
        # FLF2V: encode image and end image together
        padding_frames = frames - 2  # first and last frames are images
        img_resized = torch.concat(
            [img_resized, torch.zeros(3, padding_frames, height, width, device=device), end_img_resized], dim=1
        )
        y = vae.encode([img_resized])[0]
      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      # In this branch, the end image is encoded along with the rest part of the
      # video, so we should use `msk[-1, -1] = 1`
```