### PR TITLE
Minimum fix to work for MPS backend (for Mac OS)

### DIFF
--- a/src/musubi_tuner/cache_latents.py
+++ b/src/musubi_tuner/cache_latents.py
@@ -300,8 +300,16 @@ def main():
     parser = hv_setup_parser(parser)
 
     args = parser.parse_args()
-    device = args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu"
-    
+    device = (
+        args.device
+        if args.device is not None
+        else "cuda"
+        if torch.cuda.is_available()
+        else "mps"
+        if torch.mps.is_available()
+        else "cpu"
+    )
+
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/cache_text_encoder_outputs.py
@@ -137,7 +137,15 @@ def main():
 
     args = parser.parse_args()
 
-    device = args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu"
+    device = (
+        args.device
+        if args.device is not None
+        else "cuda"
+        if torch.cuda.is_available()
+        else "mps"
+        if torch.mps.is_available()
+        else "cpu"
+    )
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/caption_images_by_qwen_vl.py
+++ b/src/musubi_tuner/caption_images_by_qwen_vl.py
@@ -194,7 +194,7 @@ def process_images(args):
     # Set device
     device = args.device if args.device else ("cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu")
     device = torch.device(device)
-    
+
     logger.info(f"Using device: {device}")
     logger.info(f"Output format: {args.output_format}")
     if args.fp8_vl:

--- a/src/musubi_tuner/gui/gui.py
+++ b/src/musubi_tuner/gui/gui.py
@@ -924,7 +924,7 @@ num_repeats = 1
             # Construct the full command string
             # list2cmdline will quote arguments as needed
             inner_cmd_str = subprocess.list2cmdline(inner_cmd)
-            is_windows = (os.name == "nt")
+            is_windows = os.name == "nt"
 
             # Chain commands: Run training -> echo message -> pause >nul (hides default message)
             if is_windows:
@@ -941,7 +941,7 @@ num_repeats = 1
                     flags = subprocess.CREATE_NEW_CONSOLE
                     # Pass explicit 'cmd', '/c', string to ensure proper execution
                     cmd_list = ["cmd", "/c"].extend(cmd_list)
-                
+
                 subprocess.Popen(cmd_list, creationflags=flags, shell=(is_windows is False))
                 if is_windows:
                     return f"Training started in a new window! / 新しいウィンドウで学習が開始されました！\nCommand: {inner_cmd_str}"
@@ -1145,4 +1145,4 @@ num_repeats = 1
 
 if __name__ == "__main__":
     demo = construct_ui()
-    demo.launch(i18n=i18n, server_name="0.0.0.0")
+    demo.launch(i18n=i18n)

--- a/src/musubi_tuner/zimage_cache_latents.py
+++ b/src/musubi_tuner/zimage_cache_latents.py
@@ -96,7 +96,11 @@ def main():
     if args.vae_dtype is not None:
         logger.warning("VAE dtype is specified but Z-Image VAE always uses float32 for better precision.")
 
-    device = args.device if hasattr(args, "device") and args.device else ("cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu")
+    device = (
+        args.device
+        if hasattr(args, "device") and args.device
+        else ("cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu")
+    )
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/zimage_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/zimage_cache_text_encoder_outputs.py
@@ -58,7 +58,11 @@ def main():
 
     args = parser.parse_args()
 
-    device = args.device if args.device is not None else ("cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu")
+    device = (
+        args.device
+        if args.device is not None
+        else ("cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu")
+    )
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/zimage_generate_image.py
+++ b/src/musubi_tuner/zimage_generate_image.py
@@ -1010,7 +1010,15 @@ def main():
     latents_mode = args.latent_path is not None and len(args.latent_path) > 0
 
     # Set device
-    device = args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu"
+    device = (
+        args.device
+        if args.device is not None
+        else "cuda"
+        if torch.cuda.is_available()
+        else "mps"
+        if torch.mps.is_available()
+        else "cpu"
+    )
     device = torch.device(device)
     logger.info(f"Using device: {device}")
     args.device = device


### PR DESCRIPTION
# WHAT IS THIS
As per https://github.com/kohya-ss/musubi-tuner/issues/790, some minor code changes were required to allow seamless usage of musubi-tuner GUI via `uv run --extra gui python src/musubi_tuner/gui/gui.py` and actually succeed with running both pre-training and training steps to use GPU instead of CPU via PyTorch MPS backend.

Tested with M3 Ultra 256GB Mac Studio running MacOS Sequoia 15.7.2.

# Notes
- Mixed precision must be set to **no**
- Block swap not working (currently assumes CUDA (or XPU via PR https://github.com/kohya-ss/musubi-tuner/pull/801) which is not available for Mac OS PyTorch, likely addressed elsewhere)
- FP8 not supported
- For MacOS "Darwin" platform, optimizer will always use `adamw` instead of `adamw8bit` due to missing operation per https://github.com/pytorch/pytorch/issues/141287#issuecomment-3690857294 and https://github.com/bitsandbytes-foundation/bitsandbytes/issues/1402 (though it probably should be disabled for CPU as well for all platforms?)
- For larger training sets, you definitely want to set both `PYTORCH_MPS_LOW_WATERMARK` `PYTORCH_MPS_HIGH_WATERMARK` to non-zero values as currently PyTorch MPS backend has a tendency to run away with RAM hogging otherwise.