### PR TITLE
fix: Handle __index_timestep_zero__ metadata key in qwen_image_train.py for Edit-2511 checkpoints

### DIFF
--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -120,6 +120,11 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                     state_dict[state_dict_key] = f.get_tensor(key, device=loading_device, dtype=dit_weight_dtype)
             synchronize_device(loading_device)
 
+        # Add after line 121 (after synchronize_device)
+        if "__index_timestep_zero__" in state_dict:  # ComfyUI flag for edit-2511
+            assert args.edit_version == "2511", "Found __index_timestep_zero__ in state_dict, the model must be '2511' variant. Use --edit_version 2511"
+            state_dict.pop("__index_timestep_zero__")
+        
         info = model.load_state_dict(state_dict, strict=True, assign=True)
         logger.info(f"Loaded DiT model from {dit_path}, info={info}")
 


### PR DESCRIPTION
## Summary

Adds handling for the `__index_timestep_zero__` ComfyUI metadata key in `qwen_image_train.py`, consistent with the existing implementation in `qwen_image_model.py`.

## Problem

When fine-tuning Qwen-Image-Edit-2511 using checkpoints from ComfyUI-repackaged models (e.g., `Comfy-Org/Qwen-Image-Edit_ComfyUI`), training fails with:
```
RuntimeError: Error(s) in loading state_dict for QwenImageTransformer2DModel:
        Unexpected key(s) in state_dict: "__index_timestep_zero__".
```

## Root Cause

The `__index_timestep_zero__` key is a validation marker embedded by ComfyUI to identify Edit-2511 checkpoints. The inference code in `qwen_image_model.py` (lines 1404-1406) already handles this:
```python
if "__index_timestep_zero__" in sd:  # ComfyUI flag for edit-2511
    assert zero_cond_t, "Found __index_timestep_zero__ in state_dict, the model must be '2511' variant."
    sd.pop("__index_timestep_zero__")
```

However, `qwen_image_train.py` was missing this logic.

## Solution

Add the same handling to `load_transformer()` in `qwen_image_train.py`:
```python
if "__index_timestep_zero__" in state_dict:  # ComfyUI flag for edit-2511
    assert args.edit_version == "2511", \
        "Found __index_timestep_zero__ in state_dict, the model must be '2511' variant. Use --edit_version 2511"
    state_dict.pop("__index_timestep_zero__")
```

This provides:

- **Validation**: Ensures users specify `--edit_version 2511` when using 2511 checkpoints
- **Compatibility**: Removes the metadata key before `load_state_dict(strict=True)`

## Changes

- `src/musubi_tuner/qwen_image_train.py`: Added `__index_timestep_zero__` handling in `load_transformer()` method

## Testing

- [x] Training starts successfully with `qwen_image_edit_2511_bf16.safetensors` from Comfy-Org
- [x] Assert triggers correctly when using 2511 checkpoint without `--edit_version 2511`