### PR TITLE
feat: Add flag to disable cuDNN PyTorch backend when caching

### DIFF
--- a/src/musubi_tuner/cache_latents.py
+++ b/src/musubi_tuner/cache_latents.py
@@ -366,6 +366,7 @@ def setup_parser_common() -> argparse.ArgumentParser:
         default=None,
         help="debug mode: not interactive, number of images to show for each dataset",
     )
+    parser.add_argument("--disable_cudnn_backend", action="store_true", help="Disable CUDNN PyTorch backend. May be useful for AMD GPUs.")
     return parser
 
 

--- a/src/musubi_tuner/flux_kontext_cache_latents.py
+++ b/src/musubi_tuner/flux_kontext_cache_latents.py
@@ -92,6 +92,10 @@ def main():
 
     args = parser.parse_args()
 
+    if args.disable_cudnn_backend:
+        print("Disabling cuDNN PyTorch backend.")
+        torch.backends.cudnn.enabled = False
+
     if args.vae_dtype is not None:
         raise ValueError("VAE dtype is not supported in FLUX.1 Kontext.")
 

--- a/src/musubi_tuner/fpack_cache_latents.py
+++ b/src/musubi_tuner/fpack_cache_latents.py
@@ -379,6 +379,10 @@ def main():
 
     args = parser.parse_args()
 
+    if args.disable_cudnn_backend:
+        print("Disabling cuDNN PyTorch backend.")
+        torch.backends.cudnn.enabled = False
+
     if args.vae_dtype is not None:
         raise ValueError("VAE dtype is not supported in FramePack")
     # if args.batch_size != 1:

--- a/src/musubi_tuner/qwen_image_cache_latents.py
+++ b/src/musubi_tuner/qwen_image_cache_latents.py
@@ -84,6 +84,10 @@ def main():
 
     args = parser.parse_args()
 
+    if args.disable_cudnn_backend:
+        print("Disabling cuDNN PyTorch backend.")
+        torch.backends.cudnn.enabled = False
+
     if args.vae_dtype is not None:
         raise ValueError("VAE dtype is not supported in Qwen-Image.")
 

--- a/src/musubi_tuner/wan_cache_latents.py
+++ b/src/musubi_tuner/wan_cache_latents.py
@@ -215,6 +215,10 @@ def main():
 
     args = parser.parse_args()
 
+    if args.disable_cudnn_backend:
+        print("Disabling cuDNN PyTorch backend.")
+        torch.backends.cudnn.enabled = False
+
     if args.clip is not None:
         args.i2v = True
 


### PR DESCRIPTION
Supposedly MIOpen has some troubles when it comes to VAEs, causing major slowdowns. ROCm/TheRock#1542 made me aware of the issue in contexts of inference, but it also seems to matter here for caching too.

This simply adds a flag to set `torch.backends.cudnn.enabled = False`. **Caching speed for 1024\*1024 buckets is 1.53x faster and 1280\*1280 buckets is 34.23x faster.** 1536\*1536 buckets is too slow by default for me to directly compare, but it's a lot faster.

I have only tested qwen image caching, but I assume this would apply to the others. I have not checked if `torch.backends.cudnn.enabled` matters during training, so I don't know if any benefit is to be had there, so I didn't add it.

# Comparison

These are the times to cache an example dataset with 100 images for qwen image. I ran the caching twice, with the times below being the second run so that it's seen the shapes before. System info at the bottom.

## 1024*1024 buckets
- With flag: `100it [00:34, 2.91it/s]`
- Without flag: `100it [00:52, 1.90it/s]`

## 1280*1280 buckets
- With flag: `100it [01:04,1.54it/s]`
- Without flag: `100it [36:31, 21.91s/it]`

## 1536*1536 buckets
- With flag: `100it [01:54, 1.15s/it]`
- Without flag: `20it [23:26, 60.27s/it]` (Too slow, this is first run and not the entire set.)

# System Info

<details>
  <summary>venv</summary>

```
Using Python 3.12.3 environment at: venv
Package             Version                    Editable project location
------------------- -------------------------- --------------------------------------
accelerate          1.6.0
annotated-types     0.7.0
av                  14.0.1
bitsandbytes        0.48.0.dev0
came-pytorch        0.1.3
certifi             2025.8.3
charset-normalizer  3.4.3
click               8.2.1
contourpy           1.3.3
cycler              0.12.1
diffusers           0.32.1
easydict            1.13
einops              0.7.0
filelock            3.18.0
fonttools           4.59.1
fsspec              2025.5.1
ftfy                6.3.1
gitdb               4.0.12
gitpython           3.1.45
hf-xet              1.1.7
huggingface-hub     0.34.3
idna                3.10
importlib-metadata  8.7.0
jinja2              3.1.6
kiwisolver          1.4.9
markupsafe          2.1.5
matplotlib          3.10.5
mpmath              1.3.0
musubi-tuner        0.1.0                      /media/xzuyn/NVMe/LClones/musubi-tuner
networkx            3.5
numpy               2.3.1
opencv-python       4.10.0.84
packaging           25.0
pillow              11.3.0
pip                 25.2
platformdirs        4.3.8
protobuf            6.31.1
psutil              7.0.0
pydantic            2.11.7
pydantic-core       2.33.2
pyparsing           3.2.3
python-dateutil     2.9.0.post0
pytorch-triton-rocm 3.4.0+gitf7888497
pyyaml              6.0.2
regex               2025.7.34
requests            2.32.4
safetensors         0.4.5
sentencepiece       0.2.0
sentry-sdk          2.34.1
setuptools          78.1.0
six                 1.17.0
smmap               5.0.2
sympy               1.14.0
tokenizers          0.21.4
toml                0.10.2
torch               2.9.0.dev20250811+rocm6.4
torchvision         0.24.0.dev20250813+rocm6.4
tqdm                4.67.1
transformers        4.54.1
typing-extensions   4.14.0
typing-inspection   0.4.1
urllib3             2.5.0
voluptuous          0.15.2
wandb               0.21.1
wcwidth             0.2.13
zipp                3.23.0
```

</details>

<details>
  <summary>neofetch</summary>

```
            .-/+oossssoo+/-.               xzuyn@JOHN-V4 
        `:+ssssssssssssssssss+:`           ------------- 
      -+ssssssssssssssssssyyssss+-         OS: Ubuntu 24.04.2 LTS x86_64 
    .ossssssssssssssssssdMMMNysssso.       Host: MS-7D18 1.0 
   /ssssssssssshdmmNNmmyNMMMMhssssss/      Kernel: 6.8.0-84-generic 
  +ssssssssshmydMMMMMMMNddddyssssssss+     Uptime: 2 hours, 48 mins 
 /sssssssshNMMMyhhyyyyhmNMMMNhssssssss/    Packages: 2747 (dpkg), 14 (flatpak), 23 (snap) 
.ssssssssdMMMNhsssssssssshNMMMdssssssss.   Shell: bash 5.2.21 
+sssshhhyNMMNyssssssssssssyNMMMysssssss+   Resolution: 1920x1080 
ossyNMMMNyMMhsssssssssssssshmmmhssssssso   DE: GNOME 46.0 
ossyNMMMNyMMhsssssssssssssshmmmhssssssso   WM: Mutter 
+sssshhhyNMMNyssssssssssssyNMMMysssssss+   WM Theme: Adwaita 
.ssssssssdMMMNhsssssssssshNMMMdssssssss.   Theme: Yaru-purple-dark [GTK2/3] 
 /sssssssshNMMMyhhyyyyhdNMMMNhssssssss/    Icons: Yaru-purple [GTK2/3] 
  +sssssssssdmydMMMMMMMMddddyssssssss+     Terminal: gnome-terminal 
   /ssssssssssshdmNNNNmyNMMMMhssssss/      CPU: Intel i5-10400F (12) @ 4.300GHz 
    .ossssssssssssssssssdMMMNysssso.       GPU: AMD ATI Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M 
      -+sssssssssssssssssyyyssss+-         Memory: 9368MiB / 31989MiB 
        `:+ssssssssssssssssss+:`
            .-/+oossssoo+/-.
```

</details>

<details>
  <summary>ROCm & HIP versions</summary>

```
xzuyn@JOHN-V4:~$ dpkg -l | grep rocm
ii  rocm                                           6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) software stack meta package
ii  rocm-cmake                                     0.14.0.60400-47~24.04                    amd64        rocm-cmake built using CMake
ii  rocm-core                                      6.4.0.60400-47~24.04                     amd64        ROCm Runtime software stack
ii  rocm-dbgapi                                    0.77.2.60400-47~24.04                    amd64        Library to provide AMD GPU debugger API
ii  rocm-debug-agent                               2.0.4.60400-47~24.04                     amd64        Radeon Open Compute Debug Agent (ROCdebug-agent)
ii  rocm-developer-tools                           6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-device-libs                               1.0.0.60400-47~24.04                     amd64        Radeon Open Compute - device libraries
ii  rocm-gdb                                       15.2.60400-47~24.04                      amd64        ROCgdb
ii  rocm-hip-libraries                             6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-hip-runtime                               6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-hip-runtime-dev                           6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-hip-sdk                                   6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-language-runtime                          6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-llvm                                      19.0.0.25133.60400-47~24.04              amd64        ROCm core compiler
ii  rocm-ml-libraries                              6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-ml-sdk                                    6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-opencl                                    2.0.0.60400-47~24.04                     amd64        clr built using CMake
ii  rocm-opencl-dev                                2.0.0.60400-47~24.04                     amd64        clr built using CMake
ii  rocm-opencl-runtime                            6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-opencl-sdk                                6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-openmp-sdk                                6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) OpenMP Software development Kit.
ii  rocm-smi-lib                                   7.5.0.60400-47~24.04                     amd64        AMD System Management libraries
ii  rocm-utils                                     6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocminfo                                       1.0.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime rocminfo tool
xzuyn@JOHN-V4:~$ dpkg -l | grep hip
ii  hip-dev                                        6.4.43482.60400-47~24.04                 amd64        HIP:Heterogenous-computing Interface for Portability
ii  hip-doc                                        6.4.43482.60400-47~24.04                 amd64        HIP:Heterogenous-computing Interface for Portability
ii  hip-runtime-amd                                6.4.43482.60400-47~24.04                 amd64        HIP:Heterogenous-computing Interface for Portability
ii  hip-samples                                    6.4.43482.60400-47~24.04                 amd64        HIP: Heterogenous-computing Interface for Portability [HIP SAMPLES]
ii  hipblas                                        2.4.0.60400-47~24.04                     amd64        ROCm BLAS marshalling library
ii  hipblas-common-dev                             1.0.0.60400-47~24.04                     amd64        Common files for hipBLAS libraries
ii  hipblas-dev                                    2.4.0.60400-47~24.04                     amd64        ROCm BLAS marshalling library
ii  hipblaslt                                      0.12.0.60400-47~24.04                    amd64        HIP library for GEMM operations with extended functionality
ii  hipblaslt-dev                                  0.12.0.60400-47~24.04                    amd64        HIP library for GEMM operations with extended functionality
ii  hipcc                                          1.1.1.60400-47~24.04                     amd64        hipcc built using CMake
ii  hipcub-dev                                     3.4.0.60400-47~24.04                     amd64        hipCUB (rocPRIM backend)
ii  hipfft                                         1.0.18.60400-47~24.04                    amd64        ROCm FFT marshalling library
ii  hipfft-dev                                     1.0.18.60400-47~24.04                    amd64        ROCm FFT marshalling library
ii  hipfort-dev                                    0.6.0.60400-47~24.04                     amd64        Fortran Interface For GPU Kernel Libraries
ii  hipify-clang                                   19.0.0.60400-47~24.04                    amd64        Hipify CUDA source
ii  hiprand                                        2.12.0.60400-47~24.04                    amd64        Radeon Open Compute RAND library
ii  hiprand-dev                                    2.12.0.60400-47~24.04                    amd64        Radeon Open Compute RAND library
ii  hipsolver                                      2.4.0.60400-47~24.04                     amd64        Radeon Open Compute LAPACK marshalling library
ii  hipsolver-dev                                  2.4.0.60400-47~24.04                     amd64        Radeon Open Compute LAPACK marshalling library
ii  hipsparse                                      3.2.0.60400-47~24.04                     amd64        ROCm SPARSE library
ii  hipsparse-dev                                  3.2.0.60400-47~24.04                     amd64        ROCm SPARSE library
ii  hipsparselt                                    0.2.3.60400-47~24.04                     amd64        ROCm Structured Sparsity Matrix Multiplication marshalling library
ii  hipsparselt-dev                                0.2.3.60400-47~24.04                     amd64        ROCm Structured Sparsity Matrix Multiplication marshalling library
ii  hiptensor                                      1.5.0.60400-47~24.04                     amd64        AMD high-performance HIP library for tensor primitives
ii  hiptensor-dev                                  1.5.0.60400-47~24.04                     amd64        AMD high-performance HIP library for tensor primitives
ii  libamdhip64-5                                  5.7.1-3                                  amd64        Heterogeneous Interface for Portability - AMD GPUs implementation
ii  libflashrom1:amd64                             1.3.0-2.1ubuntu2                         amd64        Identify, read, write, erase, and verify BIOS/ROM/flash chips - library
ii  miopen-hip                                     3.4.0.60400-47~24.04                     amd64        AMD DNN Library
ii  miopen-hip-dev                                 3.4.0.60400-47~24.04                     amd64        AMD DNN Library
ii  rocm-hip-libraries                             6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-hip-runtime                               6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-hip-runtime-dev                           6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  rocm-hip-sdk                                   6.4.0.60400-47~24.04                     amd64        Radeon Open Compute (ROCm) Runtime software stack
ii  whiptail                                       0.52.24-2ubuntu2                         amd64        Displays user-friendly dialog boxes from shell scripts
```

</details>