### PR TITLE
Add --skip_existing to cache latents

### DIFF
--- a/src/musubi_tuner/cache_latents.py
+++ b/src/musubi_tuner/cache_latents.py
@@ -337,7 +337,20 @@ def main():
 
     # Encode images
     def encode(one_batch: list[ItemInfo]):
-        encode_and_save_batch(vae, one_batch)
+        if args.skip_existing:
+            batch_to_process = []
+            import os
+            for item in one_batch:
+                if os.path.exists(item.latent_cache_path):
+                    logger.info(f"Cache file exists, skipping: {item.latent_cache_path}")
+                else:
+                    batch_to_process.append(item)
+            
+            if not batch_to_process:
+                return
+        else:
+            batch_to_process = one_batch
+        encode_and_save_batch(vae, batch_to_process)
 
     encode_datasets(datasets, encode, args)
 
@@ -368,6 +381,11 @@ def setup_parser_common() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--disable_cudnn_backend", action="store_true", help="Disable CUDNN PyTorch backend. May be useful for AMD GPUs."
+    )
+    parser.add_argument(
+        "--skip_existing",
+        action="store_true",
+        help="Skip encoding if the latent cache file already exists.",
     )
     return parser
 

--- a/src/musubi_tuner/flux_kontext_cache_latents.py
+++ b/src/musubi_tuner/flux_kontext_cache_latents.py
@@ -125,7 +125,20 @@ def main():
 
     # encoding closure
     def encode(batch: List[ItemInfo]):
-        encode_and_save_batch(ae, batch)
+        if args.skip_existing:
+            batch_to_process = []
+            import os
+            for item in batch:
+                if os.path.exists(item.latent_cache_path):
+                    logger.info(f"Cache file exists, skipping: {item.latent_cache_path}")
+                else:
+                    batch_to_process.append(item)
+            
+            if not batch_to_process:
+                return
+        else:
+            batch_to_process = batch
+        encode_and_save_batch(ae, batch_to_process)
 
     # reuse core loop from cache_latents with no change
     cache_latents.encode_datasets(datasets, encode, args)

--- a/src/musubi_tuner/fpack_cache_latents.py
+++ b/src/musubi_tuner/fpack_cache_latents.py
@@ -422,8 +422,21 @@ def main():
 
     # encoding closure
     def encode(batch: List[ItemInfo]):
+        if args.skip_existing:
+            batch_to_process = []
+            import os
+            for item in batch:
+                if os.path.exists(item.latent_cache_path):
+                    logger.info(f"Cache file exists, skipping: {item.latent_cache_path}")
+                else:
+                    batch_to_process.append(item)
+            
+            if not batch_to_process:
+                return
+        else:
+            batch_to_process = batch
         encode_and_save_batch(
-            vae, feature_extractor, image_encoder, batch, args.f1, args.one_frame, args.one_frame_no_2x, args.one_frame_no_4x
+            vae, feature_extractor, image_encoder, batch_to_process, args.f1, args.one_frame, args.one_frame_no_2x, args.one_frame_no_4x
         )
 
     # reuse core loop from cache_latents with no change

--- a/src/musubi_tuner/qwen_image_cache_latents.py
+++ b/src/musubi_tuner/qwen_image_cache_latents.py
@@ -151,7 +151,20 @@ def main():
 
     # encoding closure
     def encode(batch: List[ItemInfo]):
-        encode_and_save_batch(vae, batch)
+        if args.skip_existing:
+            batch_to_process = []
+            import os
+            for item in batch:
+                if os.path.exists(item.latent_cache_path):
+                    logger.info(f"Cache file exists, skipping: {item.latent_cache_path}")
+                else:
+                    batch_to_process.append(item)
+            
+            if not batch_to_process:
+                return
+        else:
+            batch_to_process = batch
+        encode_and_save_batch(vae, batch_to_process)
 
     # reuse core loop from cache_latents with no change
     cache_latents.encode_datasets(datasets, encode, args)

--- a/src/musubi_tuner/wan_cache_latents.py
+++ b/src/musubi_tuner/wan_cache_latents.py
@@ -294,11 +294,6 @@ def wan_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         action="store_true",
         help="Generate cache for one frame training (single frame, single section).",
     )
-    parser.add_argument(
-        "--skip_existing",
-        action="store_true",
-        help="Skip encoding if the latent cache file already exists.",
-    )
     return parser
 
 


### PR DESCRIPTION
I'm trying to do >700 videos at full 81 frames at 720P on my RTX4080 and even caching the latents is going to take a week.
It often OOMs half way through this, and ordinarily it would just have to start again, overwriting the existing files, so I wanted a -skip_existing feature to be able to start back at where I got up to before it OOM'd