### PR TITLE
fix(wan): FlashAttention-3 call error

### DIFF
--- a/src/musubi_tuner/wan/modules/attention.py
+++ b/src/musubi_tuner/wan/modules/attention.py
@@ -226,7 +226,7 @@ def flash_attention(
             softmax_scale=softmax_scale,
             causal=causal,
             deterministic=deterministic,
-        )[0].unflatten(0, (b, lq))
+        ).unflatten(0, (b, lq))
     # elif (version is None or version == 2) and FLASH_ATTN_2_AVAILABLE:
     #     # assert FLASH_ATTN_2_AVAILABLE
     #     x = flash_attn.flash_attn_varlen_func(


### PR DESCRIPTION
Ref: https://github.com/Wan-Video/Wan2.2/pull/64

Confirmed works on:
- Task: training Wan2.2-A14B-I2V Lora with `src/musubi_tuner/wan_train_network`
- GPU: 2*H20, launch training with `accelerate launch --multi_gpu`
- Python 3.12, Pytorch 2.7.0, CUDA 12.8
- FlashAttention-3: using pre-built wheel from [mesolitica/Flash-Attention3-whl](https://huggingface.co/datasets/mesolitica/Flash-Attention3-whl), launch training with `--flash3`

Also seen ~20% speedup.