### PR TITLE
Fix train db compile bugs

### DIFF
--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -519,7 +519,21 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
 
             metadata_to_save.update(sai_metadata)
 
-            state_dict = unwrapped_model.state_dict()
+            # temporarily remove self-referencing _orig_mod to avoid infinite recursion in state_dict()
+            has_self_ref_orig_mod_module = (
+                hasattr(unwrapped_model, "_modules")
+                and "_orig_mod" in unwrapped_model._modules
+                and unwrapped_model._modules["_orig_mod"] is unwrapped_model
+            )
+            if has_self_ref_orig_mod_module:
+                del unwrapped_model._modules["_orig_mod"]
+
+            try:
+                state_dict = unwrapped_model.state_dict()
+            finally:
+                # restore _orig_mod after state_dict() if it was removed
+                if has_self_ref_orig_mod_module:
+                    unwrapped_model._modules["_orig_mod"] = unwrapped_model
 
             # if model is compiled, get original model state dict
             if "transformer_blocks.0._orig_mod.attn.add_k_proj.bias" in state_dict:


### PR DESCRIPTION
#
Unlike training LoRA, compiling when training DB will cause an infinite loop when saving weights, I got this error when training 32000steps, and I failed to save weights....
```
saving checkpoint: ./output_dir\zimage_db_qinglong-step00000010.safetensors
Traceback (most recent call last):
  File "D:\musubi-tuner-scripts\musubi-tuner\zimage_train.py", line 4, in <module>
    main()
  File "D:\musubi-tuner-scripts\musubi-tuner\src\musubi_tuner\zimage_train.py", line 686, in main
    trainer.train(args)
  File "D:\musubi-tuner-scripts\musubi-tuner\src\musubi_tuner\zimage_train.py", line 567, in train
    save_model(
  File "D:\musubi-tuner-scripts\musubi-tuner\src\musubi_tuner\zimage_train.py", line 454, in save_model
    state_dict = unwrapped_model.state_dict()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\musubi-tuner-scripts\.venv\Lib\site-packages\torch\nn\modules\module.py", line 2265, in state_dict
    module.state_dict(
  File "D:\musubi-tuner-scripts\.venv\Lib\site-packages\torch\nn\modules\module.py", line 2265, in state_dict
    module.state_dict(
  File "D:\musubi-tuner-scripts\.venv\Lib\site-packages\torch\nn\modules\module.py", line 2265, in state_dict
    module.state_dict(
  [Previous line repeated 991 more times]
  File "D:\musubi-tuner-scripts\.venv\Lib\site-packages\torch\nn\modules\module.py", line 2262, in state_dict
    self._save_to_state_dict(destination, prefix, keep_vars)
  File "D:\musubi-tuner-scripts\.venv\Lib\site-packages\torch\nn\modules\module.py", line 2155, in _save_to_state_dict
    for name, param in self._parameters.items():
                       ^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded while calling a Python object
```