### PR TITLE
fix: convert reference image to RGB in I2V sample generation to handle RGBA PNGs

### DIFF
--- a/src/musubi_tuner/wan_train_network.py
+++ b/src/musubi_tuner/wan_train_network.py
@@ -319,6 +319,8 @@ class WanNetworkTrainer(NetworkTrainer):
 
             if self.i2v_training:
                 image = Image.open(image_path)
+                if image.mode == "RGBA":
+                    image = image.convert("RGB")
                 image = resize_image_to_bucket(image, (width, height))  # returns a numpy array
                 image = torch.from_numpy(image).permute(2, 0, 1).unsqueeze(1).float()  # C, 1, H, W
                 image = image / 127.5 - 1  # -1 to 1


### PR DESCRIPTION
## Summary

When using I2V training (`--task i2v-A14B`) with a reference image that has an
alpha channel (e.g. a PNG exported with transparency), the training crashes
during sample generation at the end of each epoch with:

```
RuntimeError: Sizes of tensors must match except in dimension 1.
Expected size 4 but got size 3 for tensor number 1 in the list.
```
The training step itself finishes correctly and the checkpoint is saved —
only the sample generation call fails, aborting the entire run.

## How to reproduce

1. Use any RGBA PNG (e.g. exported from Stable Diffusion or image editors) as
   the `--i` reference image in `sample_prompts.txt`
2. Run I2V training with `--sample_every_n_epochs 1`
3. Crash occurs at the first sample generation step
