### PR TITLE
feat: add LoHa and LoKr network modules with architecture detection

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,9 @@
 GitHub Discussionsを有効にしました。コミュニティのQ&A、知識共有、技術情報の交換などにご利用ください。バグ報告や機能リクエストにはIssuesを、質問や経験の共有にはDiscussionsをご利用ください。[Discussionはこちら](https://github.com/kohya-ss/musubi-tuner/discussions)
 
 - 2026/02/15
+    - LoHa/LoKrの学習に対応しました。[PR #900](https://github.com/kohya-ss/musubi-tuner/pull/900)
+        - LyCORISのLoHa/LoKrアルゴリズムに基づいて実装されています。LyCORISプロジェクトのKohakuBlueleaf氏に深く感謝します。
+        - 詳細は[ドキュメント](./docs/loha_lokr.md)を参照してください。
     - Z-Imageのfine-tuningで、blocks_to_swapを使用している場合に、一部のオプティマイザを使用可能にする`--block_swap_optimizer_patch_params`オプションを追加しました。[PR #899](https://github.com/kohya-ss/musubi-tuner/pull/899)
         - 詳細は[ドキュメント](./docs/zimage.md#finetuning)を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ If you find this project helpful, please consider supporting its development via
 GitHub Discussions Enabled: We've enabled GitHub Discussions for community Q&A, knowledge sharing, and technical information exchange. Please use Issues for bug reports and feature requests, and Discussions for questions and sharing experiences. [Join the conversation →](https://github.com/kohya-ss/musubi-tuner/discussions)
 
 - February 15, 2026
+    - Added support for LoHa/LoKr training. See [PR #900](https://github.com/kohya-ss/musubi-tuner/pull/900)
+        - Implemented based on the LoHa/LoKr algorithms from LyCORIS. Special thanks to KohakuBlueleaf from the LyCORIS project.
+        - Please refer to the [documentation](./docs/loha_lokr.md) for details.
     - Added `--block_swap_optimizer_patch_params` option to enable the use of some optimizers when using `blocks_to_swap` in Z-Image fine-tuning. See [PR #899](https://github.com/kohya-ss/musubi-tuner/pull/899)
         - Please refer to the [documentation](./docs/zimage.md#finetuning) for details.
         

--- a/docs/loha_lokr.md
+++ b/docs/loha_lokr.md
@@ -320,12 +320,12 @@ LoHa/LoKrのネイティブサポートがあるアーキテクチャ（上記�
 
 ### Format conversion / フォーマット変換
 
-`convert_lora.py` supports only standard LoRA format conversion (between Musubi Tuner format and Diffusers format). LoHa/LoKr weights have different parameter structures and are not supported by this conversion tool. Support for LoHa/LoKr conversion (e.g., for ComfyUI) is planned for a future update.
+`convert_lora.py` is extended to also support format conversion of LoHa/LoKr weights between Musubi Tuner format and Diffusers format for ComfyUI.
 
 <details>
 <summary>日本語</summary>
 
-`convert_lora.py` は標準LoRAのフォーマット変換（Musubi Tuner形式とDiffusers形式間の変換）のみをサポートしています。LoHa/LoKrの重みはパラメータ構造が異なるため、この変換ツールではサポートされていません。LoHa/LoKrの変換（ComfyUI向けなど）は今後のアップデートで対応予定です。
+`convert_lora.py` は、LoRAに加えて、LoHa/LoKrの重みのフォーマット変換（Musubi Tuner形式とDiffusers形式間の変換）についてもサポートするよう、拡張されています。
 
 </details>
 

--- a/docs/loha_lokr.md
+++ b/docs/loha_lokr.md
@@ -31,6 +31,17 @@ Musubi Tunerでは、標準的なLoRAに加え、代替のパラメータ効率�
 
 </details>
 
+## Acknowledgments / 謝辞
+
+The LoHa and LoKr implementations in Musubi Tuner are based on the [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS) project by [KohakuBlueleaf](https://github.com/KohakuBlueleaf). We would like to express our sincere gratitude for the excellent research and open-source contributions that made this implementation possible.
+
+<details>
+<summary>日本語</summary>
+
+Musubi TunerのLoHaおよびLoKrの実装は、[KohakuBlueleaf](https://github.com/KohakuBlueleaf)氏による[LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS)プロジェクトに基づいています。この実装を可能にしてくださった素晴らしい研究とオープンソースへの貢献に心から感謝いたします。
+
+</details>
+
 ## Supported architectures / 対応アーキテクチャ
 
 LoHa and LoKr automatically detect the model architecture and apply appropriate default settings. The following architectures are supported:
@@ -326,16 +337,5 @@ LoHa/LoKrのネイティブサポートがあるアーキテクチャ（上記�
 <summary>日本語</summary>
 
 `convert_lora.py` は、LoRAに加えて、LoHa/LoKrの重みのフォーマット変換（Musubi Tuner形式とDiffusers形式間の変換）についてもサポートするよう、拡張されています。
-
-</details>
-
-## Acknowledgments / 謝辞
-
-The LoHa and LoKr implementations in Musubi Tuner are based on the [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS) project by [KohakuBlueleaf](https://github.com/KohakuBlueleaf). We would like to express our sincere gratitude for the excellent research and open-source contributions that made this implementation possible.
-
-<details>
-<summary>日本語</summary>
-
-Musubi TunerのLoHaおよびLoKrの実装は、[KohakuBlueleaf](https://github.com/KohakuBlueleaf)氏による[LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS)プロジェクトに基づいています。この実装を可能にしてくださった素晴らしい研究とオープンソースへの貢献に心から感謝いたします。
 
 </details>

--- a/docs/loha_lokr.md
+++ b/docs/loha_lokr.md
@@ -1,0 +1,337 @@
+> 📝 Click on the language section to expand / 言語をクリックして展開
+
+# LoHa / LoKr (LyCORIS)
+
+## Overview / 概要
+
+In addition to standard LoRA, Musubi Tuner supports **LoHa** (Low-rank Hadamard Product) and **LoKr** (Low-rank Kronecker Product) as alternative parameter-efficient fine-tuning methods. These are based on techniques from the [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS) project.
+
+- **LoHa**: Represents weight updates as a Hadamard (element-wise) product of two low-rank matrices. Reference: [FedPara (arXiv:2108.06098)](https://arxiv.org/abs/2108.06098)
+- **LoKr**: Represents weight updates as a Kronecker product with optional low-rank decomposition. Reference: [LoKr (arXiv:2309.14859)](https://arxiv.org/abs/2309.14859)
+
+Both methods target Linear layers only (Conv2d layers are not supported in this implementation).
+
+This feature is experimental.
+
+<details>
+<summary>日本語</summary>
+
+Musubi Tunerでは、標準的なLoRAに加え、代替のパラメータ効率の良いファインチューニング手法として **LoHa**（Low-rank Hadamard Product）と **LoKr**（Low-rank Kronecker Product）をサポートしています。これらは [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS) プロジェクトの手法に基づいています。
+
+- **LoHa**: 重みの更新を2つの低ランク行列のHadamard積（要素ごとの積）で表現します。参考文献: [FedPara (arXiv:2108.06098)](https://arxiv.org/abs/2108.06098)
+- **LoKr**: 重みの更新をKronecker積と、オプションの低ランク分解で表現します。参考文献: [LoKr (arXiv:2309.14859)](https://arxiv.org/abs/2309.14859)
+
+いずれもLinear層のみを対象としています（Conv2d層はこの実装ではサポートしていません）。
+
+この機能は実験的なものです。
+
+</details>
+
+## Supported architectures / 対応アーキテクチャ
+
+LoHa and LoKr automatically detect the model architecture and apply appropriate default settings. The following architectures are supported:
+
+- HunyuanVideo
+- HunyuanVideo 1.5
+- Wan 2.1/2.2
+- FramePack
+- FLUX.1 Kontext / FLUX.2
+- Qwen-Image series
+- Z-Image
+
+Kandinsky5 is **not supported** with LoHa/LoKr (it requires special handling that is incompatible with automatic architecture detection).
+
+Each architecture has its own default `exclude_patterns` to skip non-trainable modules (e.g., modulation layers, normalization layers). These are applied automatically when using LoHa/LoKr.
+
+<details>
+<summary>日本語</summary>
+
+LoHaとLoKrは、モデルのアーキテクチャを自動で検出し、適切なデフォルト設定を適用します。以下のアーキテクチャに対応しています:
+
+- HunyuanVideo
+- HunyuanVideo 1.5
+- Wan 2.1/2.2
+- FramePack
+- FLUX.1 Kontext / FLUX.2
+- Qwen-Image系
+- Z-Image
+
+Kandinsky5はLoHa/LoKrに **対応していません**（自動アーキテクチャ検出と互換性のない特殊な処理が必要です）。
+
+各アーキテクチャには、学習対象外のモジュール（modulation層、normalization層など）をスキップするデフォルトの `exclude_patterns` が設定されています。LoHa/LoKr使用時にはこれらが自動的に適用されます。
+
+</details>
+
+## Training / 学習
+
+To use LoHa or LoKr, change the `--network_module` argument in your training command. All other training options (dataset config, optimizer, etc.) remain the same as LoRA.
+
+<details>
+<summary>日本語</summary>
+
+LoHaまたはLoKrを使用するには、学習コマンドの `--network_module` 引数を変更します。その他の学習オプション（データセット設定、オプティマイザなど）はLoRAと同じです。
+
+</details>
+
+### LoHa
+
+```bash
+accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 src/musubi_tuner/hv_train_network.py \
+    --dit path/to/dit \
+    --dataset_config path/to/toml \
+    --sdpa --mixed_precision bf16 --fp8_base \
+    --optimizer_type adamw8bit --learning_rate 2e-4 --gradient_checkpointing \
+    --network_module networks.loha --network_dim 32 --network_alpha 16 \
+    --max_train_epochs 16 --save_every_n_epochs 1 \
+    --output_dir path/to/output --output_name my-loha
+```
+
+### LoKr
+
+```bash
+accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 src/musubi_tuner/hv_train_network.py \
+    --dit path/to/dit \
+    --dataset_config path/to/toml \
+    --sdpa --mixed_precision bf16 --fp8_base \
+    --optimizer_type adamw8bit --learning_rate 2e-4 --gradient_checkpointing \
+    --network_module networks.lokr --network_dim 32 --network_alpha 16 \
+    --max_train_epochs 16 --save_every_n_epochs 1 \
+    --output_dir path/to/output --output_name my-lokr
+```
+
+Replace `hv_train_network.py` with the appropriate training script for your architecture (e.g., `wan_train_network.py`, `fpack_train_network.py`, etc.).
+
+<details>
+<summary>日本語</summary>
+
+`hv_train_network.py` の部分は、お使いのアーキテクチャに対応する学習スクリプト（`wan_train_network.py`, `fpack_train_network.py` など）に置き換えてください。
+
+</details>
+
+### Common training options / 共通の学習オプション
+
+The following `--network_args` options are available for both LoHa and LoKr, same as LoRA:
+
+| Option | Description |
+|---|---|
+| `verbose=True` | Display detailed information about the network modules |
+| `rank_dropout=0.1` | Apply dropout to the rank dimension during training |
+| `module_dropout=0.1` | Randomly skip entire modules during training |
+| `exclude_patterns=[r'...']` | Exclude modules matching the regex patterns (in addition to architecture defaults) |
+| `include_patterns=[r'...']` | Include only modules matching the regex patterns |
+
+See [Advanced configuration](advanced_config.md) for details on how to specify `network_args`.
+
+<details>
+<summary>日本語</summary>
+
+以下の `--network_args` オプションは、LoRAと同様にLoHaとLoKrの両方で使用できます:
+
+| オプション | 説明 |
+|---|---|
+| `verbose=True` | ネットワークモジュールの詳細情報を表示 |
+| `rank_dropout=0.1` | 学習時にランク次元にドロップアウトを適用 |
+| `module_dropout=0.1` | 学習時にモジュール全体をランダムにスキップ |
+| `exclude_patterns=[r'...']` | 正規表現パターンに一致するモジュールを除外（アーキテクチャのデフォルトに追加） |
+| `include_patterns=[r'...']` | 正規表現パターンに一致するモジュールのみを対象とする |
+
+`network_args` の指定方法の詳細は [高度な設定](advanced_config.md) を参照してください。
+
+</details>
+
+### LoKr-specific option: `factor` / LoKr固有のオプション: `factor`
+
+LoKr decomposes weight dimensions using factorization. The `factor` option controls how dimensions are split:
+
+- `factor=-1` (default): Automatically find balanced factors. For example, dimension 512 is split into (16, 32).
+- `factor=N` (positive integer): Force factorization using the specified value. For example, `factor=4` splits dimension 512 into (4, 128).
+
+```bash
+--network_args "factor=4"
+```
+
+When `network_dim` (rank) is large enough relative to the factorized dimensions, LoKr uses a full matrix instead of a low-rank decomposition for the second factor. A warning will be logged in this case.
+
+<details>
+<summary>日本語</summary>
+
+LoKrは重みの次元を因数分解して分割します。`factor` オプションでその分割方法を制御します:
+
+- `factor=-1`（デフォルト）: バランスの良い因数を自動的に見つけます。例えば、次元512は(16, 32)に分割されます。
+- `factor=N`（正の整数）: 指定した値で因数分解します。例えば、`factor=4` は次元512を(4, 128)に分割します。
+
+```bash
+--network_args "factor=4"
+```
+
+`network_dim`（ランク）が因数分解された次元に対して十分に大きい場合、LoKrは第2因子に低ランク分解ではなくフル行列を使用します。その場合、警告がログに出力されます。
+
+</details>
+
+## How LoHa and LoKr work / LoHaとLoKrの仕組み
+
+### LoHa
+
+LoHa represents the weight update as a Hadamard (element-wise) product of two low-rank matrices:
+
+```
+ΔW = (W1a × W1b) ⊙ (W2a × W2b)
+```
+
+where `W1a`, `W1b`, `W2a`, `W2b` are low-rank matrices with rank `network_dim`. This means LoHa has roughly **twice the number of trainable parameters** compared to LoRA at the same rank, but can capture more complex weight structures due to the element-wise product.
+
+### LoKr
+
+LoKr represents the weight update using a Kronecker product:
+
+```
+ΔW = W1 ⊗ W2    (where W2 = W2a × W2b in low-rank mode)
+```
+
+The original weight dimensions are factorized (e.g., a 512×512 weight might be split so that W1 is 16×16 and W2 is 32×32). W1 is always a full matrix (small), while W2 can be either low-rank decomposed or a full matrix depending on the rank setting. LoKr tends to produce **smaller models** compared to LoRA at the same rank.
+
+<details>
+<summary>日本語</summary>
+
+### LoHa
+
+LoHaは重みの更新を2つの低ランク行列のHadamard積（要素ごとの積）で表現します:
+
+```
+ΔW = (W1a × W1b) ⊙ (W2a × W2b)
+```
+
+ここで `W1a`, `W1b`, `W2a`, `W2b` はランク `network_dim` の低ランク行列です。LoHaは同じランクのLoRAと比較して学習可能なパラメータ数が **約2倍** になりますが、要素ごとの積により、より複雑な重み構造を捉えることができます。
+
+### LoKr
+
+LoKrはKronecker積を使って重みの更新を表現します:
+
+```
+ΔW = W1 ⊗ W2    （低ランクモードでは W2 = W2a × W2b）
+```
+
+元の重みの次元が因数分解されます（例: 512×512の重みが、W1が16×16、W2が32×32に分割されます）。W1は常にフル行列（小さい）で、W2はランク設定に応じて低ランク分解またはフル行列になります。LoKrは同じランクのLoRAと比較して **より小さいモデル** を生成する傾向があります。
+
+</details>
+
+## Inference / 推論
+
+Trained LoHa/LoKr weights are saved in safetensors format, just like LoRA. The inference method depends on the architecture.
+
+<details>
+<summary>日本語</summary>
+
+学習済みのLoHa/LoKrの重みは、LoRAと同様にsafetensors形式で保存されます。推論方法はアーキテクチャによって異なります。
+
+</details>
+
+### Architectures with built-in support / ネイティブサポートのあるアーキテクチャ
+
+The following architectures automatically detect and load LoHa/LoKr weights without any additional options:
+
+- Wan 2.1/2.2
+- FramePack
+- HunyuanVideo 1.5
+- FLUX.2
+- Qwen-Image series
+- Z-Image
+
+Use `--lora_weight` as usual:
+
+```bash
+python src/musubi_tuner/wan_generate_video.py ... --lora_weight path/to/loha_or_lokr.safetensors
+```
+
+<details>
+<summary>日本語</summary>
+
+以下のアーキテクチャでは、LoHa/LoKrの重みを追加オプションなしで自動検出して読み込みます:
+
+- Wan 2.1/2.2
+- FramePack
+- HunyuanVideo 1.5
+- FLUX.2
+- Qwen-Image系
+- Z-Image
+
+通常通り `--lora_weight` を使用します:
+
+```bash
+python src/musubi_tuner/wan_generate_video.py ... --lora_weight path/to/loha_or_lokr.safetensors
+```
+
+</details>
+
+### HunyuanVideo / FLUX.1 Kontext
+
+For HunyuanVideo and FLUX.1 Kontext, the `--lycoris` option is required, and the [LyCORIS library](https://github.com/KohakuBlueleaf/LyCORIS) must be installed:
+
+```bash
+pip install lycoris-lora
+
+python src/musubi_tuner/hv_generate_video.py ... --lora_weight path/to/loha_or_lokr.safetensors --lycoris
+```
+
+<details>
+<summary>日本語</summary>
+
+HunyuanVideoとFLUX.1 Kontextでは、`--lycoris` オプションが必要で、[LyCORIS ライブラリ](https://github.com/KohakuBlueleaf/LyCORIS)のインストールが必要です:
+
+```bash
+pip install lycoris-lora
+
+python src/musubi_tuner/hv_generate_video.py ... --lora_weight path/to/loha_or_lokr.safetensors --lycoris
+```
+
+</details>
+
+## Limitations / 制限事項
+
+### LoRA+ is not supported / LoRA+は非対応
+
+LoRA+ (`loraplus_lr_ratio` in `--network_args`) is **not supported** with LoHa/LoKr. LoRA+ works by applying different learning rates to the LoRA-A and LoRA-B matrices, which is specific to the standard LoRA architecture. LoHa and LoKr have different parameter structures and this optimization does not apply.
+
+<details>
+<summary>日本語</summary>
+
+LoRA+（`--network_args` の `loraplus_lr_ratio`）はLoHa/LoKrでは **非対応** です。LoRA+はLoRA-AとLoRA-Bの行列に異なる学習率を適用する手法であり、標準的なLoRAのアーキテクチャに固有のものです。LoHaとLoKrはパラメータ構造が異なるため、この最適化は適用されません。
+
+</details>
+
+### Merging to base model / ベースモデルへのマージ
+
+`merge_lora.py` currently supports standard LoRA only. LoHa/LoKr weights cannot be merged into the base model using this script.
+
+For architectures with built-in LoHa/LoKr support (listed above), merging is performed automatically during model loading at inference time, so this limitation only affects offline merging workflows.
+
+<details>
+<summary>日本語</summary>
+
+`merge_lora.py` は現在、標準LoRAのみをサポートしています。このスクリプトではLoHa/LoKrの重みをベースモデルにマージすることはできません。
+
+LoHa/LoKrのネイティブサポートがあるアーキテクチャ（上記）では、推論時のモデル読み込み時にマージが自動的に行われるため、この制限はオフラインマージのワークフローにのみ影響します。
+
+</details>
+
+### Format conversion / フォーマット変換
+
+`convert_lora.py` supports only standard LoRA format conversion (between Musubi Tuner format and Diffusers format). LoHa/LoKr weights have different parameter structures and are not supported by this conversion tool. Support for LoHa/LoKr conversion (e.g., for ComfyUI) is planned for a future update.
+
+<details>
+<summary>日本語</summary>
+
+`convert_lora.py` は標準LoRAのフォーマット変換（Musubi Tuner形式とDiffusers形式間の変換）のみをサポートしています。LoHa/LoKrの重みはパラメータ構造が異なるため、この変換ツールではサポートされていません。LoHa/LoKrの変換（ComfyUI向けなど）は今後のアップデートで対応予定です。
+
+</details>
+
+## Acknowledgments / 謝辞
+
+The LoHa and LoKr implementations in Musubi Tuner are based on the [LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS) project by [KohakuBlueleaf](https://github.com/KohakuBlueleaf). We would like to express our sincere gratitude for the excellent research and open-source contributions that made this implementation possible.
+
+<details>
+<summary>日本語</summary>
+
+Musubi TunerのLoHaおよびLoKrの実装は、[KohakuBlueleaf](https://github.com/KohakuBlueleaf)氏による[LyCORIS](https://github.com/KohakuBlueleaf/LyCORIS)プロジェクトに基づいています。この実装を可能にしてくださった素晴らしい研究とオープンソースへの貢献に心から感謝いたします。
+
+</details>

--- a/docs/loha_lokr.md
+++ b/docs/loha_lokr.md
@@ -9,6 +9,8 @@ In addition to standard LoRA, Musubi Tuner supports **LoHa** (Low-rank Hadamard 
 - **LoHa**: Represents weight updates as a Hadamard (element-wise) product of two low-rank matrices. Reference: [FedPara (arXiv:2108.06098)](https://arxiv.org/abs/2108.06098)
 - **LoKr**: Represents weight updates as a Kronecker product with optional low-rank decomposition. Reference: [LoKr (arXiv:2309.14859)](https://arxiv.org/abs/2309.14859)
 
+The algorithms and recommended settings are described in the [LyCORIS documentation](https://github.com/KohakuBlueleaf/LyCORIS/blob/main/docs/Algo-List.md) and [guidelines](https://github.com/KohakuBlueleaf/LyCORIS/blob/main/docs/Guidelines.md).
+
 Both methods target Linear layers only (Conv2d layers are not supported in this implementation).
 
 This feature is experimental.
@@ -20,6 +22,8 @@ Musubi Tunerでは、標準的なLoRAに加え、代替のパラメータ効率�
 
 - **LoHa**: 重みの更新を2つの低ランク行列のHadamard積（要素ごとの積）で表現します。参考文献: [FedPara (arXiv:2108.06098)](https://arxiv.org/abs/2108.06098)
 - **LoKr**: 重みの更新をKronecker積と、オプションの低ランク分解で表現します。参考文献: [LoKr (arXiv:2309.14859)](https://arxiv.org/abs/2309.14859)
+
+アルゴリズムと推奨設定は[LyCORISのアルゴリズム解説](https://github.com/KohakuBlueleaf/LyCORIS/blob/main/docs/Algo-List.md)と[ガイドライン](https://github.com/KohakuBlueleaf/LyCORIS/blob/main/docs/Guidelines.md)を参照してください。
 
 いずれもLinear層のみを対象としています（Conv2d層はこの実装ではサポートしていません）。
 

--- a/docs/zimage.md
+++ b/docs/zimage.md
@@ -177,7 +177,7 @@ Z-Imageの学習は専用のスクリプト`zimage_train_network.py`を使用し
 
 ### Converting LoRA weights to Diffusers format for ComfyUI / LoRA重みをComfyUIで使用可能なDiffusers形式に変換する
 
-A script is provided to convert Z-Image LoRA weights to Diffusers format for ComfyUI.
+A script is provided to convert Z-Image LoRA weights to Diffusers format for ComfyUI. LoHa and LoKr formats are supported.
 
 ```bash
 python src/musubi_tuner/networks/convert_lora.py \

--- a/src/musubi_tuner/convert_lora.py
+++ b/src/musubi_tuner/convert_lora.py
@@ -59,7 +59,7 @@ def convert_from_diffusers(prefix, weights_sd):
         if "_lora_" in new_key:  # LoRA
             new_key = new_key.replace("_lora_A_", ".lora_down.").replace("_lora_B_", ".lora_up.")
 
-            # support unknown format: do not replace dots but uses lora_up/lora_up/alpha
+            # support unknown format: do not replace dots but uses lora_down/lora_up/alpha
             new_key = new_key.replace("_lora_down_", ".lora_down.").replace("_lora_up_", ".lora_up.")
         else:  # LoHa or LoKr
             new_key = new_key.replace("_hada_", ".hada_").replace("_lokr_", ".lokr_")

--- a/src/musubi_tuner/convert_lora.py
+++ b/src/musubi_tuner/convert_lora.py
@@ -56,10 +56,14 @@ def convert_from_diffusers(prefix, weights_sd):
             continue
 
         new_key = f"{prefix}{key_body}".replace(".", "_")
-        new_key = new_key.replace("_lora_A_", ".lora_down.").replace("_lora_B_", ".lora_up.")
+        if "_lora_" in new_key:  # LoRA
+            new_key = new_key.replace("_lora_A_", ".lora_down.").replace("_lora_B_", ".lora_up.")
 
-        # support unknown format: do not replace dots but uses lora_up/lora_up/alpha
-        new_key = new_key.replace("_lora_down_", ".lora_down.").replace("_lora_up_", ".lora_up.")
+            # support unknown format: do not replace dots but uses lora_up/lora_up/alpha
+            new_key = new_key.replace("_lora_down_", ".lora_down.").replace("_lora_up_", ".lora_up.")
+        else:  # LoHa or LoKr
+            new_key = new_key.replace("_hada_", ".hada_").replace("_lokr_", ".lokr_")
+
         if new_key.endswith("_alpha"):
             new_key = new_key.replace("_alpha", ".alpha")
 
@@ -103,12 +107,13 @@ def convert_to_diffusers(prefix, diffusers_prefix, weights_sd):
                 lora_alphas[lora_name] = weight
 
     new_weights_sd = {}
+    estimated_type = None
     for key, weight in weights_sd.items():
         if key.startswith(prefix):
             if "alpha" in key:
                 continue
 
-            lora_name = key.split(".", 1)[0]  # before first dot
+            lora_name, weight_name = key.split(".", 1)
 
             if lora_name in lora_name_to_module_name:
                 module_name = lora_name_to_module_name[lora_name]
@@ -136,27 +141,42 @@ def convert_to_diffusers(prefix, diffusers_prefix, weights_sd):
                     module_name = module_name.replace("txt.", "txt_")  # fix txt
                     module_name = module_name.replace("attn.", "attn_")  # fix attn
 
+            dim = None  # None means LoHa or LoKr, otherwise it's LoRA with alpha and dim is used for scaling
             if "lora_down" in key:
                 new_key = f"{diffusers_prefix}.{module_name}.lora_A.weight"
                 dim = weight.shape[0]
             elif "lora_up" in key:
                 new_key = f"{diffusers_prefix}.{module_name}.lora_B.weight"
                 dim = weight.shape[1]
+            elif "hada" in key or "lokr" in key:  # LoHa or LoKr
+                new_key = f"{diffusers_prefix}.{module_name}.{weight_name}"
+                if "hada" in key:
+                    estimated_type = "LoHa"
+                elif "lokr" in key:
+                    estimated_type = "LoKr"
             else:
                 logger.warning(f"unexpected key: {key} in default LoRA format")
                 continue
+            if dim is not None:
+                estimated_type = "LoRA"
 
-            # scale weight by alpha
-            if lora_name in lora_alphas:
+            # scale weight by alpha for LoRA with alpha (e.g., LyCORIS), to match Diffusers format which has no alpha (alpha is effectively 1)
+            if lora_name in lora_alphas and dim is not None:
                 # we scale both down and up, so scale is sqrt
                 scale = lora_alphas[lora_name] / dim
                 scale = scale.sqrt()
                 weight = weight * scale
             else:
-                logger.warning(f"missing alpha for {lora_name}")
+                if dim is not None:
+                    logger.warning(f"missing alpha for {lora_name}")
+                else:
+                    # for LoHa or LoKr, we copy alpha if exists
+                    if lora_name in lora_alphas:
+                        new_weights_sd[f"{diffusers_prefix}.{module_name}.alpha"] = lora_alphas[lora_name]
 
             new_weights_sd[new_key] = weight
 
+    logger.info(f"estimated type: {estimated_type}")
     return new_weights_sd
 
 
@@ -184,7 +204,7 @@ def convert(input_file, output_file, target_format, diffusers_prefix):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Convert LoRA weights between default and other formats")
+    parser = argparse.ArgumentParser(description="Convert LoRA/LoHa/LoKr weights between default and other formats")
     parser.add_argument("--input", type=str, required=True, help="input model file")
     parser.add_argument("--output", type=str, required=True, help="output model file")
     parser.add_argument("--target", type=str, required=True, choices=["other", "default"], help="target format")

--- a/src/musubi_tuner/networks/convert_z_image_lora_to_comfy.py
+++ b/src/musubi_tuner/networks/convert_z_image_lora_to_comfy.py
@@ -55,10 +55,10 @@ def main(args):
             count += 1
             # print(f"Renamed {k} to {new_k}")
 
-    # concat or split LoRA for QKV layers
+    # concat or split LoRA/LoHa/LoKr for QKV layers
     qkv_count = 0
     if args.reverse:
-        # ComfyUI to sd-scripts: split QKV
+        # ComfyUI to sd-scripts: split QKV (LoRA only)
         keys = list(state_dict.keys())
         for key in keys:
             if "attention_qkv" in key and "lora_down" in key:
@@ -93,8 +93,12 @@ def main(args):
                 qkv_count += 1
     else:
         # sd-scripts to ComfyUI: concat QKV
+
+        # LoRA QKV merge
         keys = list(state_dict.keys())
         for key in keys:
+            if key not in state_dict:
+                continue
             if "attention" in key and ("to_q" in key or "to_k" in key or "to_v" in key):
                 if "to_q" not in key or "lora_up" not in key:  # ensure we process only once per QKV set
                     continue
@@ -139,8 +143,144 @@ def main(args):
 
                 qkv_count += 1
 
+        # LoHa QKV merge (block-diagonal, lossless)
+        # ΔW = (w1a @ w1b) ⊙ (w2a @ w2b) * scale
+        # Using block_diag for w1a/w2a and cat for w1b/w2b preserves the exact result:
+        #   block_diag(w1a_q, w1a_k, w1a_v) @ cat(w1b_q, w1b_k, w1b_v)
+        #   = [w1a_q@w1b_q; w1a_k@w1b_k; w1a_v@w1b_v]
+        # Rank becomes 3x, alpha is adjusted accordingly.
+        keys = list(state_dict.keys())
+        for key in keys:
+            if key not in state_dict:
+                continue
+            if "attention" in key and ("to_q" in key or "to_k" in key or "to_v" in key):
+                if "to_q" not in key or "hada_w1_a" not in key:
+                    continue
+
+                lora_name = key.split(".", 1)[0]
+                lora_name_prefix = lora_name.replace("to_q", "")
+
+                w1a_list, w1b_list, w2a_list, w2b_list = [], [], [], []
+                for suffix in ["to_q", "to_k", "to_v"]:
+                    name = f"{lora_name_prefix}{suffix}"
+                    w1a_list.append(state_dict.pop(f"{name}.hada_w1_a"))
+                    w1b_list.append(state_dict.pop(f"{name}.hada_w1_b"))
+                    w2a_list.append(state_dict.pop(f"{name}.hada_w2_a"))
+                    w2b_list.append(state_dict.pop(f"{name}.hada_w2_b"))
+
+                alpha = state_dict.pop(f"{lora_name}.alpha")
+                state_dict.pop(f"{lora_name_prefix}to_k.alpha", None)
+                state_dict.pop(f"{lora_name_prefix}to_v.alpha", None)
+
+                w1a_qkv = torch.block_diag(*w1a_list)  # (3*out, 3r)
+                w1b_qkv = torch.cat(w1b_list, dim=0)  # (3r, in)
+                w2a_qkv = torch.block_diag(*w2a_list)  # (3*out, 3r)
+                w2b_qkv = torch.cat(w2b_list, dim=0)  # (3r, in)
+
+                new_lora_name = lora_name_prefix + "qkv"
+                state_dict[f"{new_lora_name}.hada_w1_a"] = w1a_qkv
+                state_dict[f"{new_lora_name}.hada_w1_b"] = w1b_qkv
+                state_dict[f"{new_lora_name}.hada_w2_a"] = w2a_qkv
+                state_dict[f"{new_lora_name}.hada_w2_b"] = w2b_qkv
+                state_dict[f"{new_lora_name}.alpha"] = alpha * 3  # rank is 3x, so alpha * 3 keeps scale unchanged
+
+                qkv_count += 1
+
+        # LoKr QKV merge: materialize weight deltas via Kronecker product, concatenate, convert to LoRA via SVD
+        # Kronecker product structure cannot be preserved across QKV concatenation,
+        # so we convert QKV layers to LoRA format. Non-QKV layers remain as LoKr.
+        keys = list(state_dict.keys())
+        for key in keys:
+            if key not in state_dict:
+                continue
+            if "attention" in key and ("to_q" in key or "to_k" in key or "to_v" in key):
+                if "to_q" not in key or "lokr_w1" not in key:
+                    continue
+
+                lora_name = key.split(".", 1)[0]
+                lora_name_prefix = lora_name.replace("to_q", "")
+
+                delta_weights = []
+                original_dtype = None
+                for suffix in ["to_q", "to_k", "to_v"]:
+                    name = f"{lora_name_prefix}{suffix}"
+                    w1 = state_dict.pop(f"{name}.lokr_w1")
+                    if original_dtype is None:
+                        original_dtype = w1.dtype
+
+                    w2a_key = f"{name}.lokr_w2_a"
+                    w2b_key = f"{name}.lokr_w2_b"
+                    w2_key = f"{name}.lokr_w2"
+
+                    if w2a_key in state_dict:
+                        # low-rank mode: w2 = w2_a @ w2_b
+                        w2a = state_dict.pop(w2a_key)
+                        w2b = state_dict.pop(w2b_key)
+                        dim = w2a.shape[1]
+                        w2 = w2a.float() @ w2b.float()
+                    elif w2_key in state_dict:
+                        # full matrix mode
+                        w2 = state_dict.pop(w2_key).float()
+                        dim = None
+                    else:
+                        raise ValueError(f"Missing lokr_w2 weights for {name}")
+
+                    alpha_i = state_dict.pop(f"{name}.alpha", None)
+
+                    # Compute scale: low-rank uses alpha/dim, full matrix uses 1.0
+                    if dim is not None:
+                        if alpha_i is not None:
+                            alpha_val = alpha_i.item() if isinstance(alpha_i, torch.Tensor) else alpha_i
+                        else:
+                            alpha_val = dim
+                        scale = alpha_val / dim
+                    else:
+                        scale = 1.0
+
+                    delta_w = torch.kron(w1.float(), w2) * scale
+                    delta_weights.append(delta_w)
+
+                # Concatenate QKV deltas
+                delta_qkv = torch.cat(delta_weights, dim=0)  # (3*out, in)
+
+                # SVD decomposition
+                U, S, Vt = torch.linalg.svd(delta_qkv, full_matrices=False)
+
+                # Determine rank
+                if args.lokr_rank is not None:
+                    svd_rank = min(args.lokr_rank, S.shape[0])
+                else:
+                    # Auto: keep singular values contributing to 99.99% of total energy (Frobenius norm squared)
+                    total_energy = (S**2).sum()
+                    cumulative_energy = (S**2).cumsum(dim=0)
+                    threshold_idx = (cumulative_energy >= total_energy * 0.9999).nonzero(as_tuple=True)[0]
+                    if len(threshold_idx) > 0:
+                        svd_rank = threshold_idx[0].item() + 1
+                    else:
+                        svd_rank = S.shape[0]
+
+                # Log reconstruction quality
+                reconstructed = (U[:, :svd_rank] * S[:svd_rank].unsqueeze(0)) @ Vt[:svd_rank, :]
+                rel_error = (delta_qkv - reconstructed).norm() / delta_qkv.norm()
+                logger.info(
+                    f"  LoKr->LoRA QKV {lora_name_prefix}qkv: rank={svd_rank}/{S.shape[0]}, "
+                    f"relative error={rel_error:.6f}"
+                )
+
+                # Construct LoRA weights: ΔW ≈ lora_up @ lora_down, with alpha = rank (scale = 1)
+                sqrt_S = torch.sqrt(S[:svd_rank])
+                lora_up = (U[:, :svd_rank] * sqrt_S.unsqueeze(0)).to(original_dtype)  # (3*out, rank)
+                lora_down = (sqrt_S.unsqueeze(1) * Vt[:svd_rank, :]).to(original_dtype)  # (rank, in)
+
+                new_lora_name = lora_name_prefix + "qkv"
+                state_dict[f"{new_lora_name}.lora_up.weight"] = lora_up
+                state_dict[f"{new_lora_name}.lora_down.weight"] = lora_down
+                state_dict[f"{new_lora_name}.alpha"] = torch.tensor(float(svd_rank))
+
+                qkv_count += 1
+
     logger.info(f"Direct key renames applied: {count}")
-    logger.info(f"QKV LoRA layers processed: {qkv_count}")
+    logger.info(f"QKV layers processed: {qkv_count}")
 
     # Calculate hash
     if metadata is not None:
@@ -155,9 +295,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Convert LoRA format")
+    parser = argparse.ArgumentParser(description="Convert LoRA/LoHa/LoKr format for Z-Image ComfyUI")
     parser.add_argument("src_path", type=str, default=None, help="source path, sd-scripts format")
     parser.add_argument("dst_path", type=str, default=None, help="destination path, ComfyUI format")
-    parser.add_argument("--reverse", action="store_true", help="reverse conversion direction")
+    parser.add_argument("--reverse", action="store_true", help="reverse conversion direction (LoRA only)")
+    parser.add_argument("--lokr_rank", type=int, default=None, help="max rank for LoKr to LoRA QKV conversion (auto if not specified)")
     args = parser.parse_args()
     main(args)

--- a/src/musubi_tuner/networks/convert_z_image_lora_to_comfy.py
+++ b/src/musubi_tuner/networks/convert_z_image_lora_to_comfy.py
@@ -262,10 +262,7 @@ def main(args):
                 # Log reconstruction quality
                 reconstructed = (U[:, :svd_rank] * S[:svd_rank].unsqueeze(0)) @ Vt[:svd_rank, :]
                 rel_error = (delta_qkv - reconstructed).norm() / delta_qkv.norm()
-                logger.info(
-                    f"  LoKr->LoRA QKV {lora_name_prefix}qkv: rank={svd_rank}/{S.shape[0]}, "
-                    f"relative error={rel_error:.6f}"
-                )
+                logger.info(f"  LoKr->LoRA QKV {lora_name_prefix}qkv: rank={svd_rank}/{S.shape[0]}, relative error={rel_error:.6f}")
 
                 # Construct LoRA weights: ΔW ≈ lora_up @ lora_down, with alpha = rank (scale = 1)
                 sqrt_S = torch.sqrt(S[:svd_rank])
@@ -299,6 +296,8 @@ if __name__ == "__main__":
     parser.add_argument("src_path", type=str, default=None, help="source path, sd-scripts format")
     parser.add_argument("dst_path", type=str, default=None, help="destination path, ComfyUI format")
     parser.add_argument("--reverse", action="store_true", help="reverse conversion direction (LoRA only)")
-    parser.add_argument("--lokr_rank", type=int, default=None, help="max rank for LoKr to LoRA QKV conversion (auto if not specified)")
+    parser.add_argument(
+        "--lokr_rank", type=int, default=None, help="max rank for LoKr to LoRA QKV conversion (auto if not specified)"
+    )
     args = parser.parse_args()
     main(args)

--- a/src/musubi_tuner/networks/loha.py
+++ b/src/musubi_tuner/networks/loha.py
@@ -7,8 +7,7 @@
 
 import ast
 import logging
-import math
-from typing import Any, Dict, List, Optional, Type
+from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
@@ -289,9 +288,7 @@ def create_arch_network_from_weights(
 ) -> lora_module.LoRANetwork:
     """Create LoHa network from saved weights with auto-detected architecture."""
     target_replace_modules, _ = detect_arch_config(unet)
-    return create_network_from_weights(
-        target_replace_modules, multiplier, weights_sd, text_encoders, unet, for_inference, **kwargs
-    )
+    return create_network_from_weights(target_replace_modules, multiplier, weights_sd, text_encoders, unet, for_inference, **kwargs)
 
 
 def merge_weights_to_tensor(

--- a/src/musubi_tuner/networks/loha.py
+++ b/src/musubi_tuner/networks/loha.py
@@ -27,7 +27,9 @@ class HadaWeight(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, w1a, w1b, w2a, w2b, scale=torch.tensor(1)):
+    def forward(ctx, w1a, w1b, w2a, w2b, scale=None):
+        if scale is None:
+            scale = torch.tensor(1, device=w1a.device, dtype=w1a.dtype)
         ctx.save_for_backward(w1a, w1b, w2a, w2b, scale)
         diff_weight = ((w1a @ w1b) * (w2a @ w2b)) * scale
         return diff_weight

--- a/src/musubi_tuner/networks/loha.py
+++ b/src/musubi_tuner/networks/loha.py
@@ -1,0 +1,346 @@
+# LoHa (Low-rank Hadamard Product) network module
+# Linear layers only (no Conv2d/Tucker decomposition)
+# Reference: https://arxiv.org/abs/2108.06098
+#
+# Based on the LyCORIS project by KohakuBlueleaf
+# https://github.com/KohakuBlueleaf/LyCORIS
+
+import ast
+import logging
+import math
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from . import lora as lora_module
+from .network_arch import detect_arch_config
+
+logger = logging.getLogger(__name__)
+
+
+class HadaWeight(torch.autograd.Function):
+    """Efficient Hadamard product forward/backward for LoHa.
+
+    Computes ((w1a @ w1b) * (w2a @ w2b)) * scale with custom backward
+    that recomputes intermediates instead of storing them.
+    """
+
+    @staticmethod
+    def forward(ctx, w1a, w1b, w2a, w2b, scale=torch.tensor(1)):
+        ctx.save_for_backward(w1a, w1b, w2a, w2b, scale)
+        diff_weight = ((w1a @ w1b) * (w2a @ w2b)) * scale
+        return diff_weight
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        (w1a, w1b, w2a, w2b, scale) = ctx.saved_tensors
+        grad_out = grad_out * scale
+        temp = grad_out * (w2a @ w2b)
+        grad_w1a = temp @ w1b.T
+        grad_w1b = w1a.T @ temp
+
+        temp = grad_out * (w1a @ w1b)
+        grad_w2a = temp @ w2b.T
+        grad_w2b = w2a.T @ temp
+
+        del temp
+        return grad_w1a, grad_w1b, grad_w2a, grad_w2b, None
+
+
+class LoHaModule(torch.nn.Module):
+    """LoHa module for training. Replaces forward method of the original Linear."""
+
+    def __init__(
+        self,
+        lora_name,
+        org_module: torch.nn.Module,
+        multiplier=1.0,
+        lora_dim=4,
+        alpha=1,
+        dropout=None,
+        rank_dropout=None,
+        module_dropout=None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.lora_name = lora_name
+        self.lora_dim = lora_dim
+
+        if org_module.__class__.__name__ == "Conv2d":
+            raise ValueError("LoHa Conv2d is not supported in this implementation")
+        else:
+            in_dim = org_module.in_features
+            out_dim = org_module.out_features
+
+        # Hadamard product parameters: ΔW = (w1a @ w1b) * (w2a @ w2b)
+        self.hada_w1_a = nn.Parameter(torch.empty(out_dim, lora_dim))
+        self.hada_w1_b = nn.Parameter(torch.empty(lora_dim, in_dim))
+        self.hada_w2_a = nn.Parameter(torch.empty(out_dim, lora_dim))
+        self.hada_w2_b = nn.Parameter(torch.empty(lora_dim, in_dim))
+
+        # Initialization: w1_a normal(0.1), w1_b normal(1.0), w2_a = 0, w2_b normal(1.0)
+        # Ensures ΔW = 0 at init since w2_a = 0
+        torch.nn.init.normal_(self.hada_w1_a, std=0.1)
+        torch.nn.init.normal_(self.hada_w1_b, std=1.0)
+        torch.nn.init.constant_(self.hada_w2_a, 0)
+        torch.nn.init.normal_(self.hada_w2_b, std=1.0)
+
+        if type(alpha) == torch.Tensor:
+            alpha = alpha.detach().float().numpy()
+        alpha = lora_dim if alpha is None or alpha == 0 else alpha
+        self.scale = alpha / self.lora_dim
+        self.register_buffer("alpha", torch.tensor(alpha))
+
+        self.multiplier = multiplier
+        self.org_module = org_module  # remove in applying
+        self.dropout = dropout
+        self.rank_dropout = rank_dropout
+        self.module_dropout = module_dropout
+
+    def apply_to(self):
+        self.org_forward = self.org_module.forward
+        self.org_module.forward = self.forward
+        del self.org_module
+
+    def get_diff_weight(self):
+        """Return materialized weight delta."""
+        scale = torch.tensor(self.scale, dtype=self.hada_w1_a.dtype, device=self.hada_w1_a.device)
+        return HadaWeight.apply(self.hada_w1_a, self.hada_w1_b, self.hada_w2_a, self.hada_w2_b, scale)
+
+    def forward(self, x):
+        org_forwarded = self.org_forward(x)
+
+        # module dropout
+        if self.module_dropout is not None and self.training:
+            if torch.rand(1) < self.module_dropout:
+                return org_forwarded
+
+        diff_weight = self.get_diff_weight()
+
+        # rank dropout
+        if self.rank_dropout is not None and self.training:
+            drop = (torch.rand(diff_weight.size(0), device=diff_weight.device) > self.rank_dropout).to(diff_weight.dtype)
+            drop = drop.view(-1, 1)
+            diff_weight = diff_weight * drop
+            # scaling for rank dropout
+            scale = 1.0 / (1.0 - self.rank_dropout)
+        else:
+            scale = 1.0
+
+        return org_forwarded + F.linear(x, diff_weight) * self.multiplier * scale
+
+
+class LoHaInfModule(LoHaModule):
+    """LoHa module for inference. Supports merge_to and get_weight."""
+
+    def __init__(
+        self,
+        lora_name,
+        org_module: torch.nn.Module,
+        multiplier=1.0,
+        lora_dim=4,
+        alpha=1,
+        **kwargs,
+    ):
+        # no dropout for inference
+        super().__init__(lora_name, org_module, multiplier, lora_dim, alpha)
+
+        self.org_module_ref = [org_module]
+        self.enabled = True
+        self.network: lora_module.LoRANetwork = None
+
+    def set_network(self, network):
+        self.network = network
+
+    def merge_to(self, sd, dtype, device, non_blocking=False):
+        # extract weight from org_module
+        org_sd = self.org_module.state_dict()
+        weight = org_sd["weight"]
+        org_dtype = weight.dtype
+        org_device = weight.device
+        weight = weight.to(device, dtype=torch.float, non_blocking=non_blocking)
+
+        if dtype is None:
+            dtype = org_dtype
+        if device is None:
+            device = org_device
+
+        # get LoHa weights
+        w1a = sd["hada_w1_a"].to(device, dtype=torch.float, non_blocking=non_blocking)
+        w1b = sd["hada_w1_b"].to(device, dtype=torch.float, non_blocking=non_blocking)
+        w2a = sd["hada_w2_a"].to(device, dtype=torch.float, non_blocking=non_blocking)
+        w2b = sd["hada_w2_b"].to(device, dtype=torch.float, non_blocking=non_blocking)
+
+        # compute ΔW = ((w1a @ w1b) * (w2a @ w2b)) * scale
+        diff_weight = ((w1a @ w1b) * (w2a @ w2b)) * self.scale
+
+        # merge
+        weight = weight + self.multiplier * diff_weight
+
+        org_sd["weight"] = weight.to(org_device, dtype=dtype)
+        self.org_module.load_state_dict(org_sd)
+
+    def get_weight(self, multiplier=None):
+        if multiplier is None:
+            multiplier = self.multiplier
+
+        w1a = self.hada_w1_a.to(torch.float)
+        w1b = self.hada_w1_b.to(torch.float)
+        w2a = self.hada_w2_a.to(torch.float)
+        w2b = self.hada_w2_b.to(torch.float)
+
+        weight = ((w1a @ w1b) * (w2a @ w2b)) * self.scale * multiplier
+        return weight
+
+    def default_forward(self, x):
+        diff_weight = self.get_diff_weight()
+        return self.org_forward(x) + F.linear(x, diff_weight) * self.multiplier
+
+    def forward(self, x):
+        if not self.enabled:
+            return self.org_forward(x)
+        return self.default_forward(x)
+
+
+def create_arch_network(
+    multiplier: float,
+    network_dim: Optional[int],
+    network_alpha: Optional[float],
+    vae: nn.Module,
+    text_encoders: List[nn.Module],
+    unet: nn.Module,
+    neuron_dropout: Optional[float] = None,
+    **kwargs,
+):
+    """Create a LoHa network with auto-detected architecture."""
+    target_replace_modules, default_excludes = detect_arch_config(unet)
+
+    # merge user exclude_patterns with defaults
+    exclude_patterns = kwargs.get("exclude_patterns", None)
+    if exclude_patterns is None:
+        exclude_patterns = []
+    else:
+        exclude_patterns = ast.literal_eval(exclude_patterns)
+    exclude_patterns.extend(default_excludes)
+    kwargs["exclude_patterns"] = exclude_patterns
+
+    return lora_module.create_network(
+        target_replace_modules,
+        "lora_unet",
+        multiplier,
+        network_dim,
+        network_alpha,
+        vae,
+        text_encoders,
+        unet,
+        neuron_dropout=neuron_dropout,
+        module_class=LoHaModule,
+        **kwargs,
+    )
+
+
+def create_network_from_weights(
+    target_replace_modules: List[str],
+    multiplier: float,
+    weights_sd: Dict[str, torch.Tensor],
+    text_encoders: Optional[List[nn.Module]] = None,
+    unet: Optional[nn.Module] = None,
+    for_inference: bool = False,
+    **kwargs,
+) -> lora_module.LoRANetwork:
+    """Create LoHa network from saved weights (internal)."""
+    modules_dim = {}
+    modules_alpha = {}
+    for key, value in weights_sd.items():
+        if "." not in key:
+            continue
+
+        lora_name = key.split(".")[0]
+        if "alpha" in key:
+            modules_alpha[lora_name] = value
+        elif "hada_w1_b" in key:
+            dim = value.shape[0]
+            modules_dim[lora_name] = dim
+
+    module_class = LoHaInfModule if for_inference else LoHaModule
+
+    network = lora_module.LoRANetwork(
+        target_replace_modules,
+        "lora_unet",
+        text_encoders,
+        unet,
+        multiplier=multiplier,
+        modules_dim=modules_dim,
+        modules_alpha=modules_alpha,
+        module_class=module_class,
+    )
+    return network
+
+
+def create_arch_network_from_weights(
+    multiplier: float,
+    weights_sd: Dict[str, torch.Tensor],
+    text_encoders: Optional[List[nn.Module]] = None,
+    unet: Optional[nn.Module] = None,
+    for_inference: bool = False,
+    **kwargs,
+) -> lora_module.LoRANetwork:
+    """Create LoHa network from saved weights with auto-detected architecture."""
+    target_replace_modules, _ = detect_arch_config(unet)
+    return create_network_from_weights(
+        target_replace_modules, multiplier, weights_sd, text_encoders, unet, for_inference, **kwargs
+    )
+
+
+def merge_weights_to_tensor(
+    model_weight: torch.Tensor,
+    lora_name: str,
+    lora_sd: Dict[str, torch.Tensor],
+    lora_weight_keys: set,
+    multiplier: float,
+    calc_device: torch.device,
+) -> torch.Tensor:
+    """Merge LoHa weights directly into a model weight tensor.
+
+    No Module/Network creation needed. Consumed keys are removed from lora_weight_keys.
+    Returns model_weight unchanged if no matching LoHa keys found.
+    """
+    w1a_key = lora_name + ".hada_w1_a"
+    w1b_key = lora_name + ".hada_w1_b"
+    w2a_key = lora_name + ".hada_w2_a"
+    w2b_key = lora_name + ".hada_w2_b"
+    alpha_key = lora_name + ".alpha"
+
+    if w1a_key not in lora_weight_keys:
+        return model_weight
+
+    w1a = lora_sd[w1a_key].to(calc_device)
+    w1b = lora_sd[w1b_key].to(calc_device)
+    w2a = lora_sd[w2a_key].to(calc_device)
+    w2b = lora_sd[w2b_key].to(calc_device)
+
+    dim = w1b.shape[0]
+    alpha = lora_sd.get(alpha_key, torch.tensor(dim))
+    if isinstance(alpha, torch.Tensor):
+        alpha = alpha.item()
+    scale = alpha / dim
+
+    original_dtype = model_weight.dtype
+    if original_dtype.itemsize == 1:  # fp8
+        model_weight = model_weight.to(torch.float16)
+        w1a, w1b, w2a, w2b = w1a.to(torch.float16), w1b.to(torch.float16), w2a.to(torch.float16), w2b.to(torch.float16)
+
+    # ΔW = ((w1a @ w1b) * (w2a @ w2b)) * scale
+    diff_weight = ((w1a @ w1b) * (w2a @ w2b)) * scale
+    model_weight = model_weight + multiplier * diff_weight
+
+    if original_dtype.itemsize == 1:
+        model_weight = model_weight.to(original_dtype)
+
+    # remove consumed keys
+    for key in [w1a_key, w1b_key, w2a_key, w2b_key, alpha_key]:
+        lora_weight_keys.discard(key)
+
+    return model_weight

--- a/src/musubi_tuner/networks/lokr.py
+++ b/src/musubi_tuner/networks/lokr.py
@@ -8,7 +8,7 @@
 import ast
 import logging
 import math
-from typing import Any, Dict, List, Optional, Type
+from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
@@ -354,9 +354,7 @@ def create_arch_network_from_weights(
 ) -> lora_module.LoRANetwork:
     """Create LoKr network from saved weights with auto-detected architecture."""
     target_replace_modules, _ = detect_arch_config(unet)
-    return create_network_from_weights(
-        target_replace_modules, multiplier, weights_sd, text_encoders, unet, for_inference, **kwargs
-    )
+    return create_network_from_weights(target_replace_modules, multiplier, weights_sd, text_encoders, unet, for_inference, **kwargs)
 
 
 def merge_weights_to_tensor(

--- a/src/musubi_tuner/networks/lokr.py
+++ b/src/musubi_tuner/networks/lokr.py
@@ -1,0 +1,442 @@
+# LoKr (Low-rank Kronecker Product) network module
+# Linear layers only (no Conv2d/Tucker decomposition)
+# Reference: https://arxiv.org/abs/2309.14859
+#
+# Based on the LyCORIS project by KohakuBlueleaf
+# https://github.com/KohakuBlueleaf/LyCORIS
+
+import ast
+import logging
+import math
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from . import lora as lora_module
+from .network_arch import detect_arch_config
+
+logger = logging.getLogger(__name__)
+
+
+def factorization(dimension: int, factor: int = -1) -> tuple:
+    """Return a tuple of two values whose product equals dimension,
+    optimized for balanced factors.
+
+    In LoKr, the first value is for the weight scale (smaller),
+    and the second value is for the weight (larger).
+
+    Examples:
+        factor=-1: 128 -> (8, 16), 512 -> (16, 32), 1024 -> (32, 32)
+        factor=4:  128 -> (4, 32), 512 -> (4, 128)
+    """
+    if factor > 0 and (dimension % factor) == 0:
+        m = factor
+        n = dimension // factor
+        if m > n:
+            n, m = m, n
+        return m, n
+    if factor < 0:
+        factor = dimension
+    m, n = 1, dimension
+    length = m + n
+    while m < n:
+        new_m = m + 1
+        while dimension % new_m != 0:
+            new_m += 1
+        new_n = dimension // new_m
+        if new_m + new_n > length or new_m > factor:
+            break
+        else:
+            m, n = new_m, new_n
+    if m > n:
+        n, m = m, n
+    return m, n
+
+
+def make_kron(w1, w2, scale):
+    """Compute Kronecker product of w1 and w2, scaled by scale."""
+    if w1.dim() != w2.dim():
+        for _ in range(w2.dim() - w1.dim()):
+            w1 = w1.unsqueeze(-1)
+    w2 = w2.contiguous()
+    rebuild = torch.kron(w1, w2)
+    if scale != 1:
+        rebuild = rebuild * scale
+    return rebuild
+
+
+class LoKrModule(torch.nn.Module):
+    """LoKr module for training. Replaces forward method of the original Linear."""
+
+    def __init__(
+        self,
+        lora_name,
+        org_module: torch.nn.Module,
+        multiplier=1.0,
+        lora_dim=4,
+        alpha=1,
+        dropout=None,
+        rank_dropout=None,
+        module_dropout=None,
+        factor=-1,
+        **kwargs,
+    ):
+        super().__init__()
+        self.lora_name = lora_name
+        self.lora_dim = lora_dim
+
+        if org_module.__class__.__name__ == "Conv2d":
+            raise ValueError("LoKr Conv2d is not supported in this implementation")
+        else:
+            in_dim = org_module.in_features
+            out_dim = org_module.out_features
+
+        factor = int(factor)
+        self.use_w2 = False
+
+        # Factorize dimensions
+        in_m, in_n = factorization(in_dim, factor)
+        out_l, out_k = factorization(out_dim, factor)
+
+        # w1 is always a full matrix (the "scale" factor, small)
+        self.lokr_w1 = nn.Parameter(torch.empty(out_l, in_m))
+
+        # w2: low-rank decomposition if rank is small enough, otherwise full matrix
+        if lora_dim < max(out_k, in_n) / 2:
+            self.lokr_w2_a = nn.Parameter(torch.empty(out_k, lora_dim))
+            self.lokr_w2_b = nn.Parameter(torch.empty(lora_dim, in_n))
+        else:
+            self.use_w2 = True
+            self.lokr_w2 = nn.Parameter(torch.empty(out_k, in_n))
+            if lora_dim >= max(out_k, in_n) / 2:
+                logger.warning(
+                    f"LoKr: lora_dim {lora_dim} is large for dim={max(in_dim, out_dim)} "
+                    f"and factor={factor}, using full matrix mode."
+                )
+
+        if type(alpha) == torch.Tensor:
+            alpha = alpha.detach().float().numpy()
+        alpha = lora_dim if alpha is None or alpha == 0 else alpha
+        # if both w1 and w2 are full matrices, use scale = 1
+        if self.use_w2:
+            alpha = lora_dim
+        self.scale = alpha / self.lora_dim
+        self.register_buffer("alpha", torch.tensor(alpha))
+
+        # Initialization
+        torch.nn.init.kaiming_uniform_(self.lokr_w1, a=math.sqrt(5))
+        if self.use_w2:
+            torch.nn.init.constant_(self.lokr_w2, 0)
+        else:
+            torch.nn.init.kaiming_uniform_(self.lokr_w2_a, a=math.sqrt(5))
+            torch.nn.init.constant_(self.lokr_w2_b, 0)
+        # Ensures ΔW = kron(w1, 0) = 0 at init
+
+        self.multiplier = multiplier
+        self.org_module = org_module  # remove in applying
+        self.dropout = dropout
+        self.rank_dropout = rank_dropout
+        self.module_dropout = module_dropout
+
+    def apply_to(self):
+        self.org_forward = self.org_module.forward
+        self.org_module.forward = self.forward
+        del self.org_module
+
+    def get_diff_weight(self):
+        """Return materialized weight delta."""
+        w1 = self.lokr_w1
+        if self.use_w2:
+            w2 = self.lokr_w2
+        else:
+            w2 = self.lokr_w2_a @ self.lokr_w2_b
+        return make_kron(w1, w2, self.scale)
+
+    def forward(self, x):
+        org_forwarded = self.org_forward(x)
+
+        # module dropout
+        if self.module_dropout is not None and self.training:
+            if torch.rand(1) < self.module_dropout:
+                return org_forwarded
+
+        diff_weight = self.get_diff_weight()
+
+        # rank dropout
+        if self.rank_dropout is not None and self.training:
+            drop = (torch.rand(diff_weight.size(0), device=diff_weight.device) > self.rank_dropout).to(diff_weight.dtype)
+            drop = drop.view(-1, 1)
+            diff_weight = diff_weight * drop
+            scale = 1.0 / (1.0 - self.rank_dropout)
+        else:
+            scale = 1.0
+
+        return org_forwarded + F.linear(x, diff_weight) * self.multiplier * scale
+
+
+class LoKrInfModule(LoKrModule):
+    """LoKr module for inference. Supports merge_to and get_weight."""
+
+    def __init__(
+        self,
+        lora_name,
+        org_module: torch.nn.Module,
+        multiplier=1.0,
+        lora_dim=4,
+        alpha=1,
+        **kwargs,
+    ):
+        # no dropout for inference; pass factor from kwargs if present
+        factor = kwargs.pop("factor", -1)
+        super().__init__(lora_name, org_module, multiplier, lora_dim, alpha, factor=factor)
+
+        self.org_module_ref = [org_module]
+        self.enabled = True
+        self.network: lora_module.LoRANetwork = None
+
+    def set_network(self, network):
+        self.network = network
+
+    def merge_to(self, sd, dtype, device, non_blocking=False):
+        # extract weight from org_module
+        org_sd = self.org_module.state_dict()
+        weight = org_sd["weight"]
+        org_dtype = weight.dtype
+        org_device = weight.device
+        weight = weight.to(device, dtype=torch.float, non_blocking=non_blocking)
+
+        if dtype is None:
+            dtype = org_dtype
+        if device is None:
+            device = org_device
+
+        # get LoKr weights
+        w1 = sd["lokr_w1"].to(device, dtype=torch.float, non_blocking=non_blocking)
+
+        if "lokr_w2" in sd:
+            w2 = sd["lokr_w2"].to(device, dtype=torch.float, non_blocking=non_blocking)
+        else:
+            w2a = sd["lokr_w2_a"].to(device, dtype=torch.float, non_blocking=non_blocking)
+            w2b = sd["lokr_w2_b"].to(device, dtype=torch.float, non_blocking=non_blocking)
+            w2 = w2a @ w2b
+
+        # compute ΔW via Kronecker product
+        diff_weight = make_kron(w1, w2, self.scale)
+
+        # merge
+        weight = weight + self.multiplier * diff_weight
+
+        org_sd["weight"] = weight.to(org_device, dtype=dtype)
+        self.org_module.load_state_dict(org_sd)
+
+    def get_weight(self, multiplier=None):
+        if multiplier is None:
+            multiplier = self.multiplier
+
+        w1 = self.lokr_w1.to(torch.float)
+        if self.use_w2:
+            w2 = self.lokr_w2.to(torch.float)
+        else:
+            w2 = (self.lokr_w2_a @ self.lokr_w2_b).to(torch.float)
+
+        weight = make_kron(w1, w2, self.scale) * multiplier
+        return weight
+
+    def default_forward(self, x):
+        diff_weight = self.get_diff_weight()
+        return self.org_forward(x) + F.linear(x, diff_weight) * self.multiplier
+
+    def forward(self, x):
+        if not self.enabled:
+            return self.org_forward(x)
+        return self.default_forward(x)
+
+
+def create_arch_network(
+    multiplier: float,
+    network_dim: Optional[int],
+    network_alpha: Optional[float],
+    vae: nn.Module,
+    text_encoders: List[nn.Module],
+    unet: nn.Module,
+    neuron_dropout: Optional[float] = None,
+    **kwargs,
+):
+    """Create a LoKr network with auto-detected architecture."""
+    target_replace_modules, default_excludes = detect_arch_config(unet)
+
+    # merge user exclude_patterns with defaults
+    exclude_patterns = kwargs.get("exclude_patterns", None)
+    if exclude_patterns is None:
+        exclude_patterns = []
+    else:
+        exclude_patterns = ast.literal_eval(exclude_patterns)
+    exclude_patterns.extend(default_excludes)
+    kwargs["exclude_patterns"] = exclude_patterns
+
+    # extract factor from kwargs
+    factor = kwargs.pop("factor", -1)
+    factor = int(factor)
+
+    return lora_module.create_network(
+        target_replace_modules,
+        "lora_unet",
+        multiplier,
+        network_dim,
+        network_alpha,
+        vae,
+        text_encoders,
+        unet,
+        neuron_dropout=neuron_dropout,
+        module_class=LoKrModule,
+        module_kwargs={"factor": factor},
+        **kwargs,
+    )
+
+
+def create_network_from_weights(
+    target_replace_modules: List[str],
+    multiplier: float,
+    weights_sd: Dict[str, torch.Tensor],
+    text_encoders: Optional[List[nn.Module]] = None,
+    unet: Optional[nn.Module] = None,
+    for_inference: bool = False,
+    **kwargs,
+) -> lora_module.LoRANetwork:
+    """Create LoKr network from saved weights (internal)."""
+    modules_dim = {}
+    modules_alpha = {}
+    for key, value in weights_sd.items():
+        if "." not in key:
+            continue
+
+        lora_name = key.split(".")[0]
+        if "alpha" in key:
+            modules_alpha[lora_name] = value
+        elif "lokr_w2_a" in key:
+            # low-rank mode: dim = w2_a.shape[1]
+            dim = value.shape[1]
+            modules_dim[lora_name] = dim
+        elif "lokr_w2" in key and "lokr_w2_a" not in key and "lokr_w2_b" not in key:
+            # full matrix mode: use dim=1 as placeholder
+            if lora_name not in modules_dim:
+                modules_dim[lora_name] = 1
+
+    # extract factor for LoKr (user must specify via --network_args factor=N if different from default)
+    factor = int(kwargs.pop("factor", -1))
+
+    module_class = LoKrInfModule if for_inference else LoKrModule
+    module_kwargs = {"factor": factor}
+
+    network = lora_module.LoRANetwork(
+        target_replace_modules,
+        "lora_unet",
+        text_encoders,
+        unet,
+        multiplier=multiplier,
+        modules_dim=modules_dim,
+        modules_alpha=modules_alpha,
+        module_class=module_class,
+        module_kwargs=module_kwargs,
+    )
+    return network
+
+
+def create_arch_network_from_weights(
+    multiplier: float,
+    weights_sd: Dict[str, torch.Tensor],
+    text_encoders: Optional[List[nn.Module]] = None,
+    unet: Optional[nn.Module] = None,
+    for_inference: bool = False,
+    **kwargs,
+) -> lora_module.LoRANetwork:
+    """Create LoKr network from saved weights with auto-detected architecture."""
+    target_replace_modules, _ = detect_arch_config(unet)
+    return create_network_from_weights(
+        target_replace_modules, multiplier, weights_sd, text_encoders, unet, for_inference, **kwargs
+    )
+
+
+def merge_weights_to_tensor(
+    model_weight: torch.Tensor,
+    lora_name: str,
+    lora_sd: Dict[str, torch.Tensor],
+    lora_weight_keys: set,
+    multiplier: float,
+    calc_device: torch.device,
+) -> torch.Tensor:
+    """Merge LoKr weights directly into a model weight tensor.
+
+    No Module/Network creation needed. Consumed keys are removed from lora_weight_keys.
+    Returns model_weight unchanged if no matching LoKr keys found.
+    """
+    w1_key = lora_name + ".lokr_w1"
+    w2_key = lora_name + ".lokr_w2"
+    w2a_key = lora_name + ".lokr_w2_a"
+    w2b_key = lora_name + ".lokr_w2_b"
+    alpha_key = lora_name + ".alpha"
+
+    if w1_key not in lora_weight_keys:
+        return model_weight
+
+    w1 = lora_sd[w1_key].to(calc_device)
+
+    # determine low-rank vs full matrix mode
+    if w2a_key in lora_weight_keys:
+        # low-rank: w2 = w2_a @ w2_b
+        w2a = lora_sd[w2a_key].to(calc_device)
+        w2b = lora_sd[w2b_key].to(calc_device)
+        dim = w2a.shape[1]
+        consumed_keys = [w1_key, w2a_key, w2b_key, alpha_key]
+    elif w2_key in lora_weight_keys:
+        # full matrix mode
+        w2a = None
+        w2b = None
+        dim = None  # will use scale=1.0
+        consumed_keys = [w1_key, w2_key, alpha_key]
+    else:
+        return model_weight
+
+    alpha = lora_sd.get(alpha_key, None)
+    if alpha is not None and isinstance(alpha, torch.Tensor):
+        alpha = alpha.item()
+
+    # compute scale
+    if w2a is not None:
+        # low-rank mode
+        if alpha is None:
+            alpha = dim
+        scale = alpha / dim
+    else:
+        # full matrix mode: scale = 1.0
+        scale = 1.0
+
+    original_dtype = model_weight.dtype
+    if original_dtype.itemsize == 1:  # fp8
+        model_weight = model_weight.to(torch.float16)
+        w1 = w1.to(torch.float16)
+        if w2a is not None:
+            w2a, w2b = w2a.to(torch.float16), w2b.to(torch.float16)
+
+    # compute w2
+    if w2a is not None:
+        w2 = w2a @ w2b
+    else:
+        w2 = lora_sd[w2_key].to(calc_device)
+        if original_dtype.itemsize == 1:
+            w2 = w2.to(torch.float16)
+
+    # ΔW = kron(w1, w2) * scale
+    diff_weight = make_kron(w1, w2, scale)
+    model_weight = model_weight + multiplier * diff_weight
+
+    if original_dtype.itemsize == 1:
+        model_weight = model_weight.to(original_dtype)
+
+    # remove consumed keys
+    for key in consumed_keys:
+        lora_weight_keys.discard(key)
+
+    return model_weight

--- a/src/musubi_tuner/networks/lokr.py
+++ b/src/musubi_tuner/networks/lokr.py
@@ -320,9 +320,9 @@ def create_network_from_weights(
             dim = value.shape[1]
             modules_dim[lora_name] = dim
         elif "lokr_w2" in key and "lokr_w2_a" not in key and "lokr_w2_b" not in key:
-            # full matrix mode: use dim=1 as placeholder
+            # full matrix mode: set dim large enough to trigger full-matrix path
             if lora_name not in modules_dim:
-                modules_dim[lora_name] = 1
+                modules_dim[lora_name] = max(value.shape)
 
     # extract factor for LoKr (user must specify via --network_args factor=N if different from default)
     factor = int(kwargs.pop("factor", -1))

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -512,12 +512,12 @@ class LoRANetwork(torch.nn.Module):
                             # exclude/include filter
                             excluded = False
                             for pattern in exclude_re_patterns:
-                                if pattern.match(original_name):
+                                if pattern.fullmatch(original_name):
                                     excluded = True
                                     break
                             included = False
                             for pattern in include_re_patterns:
-                                if pattern.match(original_name):
+                                if pattern.fullmatch(original_name):
                                     included = True
                                     break
                             if excluded and not included:

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -7,7 +7,7 @@ import ast
 import math
 import os
 import re
-from typing import Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 from transformers import CLIPTextModel
 import torch
 import torch.nn as nn
@@ -179,19 +179,6 @@ class LoRAInfModule(LoRAModule):
     def set_network(self, network):
         self.network = network
 
-    # merge weight to org_module
-    # def merge_to(self, sd, dtype, device, non_blocking=False):
-    #     if torch.cuda.is_available():
-    #         stream = torch.cuda.Stream(device=device)
-    #         with torch.cuda.stream(stream):
-    #             print(f"merge_to {self.lora_name}")
-    #             self._merge_to(sd, dtype, device, non_blocking)
-    #             torch.cuda.synchronize(device=device)
-    #             print(f"merge_to {self.lora_name} done")
-    #         torch.cuda.empty_cache()
-    #     else:
-    #         self._merge_to(sd, dtype, device, non_blocking)
-
     def merge_to(self, sd, dtype, device, non_blocking=False):
         # extract weight from org_module
         org_sd = self.org_module.state_dict()
@@ -340,6 +327,8 @@ def create_network(
     text_encoders: List[nn.Module],
     unet: nn.Module,
     neuron_dropout: Optional[float] = None,
+    module_class: Type[object] = None,
+    module_kwargs: Optional[Dict[str, Any]] = None,
     **kwargs,
 ):
     """architecture independent network creation"""
@@ -381,6 +370,9 @@ def create_network(
     if include_patterns is not None and isinstance(include_patterns, str):
         include_patterns = ast.literal_eval(include_patterns)
 
+    if module_class is None:
+        module_class = LoRAModule
+
     # too many arguments ( ^ω^)･･･
     network = LoRANetwork(
         target_replace_modules,
@@ -395,6 +387,8 @@ def create_network(
         module_dropout=module_dropout,
         conv_lora_dim=conv_dim,
         conv_alpha=conv_alpha,
+        module_class=module_class,
+        module_kwargs=module_kwargs,
         exclude_patterns=exclude_patterns,
         include_patterns=include_patterns,
         verbose=verbose,
@@ -430,6 +424,7 @@ class LoRANetwork(torch.nn.Module):
         conv_lora_dim: Optional[int] = None,
         conv_alpha: Optional[float] = None,
         module_class: Type[object] = LoRAModule,
+        module_kwargs: Optional[Dict[str, Any]] = None,
         modules_dim: Optional[Dict[str, int]] = None,
         modules_alpha: Optional[Dict[str, int]] = None,
         exclude_patterns: Optional[List[str]] = None,
@@ -448,6 +443,7 @@ class LoRANetwork(torch.nn.Module):
         self.module_dropout = module_dropout
         self.target_replace_modules = target_replace_modules
         self.prefix = prefix
+        self.module_kwargs = module_kwargs or {}
 
         self.loraplus_lr_ratio = None
         # self.loraplus_unet_lr_ratio = None
@@ -565,6 +561,7 @@ class LoRANetwork(torch.nn.Module):
                                 dropout=dropout,
                                 rank_dropout=rank_dropout,
                                 module_dropout=module_dropout,
+                                **self.module_kwargs,
                             )
                             loras.append(lora)
 
@@ -712,6 +709,9 @@ class LoRANetwork(torch.nn.Module):
                     else:
                         param_groups["lora"][f"{lora.lora_name}.{name}"] = param
 
+            if loraplus_ratio is not None and len(param_groups["plus"]) == 0:
+                logger.warning("LoRA+ is not effective for this network type (no 'lora_up' parameters found)")
+
             params = []
             descriptions = []
             for key in param_groups.keys():
@@ -830,6 +830,12 @@ class LoRANetwork(torch.nn.Module):
         keys_scaled = 0
 
         state_dict = self.state_dict()
+
+        # guard: only supported for LoRA (lora_down/lora_up parameterization)
+        if not any("lora_down" in k and "weight" in k for k in state_dict.keys()):
+            logger.warning("max_norm_regularization is only supported for LoRA")
+            return 0, 0.0, 0.0
+
         for key in state_dict.keys():
             if "lora_down" in key and "weight" in key:
                 downkeys.append(key)
@@ -887,6 +893,8 @@ def create_network_from_weights(
     text_encoders: Optional[List[nn.Module]] = None,
     unet: Optional[nn.Module] = None,
     for_inference: bool = False,
+    module_class: Optional[Type[object]] = None,
+    module_kwargs: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> LoRANetwork:
     # get dim/alpha mapping
@@ -904,7 +912,8 @@ def create_network_from_weights(
             modules_dim[lora_name] = dim
             # logger.info(lora_name, value.size(), dim)
 
-    module_class = LoRAInfModule if for_inference else LoRAModule
+    if module_class is None:
+        module_class = LoRAInfModule if for_inference else LoRAModule
 
     network = LoRANetwork(
         target_replace_modules,
@@ -915,5 +924,6 @@ def create_network_from_weights(
         modules_dim=modules_dim,
         modules_alpha=modules_alpha,
         module_class=module_class,
+        module_kwargs=module_kwargs,
     )
     return network

--- a/src/musubi_tuner/networks/network_arch.py
+++ b/src/musubi_tuner/networks/network_arch.py
@@ -1,0 +1,61 @@
+"""Architecture detection and configuration for network modules (LoHa, LoKr, etc.)."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def detect_arch_config(unet):
+    """Detect architecture from model structure.
+
+    Returns: (target_replace_modules, default_exclude_patterns)
+    """
+    module_class_names = set()
+    for module in unet.modules():
+        module_class_names.add(type(module).__name__)
+
+    # Order matters for disambiguation
+    if "WanAttentionBlock" in module_class_names:
+        from .lora_wan import WAN_TARGET_REPLACE_MODULES
+
+        return WAN_TARGET_REPLACE_MODULES, [r".*(patch_embedding|text_embedding|time_embedding|time_projection|norm|head).*"]
+
+    if "QwenImageTransformerBlock" in module_class_names:
+        from .lora_qwen_image import QWEN_IMAGE_TARGET_REPLACE_MODULES
+
+        return QWEN_IMAGE_TARGET_REPLACE_MODULES, [r".*(_mod_).*"]
+
+    if "ZImageTransformerBlock" in module_class_names:
+        from .lora_zimage import ZIMAGE_TARGET_REPLACE_MODULES
+
+        return ZIMAGE_TARGET_REPLACE_MODULES, [r".*(_modulation|_refiner).*"]
+
+    if "HunyuanVideoTransformerBlock" in module_class_names:
+        from .lora_framepack import FRAMEPACK_TARGET_REPLACE_MODULES
+
+        return FRAMEPACK_TARGET_REPLACE_MODULES, [r".*(norm).*"]
+
+    # Kandinsky5 is not supported in auto-detection (uses include_patterns, requires special handling)
+
+    if "DoubleStreamBlock" in module_class_names:
+        # FLUX Kontext and FLUX 2 share same target/exclude config
+        from .lora_flux import FLUX_KONTEXT_TARGET_REPLACE_MODULES
+
+        return FLUX_KONTEXT_TARGET_REPLACE_MODULES, [
+            r".*(img_mod\.lin|txt_mod\.lin|modulation\.lin).*",
+            r".*(norm).*",
+        ]
+
+    if "MMSingleStreamBlock" in module_class_names:
+        # HunyuanVideo (has both MMDoubleStreamBlock and MMSingleStreamBlock)
+        from .lora import HUNYUAN_TARGET_REPLACE_MODULES
+
+        return HUNYUAN_TARGET_REPLACE_MODULES, [r".*(img_mod|txt_mod|modulation).*"]
+
+    if "MMDoubleStreamBlock" in module_class_names:
+        # HunyuanVideo 1.5 (only MMDoubleStreamBlock, no MMSingleStreamBlock)
+        from .lora_hv_1_5 import HV_1_5_IMAGE_TARGET_REPLACE_MODULES
+
+        return HV_1_5_IMAGE_TARGET_REPLACE_MODULES, [r".*(_in).*"]
+
+    raise ValueError(f"Cannot auto-detect architecture. Module classes found: {sorted(module_class_names)}")

--- a/src/musubi_tuner/utils/lora_utils.py
+++ b/src/musubi_tuner/utils/lora_utils.py
@@ -128,10 +128,7 @@ def load_safetensors_with_lora_and_fp8(
         lora_network_types = [detect_network_type(lora_sd) for lora_sd in lora_weights_list]
 
         # Merge LoRA weights into the state dict
-        logger.info(
-            f"Merging LoRA weights into state dict. multipliers: {lora_multipliers}, "
-            f"network types: {lora_network_types}"
-        )
+        logger.info(f"Merging LoRA weights into state dict. multipliers: {lora_multipliers}, network types: {lora_network_types}")
 
         # make hook for LoRA merging
         def weight_hook_func(model_weight_key, model_weight: torch.Tensor, keep_on_calc_device=False):
@@ -196,16 +193,12 @@ def load_safetensors_with_lora_and_fp8(
                         model_weight = (
                             model_weight
                             + multiplier
-                            * (up_weight.squeeze(3).squeeze(2) @ down_weight.squeeze(3).squeeze(2))
-                            .unsqueeze(2)
-                            .unsqueeze(3)
+                            * (up_weight.squeeze(3).squeeze(2) @ down_weight.squeeze(3).squeeze(2)).unsqueeze(2).unsqueeze(3)
                             * scale
                         )
                     else:
                         # conv2d 3x3
-                        conved = torch.nn.functional.conv2d(down_weight.permute(1, 0, 2, 3), up_weight).permute(
-                            1, 0, 2, 3
-                        )
+                        conved = torch.nn.functional.conv2d(down_weight.permute(1, 0, 2, 3), up_weight).permute(1, 0, 2, 3)
                         model_weight = model_weight + multiplier * conved * scale
 
                     if original_dtype.itemsize == 1:  # fp8

--- a/src/musubi_tuner/utils/lora_utils.py
+++ b/src/musubi_tuner/utils/lora_utils.py
@@ -22,6 +22,18 @@ from musubi_tuner.utils.safetensors_utils import (
 )
 
 
+def detect_network_type(lora_sd: Dict[str, torch.Tensor]) -> str:
+    """Detect network type (lora, loha, lokr) from state dict keys."""
+    for key in lora_sd:
+        if "lora_down" in key:
+            return "lora"
+        if "hada_w1_a" in key:
+            return "loha"
+        if "lokr_w1" in key:
+            return "lokr"
+    return "lora"  # default
+
+
 def filter_lora_state_dict(
     weights_sd: Dict[str, torch.Tensor],
     include_pattern: Optional[str] = None,
@@ -112,12 +124,18 @@ def load_safetensors_with_lora_and_fp8(
         if len(lora_multipliers) > len(lora_weights_list):
             lora_multipliers = lora_multipliers[: len(lora_weights_list)]
 
+        # detect network types for each lora_sd
+        lora_network_types = [detect_network_type(lora_sd) for lora_sd in lora_weights_list]
+
         # Merge LoRA weights into the state dict
-        logger.info(f"Merging LoRA weights into state dict. multipliers: {lora_multipliers}")
+        logger.info(
+            f"Merging LoRA weights into state dict. multipliers: {lora_multipliers}, "
+            f"network types: {lora_network_types}"
+        )
 
         # make hook for LoRA merging
         def weight_hook_func(model_weight_key, model_weight: torch.Tensor, keep_on_calc_device=False):
-            nonlocal list_of_lora_weight_keys, lora_weights_list, lora_multipliers, calc_device
+            nonlocal list_of_lora_weight_keys, lora_weights_list, lora_multipliers, lora_network_types, calc_device
 
             if not model_weight_key.endswith(".weight"):
                 return model_weight
@@ -126,63 +144,78 @@ def load_safetensors_with_lora_and_fp8(
             if original_device != calc_device:
                 model_weight = model_weight.to(calc_device)  # to make calculation faster
 
-            for lora_weight_keys, lora_sd, multiplier in zip(list_of_lora_weight_keys, lora_weights_list, lora_multipliers):
-                # check if this weight has LoRA weights
+            for lora_weight_keys, lora_sd, multiplier, net_type in zip(
+                list_of_lora_weight_keys, lora_weights_list, lora_multipliers, lora_network_types
+            ):
                 lora_name = model_weight_key.rsplit(".", 1)[0]  # remove trailing ".weight"
                 lora_name = "lora_unet_" + lora_name.replace(".", "_")
-                down_key = lora_name + ".lora_down.weight"
-                up_key = lora_name + ".lora_up.weight"
-                alpha_key = lora_name + ".alpha"
-                if down_key not in lora_weight_keys or up_key not in lora_weight_keys:
-                    continue
 
-                # get LoRA weights
-                down_weight = lora_sd[down_key]
-                up_weight = lora_sd[up_key]
+                if net_type == "loha":
+                    from musubi_tuner.networks.loha import merge_weights_to_tensor as loha_merge
 
-                dim = down_weight.size()[0]
-                alpha = lora_sd.get(alpha_key, dim)
-                scale = alpha / dim
+                    model_weight = loha_merge(model_weight, lora_name, lora_sd, lora_weight_keys, multiplier, calc_device)
+                elif net_type == "lokr":
+                    from musubi_tuner.networks.lokr import merge_weights_to_tensor as lokr_merge
 
-                down_weight = down_weight.to(calc_device)
-                up_weight = up_weight.to(calc_device)
-
-                original_dtype = model_weight.dtype
-                if original_dtype.itemsize == 1:  # fp8
-                    # temporarily convert to float16 for calculation
-                    model_weight = model_weight.to(torch.float16)
-                    down_weight = down_weight.to(torch.float16)
-                    up_weight = up_weight.to(torch.float16)
-
-                # W <- W + U * D
-                if len(model_weight.size()) == 2:
-                    # linear
-                    if len(up_weight.size()) == 4:  # use linear projection mismatch
-                        up_weight = up_weight.squeeze(3).squeeze(2)
-                        down_weight = down_weight.squeeze(3).squeeze(2)
-                    model_weight = model_weight + multiplier * (up_weight @ down_weight) * scale
-                elif down_weight.size()[2:4] == (1, 1):
-                    # conv2d 1x1
-                    model_weight = (
-                        model_weight
-                        + multiplier
-                        * (up_weight.squeeze(3).squeeze(2) @ down_weight.squeeze(3).squeeze(2)).unsqueeze(2).unsqueeze(3)
-                        * scale
-                    )
+                    model_weight = lokr_merge(model_weight, lora_name, lora_sd, lora_weight_keys, multiplier, calc_device)
                 else:
-                    # conv2d 3x3
-                    conved = torch.nn.functional.conv2d(down_weight.permute(1, 0, 2, 3), up_weight).permute(1, 0, 2, 3)
-                    # logger.info(conved.size(), weight.size(), module.stride, module.padding)
-                    model_weight = model_weight + multiplier * conved * scale
+                    # standard LoRA (lora_down/lora_up)
+                    down_key = lora_name + ".lora_down.weight"
+                    up_key = lora_name + ".lora_up.weight"
+                    alpha_key = lora_name + ".alpha"
+                    if down_key not in lora_weight_keys or up_key not in lora_weight_keys:
+                        continue
 
-                if original_dtype.itemsize == 1:  # fp8
-                    model_weight = model_weight.to(original_dtype)  # convert back to original dtype
+                    # get LoRA weights
+                    down_weight = lora_sd[down_key]
+                    up_weight = lora_sd[up_key]
 
-                # remove LoRA keys from set
-                lora_weight_keys.remove(down_key)
-                lora_weight_keys.remove(up_key)
-                if alpha_key in lora_weight_keys:
-                    lora_weight_keys.remove(alpha_key)
+                    dim = down_weight.size()[0]
+                    alpha = lora_sd.get(alpha_key, dim)
+                    scale = alpha / dim
+
+                    down_weight = down_weight.to(calc_device)
+                    up_weight = up_weight.to(calc_device)
+
+                    original_dtype = model_weight.dtype
+                    if original_dtype.itemsize == 1:  # fp8
+                        # temporarily convert to float16 for calculation
+                        model_weight = model_weight.to(torch.float16)
+                        down_weight = down_weight.to(torch.float16)
+                        up_weight = up_weight.to(torch.float16)
+
+                    # W <- W + U * D
+                    if len(model_weight.size()) == 2:
+                        # linear
+                        if len(up_weight.size()) == 4:  # use linear projection mismatch
+                            up_weight = up_weight.squeeze(3).squeeze(2)
+                            down_weight = down_weight.squeeze(3).squeeze(2)
+                        model_weight = model_weight + multiplier * (up_weight @ down_weight) * scale
+                    elif down_weight.size()[2:4] == (1, 1):
+                        # conv2d 1x1
+                        model_weight = (
+                            model_weight
+                            + multiplier
+                            * (up_weight.squeeze(3).squeeze(2) @ down_weight.squeeze(3).squeeze(2))
+                            .unsqueeze(2)
+                            .unsqueeze(3)
+                            * scale
+                        )
+                    else:
+                        # conv2d 3x3
+                        conved = torch.nn.functional.conv2d(down_weight.permute(1, 0, 2, 3), up_weight).permute(
+                            1, 0, 2, 3
+                        )
+                        model_weight = model_weight + multiplier * conved * scale
+
+                    if original_dtype.itemsize == 1:  # fp8
+                        model_weight = model_weight.to(original_dtype)  # convert back to original dtype
+
+                    # remove LoRA keys from set
+                    lora_weight_keys.remove(down_key)
+                    lora_weight_keys.remove(up_key)
+                    if alpha_key in lora_weight_keys:
+                        lora_weight_keys.remove(alpha_key)
 
             if not keep_on_calc_device and original_device != calc_device:
                 model_weight = model_weight.to(original_device)  # move back to original device


### PR DESCRIPTION
This pull request adds comprehensive support for LoHa (Low-rank Hadamard Product) as an alternative parameter-efficient fine-tuning method alongside LoRA in Musubi Tuner. It introduces a new `loha.py` network module, updates documentation, and makes minor improvements to the core LoRA network code to support modularity and extensibility.

**Major features and documentation:**

*Adds support for LoHa network modules and documents their usage and limitations, while refactoring the core LoRA code to allow for easy integration of new network module types.*

---

**LoHa network module implementation:**

- Introduced a new `LoHa` network module in `loha.py`, including both training (`LoHaModule`) and inference (`LoHaInfModule`) classes, custom autograd function for the Hadamard product, weight merging utilities, and architecture auto-detection. This enables training and inference using LoHa on supported architectures, with dropout and module exclusion features.

**Documentation updates:**

- Added a new documentation file `docs/loha_lokr.md` that explains LoHa and LoKr, their usage, supported architectures, training/inference instructions, options, limitations, and acknowledgments, in both English and Japanese.

**Core LoRA network extensibility:**

- Updated `lora.py` to support passing a custom `module_class` and `module_kwargs` to the `create_network` function, enabling integration of alternative network modules like LoHa. [[1]](diffhunk://#diff-f0929933f0f0297a23385c95e599a0c21689b543be6be1b443791608c9e9fb05R330-R331) [[2]](diffhunk://#diff-f0929933f0f0297a23385c95e599a0c21689b543be6be1b443791608c9e9fb05R373-R375)
- Minor type annotation improvement in `lora.py` to support `Any` type for future extensibility.

**Code cleanup:**

- Removed commented-out legacy code for weight merging in `lora.py` for clarity and maintainability.

---

Much of the code was written by Claude Code/Opus 4.6.