### PR TITLE
Free VRAM for lazy loading in batch prompt mode

### DIFF
--- a/src/musubi_tuner/wan_generate_video.py
+++ b/src/musubi_tuner/wan_generate_video.py
@@ -1488,6 +1488,11 @@ def run_sampling(
             # update latent
             latent = temp_x0.squeeze(0)
 
+    if len(models) > 1 and args.lazy_loading:  # lazy loading
+        del model
+        gc.collect()
+        clean_memory_on_device(device)
+
     return latent
 
 


### PR DESCRIPTION
Hi, I'm running into out-of-memory errors when starting the second prompt in batch prompt mode with Wan 2.2 14B inference (specifically t2v).

I think that it's simply not unloading the low noise model correctly when starting the next prompt (based on my VRAM usage being steady for the first inference and then doubling on starting the high noise section of the second prompt).

I'm not sure why the `model` variable doesn't get garbage collected automatically when leaving the `run_sampling` function (maybe because in some paths through the code it's referencing the contents of `models`?), but adding this simple if statement at the end fixes the issue for me!

