### PR TITLE
support datasets in json format as well as jsonl

### DIFF
--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -966,14 +966,18 @@ class ImageJsonlDatasource(ImageDatasource):
         # load jsonl
         logger.info(f"load image jsonl from {self.image_jsonl_file}")
         self.data = []
-        with open(self.image_jsonl_file, "r", encoding="utf-8") as f:
-            for line in f:
-                try:
-                    data = json.loads(line)
-                except json.JSONDecodeError:
-                    logger.error(f"failed to load json: {line} @ {self.image_jsonl_file}")
-                    raise
-                self.data.append(data)
+        try:
+            with open(self.image_jsonl_file, "r", encoding="utf-8") as f:
+                self.data = json.loads(f.read())
+        except json.decoder.JSONDecodeError:
+            with open(self.image_jsonl_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.error(f"failed to load json: {line} @ {self.image_jsonl_file}")
+                        raise
+                    self.data.append(data)
         logger.info(f"loaded {len(self.data)} images")
 
         # Normalize control paths


### PR DESCRIPTION
Datasets were only supported in jsonl format where each line contains one-line json entry (separated by '\n').  I didn't even know that it actually exists as a standard https://jsonlines.org/, I thought it's just a non-standard format for this project. I've added support for datasets in the standard json list format, i.e. what happens when you do `json.dumps(myListOfDicts, indent=2)`

jsonl
```jsonl
{"image_path": "...", "caption": "..."}
{"image_path": "...", "caption": "..."}
{"image_path": "...", "caption": "..."}
{"image_path": "...", "caption": "..."}

```

json
```json
[
  {
    "image_path": "...",
    "caption": "..."
  },
  {
    "image_path": "...",
    "caption": "..."
  },
  {
    "image_path": "...",
    "caption": "..."
  },
  {
    "image_path": "...",
    "caption": "..."
  }
]
```

I don't think it's needed to rename config names, or to look at extension instead of try-except for this. `dataset_jsonl` can be interpreted as just a json list, not json lines