### PR TITLE
Add CUDA 13.0 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ cu128 = [
     "torch>=2.7.1",
     "torchvision>=0.22.1",
 ]
+cu130 = [
+    "torch>=2.9.1",
+    "torchvision>=0.24.1",
+]
 gui = [
     "gradio>=4.0.0, <6.0.0",
 ]
@@ -44,6 +48,7 @@ conflicts = [
   [
     { extra = "cu124" },
     { extra = "cu128" },
+    { extra = "cu130" },
   ],
 ]
 
@@ -64,10 +69,12 @@ build-backend = "hatchling.build"
 torch = [
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
+  { index = "pytorch-cu130", extra = "cu130" },
 ]
 torchvision = [
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
+  { index = "pytorch-cu130", extra = "cu130" },
 ]
 
 [[tool.uv.index]]
@@ -78,6 +85,11 @@ explicit = true
 [[tool.uv.index]]
 name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
 [tool.ruff]


### PR DESCRIPTION
# WHAT IS THIS
Using `uv` on Windows 11 with a 16GB RTX5070 GPU installed, this required CUDA 13.0 PyTorch build to work (via `uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu130 --force-reinstall`).

This simply adds the minimum necessary changes to ensure the trainer via the GUI actually uses the GPU and not the CPU, when executing via `uv run --extra gui .\src\musubi_tuner\gui\gui.py`

Evidence of auto-installed versions via `uv`:
<img width="1095" height="398" alt="image" src="https://github.com/user-attachments/assets/3fec0855-e0d2-4241-a75d-c2e395be9f4d" />
