### PR TITLE
Prevent NaN during Z-Image-Turbo fp16 training

### DIFF
--- a/src/musubi_tuner/zimage/zimage_model.py
+++ b/src/musubi_tuner/zimage/zimage_model.py
@@ -275,7 +275,9 @@ class ZImageTransformerBlock(nn.Module):
             del scale_msa
             x = x + gate_msa * self.attention_norm2(clamp_fp16(attn_out))
             del gate_msa
-            x = x + gate_mlp * self.ffn_norm2(clamp_fp16(self.feed_forward(self.ffn_norm1(x) * scale_mlp, apply_fp16_downscale=True)))
+            x = x + gate_mlp * self.ffn_norm2(
+                clamp_fp16(self.feed_forward(self.ffn_norm1(x) * scale_mlp, apply_fp16_downscale=True))
+            )
             del scale_mlp, gate_mlp
         else:
             attn_out = self.attention(self.attention_norm1(x), freqs_cis=freqs_cis, attn_params=attn_params)


### PR DESCRIPTION
Port of the NaN prevention method for ComfyUI, consisting of the clamping in the ComfyUI Lumina 2 code, and the scaling method in the pull request by @vanDuven (https://github.com/comfyanonymous/ComfyUI/pull/11187). Currently specifying `--mixed_precision fp16` will result the average loss to become NaN (as opposed to `--mixed_precision bf16`, for example). After the change, fp16 trains stably and also more efficiently on pre-bf16 hardware.

Note that the remaining issues mentioned with ComfyUI is not applicable here, as this is modifies code for Z-Image-Turbo only.