### PR TITLE
Log `d*eff_lr` for ProdigyPlusScheduleFree, and some cleanup of LR logging

### DIFF
--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -403,12 +403,12 @@ class NetworkTrainer:
             if lr_descriptions is not None:
                 lr_desc = lr_descriptions[i]
             else:
-                idx = i - (0 if network_train_unet_only else -1)
+                idx = i - (0 if network_train_unet_only else 1)
                 if idx == -1:
                     lr_desc = "textencoder"
                 else:
                     if len(lrs) > 2:
-                        lr_desc = f"group{idx}"
+                        lr_desc = f"group{i}"
                     else:
                         lr_desc = "unet"
 
@@ -419,26 +419,12 @@ class NetworkTrainer:
                 logs[f"lr/d*lr/{lr_desc}"] = (
                     lr_scheduler.optimizers[-1].param_groups[i]["d"] * lr_scheduler.optimizers[-1].param_groups[i]["lr"]
                 )
-            if (
-                args.optimizer_type.lower().endswith("ProdigyPlusScheduleFree".lower()) and optimizer is not None
-            ):  # tracking d*lr value of unet.
-                logs["lr/d*lr"] = optimizer.param_groups[0]["d"] * optimizer.param_groups[0]["lr"]
-        else:
-            idx = 0
-            if not network_train_unet_only:
-                logs["lr/textencoder"] = float(lrs[0])
-                idx = 1
 
-            for i in range(idx, len(lrs)):
-                logs[f"lr/group{i}"] = float(lrs[i])
-                if args.optimizer_type.lower().startswith("DAdapt".lower()) or args.optimizer_type.lower().endswith(
-                    "Prodigy".lower()
-                ):
-                    logs[f"lr/d*lr/group{i}"] = (
-                        lr_scheduler.optimizers[-1].param_groups[i]["d"] * lr_scheduler.optimizers[-1].param_groups[i]["lr"]
-                    )
-                if args.optimizer_type.lower().endswith("ProdigyPlusScheduleFree".lower()) and optimizer is not None:
-                    logs[f"lr/d*lr/group{i}"] = optimizer.param_groups[i]["d"] * optimizer.param_groups[i]["lr"]
+            if args.optimizer_type.lower().endswith("ProdigyPlusScheduleFree".lower()) and optimizer is not None:
+                # tracking d*lr value of unet.
+                logs[f"lr/d*lr/{lr_desc}"] = optimizer.param_groups[i]["d"] * optimizer.param_groups[i]["lr"]
+                if "effective_lr" in optimizer.param_groups[i]:
+                    logs[f"lr/d*eff_lr/{lr_desc}"] = optimizer.param_groups[i]["d"] * optimizer.param_groups[i]["effective_lr"]
 
         return logs
 


### PR DESCRIPTION
When using ProdigyPlusScheduleFree, I'd like to add `d * effective_lr` to the logs. Compared to `d * lr`, it's a closer approximation to the LR in the traditional sense, see their [README](https://github.com/LoganBooker/prodigy-plus-schedule-free) for details. It's only available since prodigy-plus-schedule-free 2.0.0 .

While implementing this, I noticed a few problems in the current logging:
1. There is a `for ... else ...` block (which is a valid construct in Python). There is no `break` in the `for ...` block, so the `else ...` block will always execute, and log the same things twice.
    If I understand correctly, the `else ...` block was used to handle the case that `lr_descriptions` is None, but now it's already handled in the `for ...` block, so we can remove the `else ...` block.
2. `idx = i - (0 if network_train_unet_only else -1)` will never set `idx` to -1. It should be `idx = i - (0 if network_train_unet_only else 1)` (No one noticed this because nowadays no one trains the text encoder?)
3. `lr_desc = f"group{idx}"` looks inconsistent that the displayed param group index is different from the actual index in the optimizer, which will make debugging a bit more difficult. It's better to do `lr_desc = f"group{i}"`, which was already in the `else ...` block.
4. Nowadays ProdigyPlusScheduleFree supports multiple param groups, so we change `optimizer.param_groups[0]` to `optimizer.param_groups[i]`.

Screenshot before this PR, with the same things logged twice:
<img width="3018" height="1559" alt="{90A1DA10-E729-461D-8958-A1B28CF049AF}" src="https://github.com/user-attachments/assets/9a283fc7-4dc6-4b28-9986-9e625ea99db0" />

After this PR:
<img width="2987" height="1571" alt="{93CFC04B-CECD-49AD-AA1C-D0A717A561CE}" src="https://github.com/user-attachments/assets/bf5b5df0-4f56-49bf-8a85-c3fa2d473b90" />

This PR also applies to the sd3 branch of sd-scripts.