### PR TITLE
fix: move image tensor to GPU for gradient checkpointing CPU offloading

### DIFF
--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -646,6 +646,8 @@ class Flux2(nn.Module):
 
         del single_block_mod, pe
 
+        img = img.to(vec.device)  # move to gpu if gradient checkpointing cpu offloading is used
+
         img = img[:, num_txt_tokens:, ...]
 
         img = self.final_layer(img, vec)


### PR DESCRIPTION
This issue was reported in #867. Thank you xzuyn for reporting the issue.