### PR TITLE
fix: FLUX.2 Gradient Checkpointing CPU Offload

### DIFF
--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -706,7 +706,7 @@ class LastLayer(nn.Module):
         if shift.ndim == 2:
             shift = shift[:, None, :]
             scale = scale[:, None, :]
-        x = x.to(torch.float32)  # for numerical stability
+        x = x.to(dtype=torch.float32, device=scale.device)  # for numerical stability
         x = (1 + scale) * self.norm_final(x) + shift
         x = self.linear(x)
         return x.to(org_dtype)


### PR DESCRIPTION
Fixes this problem when you use `--gradient_checkpointing_cpu_offload`.
```
Traceback (most recent call last):
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/src/musubi_tuner/flux_2_train_network.py", line 363, in <module>
    main()
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/src/musubi_tuner/flux_2_train_network.py", line 359, in main
    trainer.train(args)
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/src/musubi_tuner/hv_train_network.py", line 2292, in train
    model_pred, target = self.call_dit(
                         ^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/src/musubi_tuner/flux_2_train_network.py", line 323, in call_dit
    model_pred = model(x=img_input, x_ids=img_input_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance_vec)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1783, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1794, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/venv/lib/python3.12/site-packages/accelerate/utils/operations.py", line 814, in forward
    return model_forward(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/venv/lib/python3.12/site-packages/accelerate/utils/operations.py", line 802, in __call__
    return convert_to_fp32(self.model_forward(*args, **kwargs))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/venv/lib/python3.12/site-packages/torch/amp/autocast_mode.py", line 44, in decorate_autocast
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/src/musubi_tuner/flux_2/flux2_models.py", line 651, in forward
    img = self.final_layer(img, vec)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1783, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1794, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/xzuyn/NVMe/LClones/musubi-tuner/src/musubi_tuner/flux_2/flux2_models.py", line 710, in forward
    x = (1 + scale) * self.norm_final(x) + shift
        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```