### PR TITLE
fix: Remove required flag from argument parsers in training scripts

### DIFF
--- a/src/musubi_tuner/fpack_train_network.py
+++ b/src/musubi_tuner/fpack_train_network.py
@@ -607,7 +607,7 @@ def framepack_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argument
     parser.add_argument(
         "--vae_spatial_tile_sample_min_size", type=int, default=None, help="spatial tile sample min size for VAE, default 256"
     )
-    parser.add_argument("--image_encoder", type=str, required=True, help="Image encoder (CLIP) checkpoint path or directory")
+    parser.add_argument("--image_encoder", type=str, default=None, help="Image encoder (CLIP) checkpoint path or directory")
     parser.add_argument("--latent_window_size", type=int, default=9, help="FramePack latent window size (default 9)")
     parser.add_argument("--bulk_decode", action="store_true", help="decode all frames at once in sample generation")
     parser.add_argument("--f1", action="store_true", help="Use F1 sampling method for sample generation")

--- a/src/musubi_tuner/hv_1_5_train_network.py
+++ b/src/musubi_tuner/hv_1_5_train_network.py
@@ -471,9 +471,9 @@ def hv1_5_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     )
     parser.add_argument("--dit_dtype", type=str, default=None, help="data type for DiT, default is bfloat16")
     parser.add_argument("--fp8_scaled", action="store_true", help="use scaled fp8 for DiT")
-    parser.add_argument("--text_encoder", type=str, default=None, required=True, help="text encoder (Qwen2.5-VL) checkpoint path")
+    parser.add_argument("--text_encoder", type=str, default=None, help="text encoder (Qwen2.5-VL) checkpoint path")
     parser.add_argument("--fp8_vl", action="store_true", help="use fp8 for Text Encoder model")
-    parser.add_argument("--byt5", type=str, default=None, required=True, help="BYT5 checkpoint path")
+    parser.add_argument("--byt5", type=str, default=None, help="BYT5 checkpoint path")
     parser.add_argument("--image_encoder", type=str, default=None, help="SigLIP image encoder path (for I2V cache compatibility)")
     parser.add_argument(
         "--vae_sample_size",

--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -1214,7 +1214,6 @@ def setup_parser() -> argparse.ArgumentParser:
         "--dataset_config",
         type=pathlib.Path,
         default=None,
-        required=True,
         help="config file for dataset / データセットの設定ファイル",
     )
 
@@ -1443,7 +1442,7 @@ def setup_parser() -> argparse.ArgumentParser:
     )
 
     # model settings
-    parser.add_argument("--dit", type=str, required=True, help="DiT checkpoint path / DiTのチェックポイントのパス")
+    parser.add_argument("--dit", type=str, default=None, help="DiT checkpoint path / DiTのチェックポイントのパス")
     parser.add_argument("--dit_dtype", type=str, default=None, help="data type for DiT, default is bfloat16")
     parser.add_argument("--dit_in_channels", type=int, default=16, help="input channels for DiT, default is 16, skyreels I2V is 32")
     parser.add_argument("--vae", type=str, help="VAE checkpoint path / VAEのチェックポイントのパス")
@@ -1544,7 +1543,6 @@ def setup_parser() -> argparse.ArgumentParser:
         "--output_name",
         type=str,
         default=None,
-        required=True,
         help="base name of trained model file / 学習後のモデルの拡張子を除くファイル名",
     )
     parser.add_argument("--resume", type=str, default=None, help="saved state to resume training / 学習再開するモデルのstate")

--- a/src/musubi_tuner/zimage_train_network.py
+++ b/src/musubi_tuner/zimage_train_network.py
@@ -329,7 +329,7 @@ def zimage_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
     """Z-Image specific parser setup"""
     # parser.add_argument("--dit_dtype", type=str, default=None, help="data type for DiT, default is bfloat16")
     parser.add_argument("--fp8_scaled", action="store_true", help="use scaled fp8 for DiT")
-    parser.add_argument("--text_encoder", type=str, required=True, help="Qwen3 text encoder checkpoint path")
+    parser.add_argument("--text_encoder", type=str, default=None, help="Qwen3 text encoder checkpoint path")
     parser.add_argument("--fp8_llm", action="store_true", help="use fp8 for Text Encoder model")
     parser.add_argument(
         "--use_32bit_attention",


### PR DESCRIPTION
This breaks loading config from file. Closes #764.

Checking for required arguments will be addressed in a separate pull request.