### PR TITLE
fix: replace verbose print statements with logger.debug in cache latents files

### DIFF
--- a/src/musubi_tuner/qwen_image_cache_latents.py
+++ b/src/musubi_tuner/qwen_image_cache_latents.py
@@ -100,7 +100,7 @@ def encode_and_save_batch(vae: qwen_image_autoencoder_kl.AutoencoderKLQwenImage,
         def decode(lat):
             with torch.no_grad():
                 pixels = vae.decode_to_pixels(lat)
-            print(pixels.min(), pixels.max(), pixels.shape)
+            logger.debug(f"pixels min/max/shape: {pixels.min()}, {pixels.max()}, {pixels.shape}")
             pixels = pixels.to(torch.float32).cpu()
             pixels = (pixels * 255).clamp(0, 255).to(torch.uint8)  # convert to uint8
             pixels = pixels[0].permute(1, 2, 0)  # C, H, W -> H, W, C


### PR DESCRIPTION
Hey, I just started looking at this repo, nice work!

I noticed that some of the `*_cache_latents.py` files were a little noisy and had `print()` calls for shape/debug info. This replaces them with `logger.debug()` so they're silenced by default but still accessible when needed. I've only run this new code with Qwen so far, but I had Claude write a [test script]( https://github.com/belambert/musubi-tuner/blob/logging_fix_test/test_cache_latents_smoke.py) to verify the others.

Happy to change anything if you'd prefer it some other way.

This issue was mentioned here: https://github.com/kohya-ss/musubi-tuner/discussions/698

Files changed:
- `flux_2_cache_latents.py` — cache saving shape info
- `flux_kontext_cache_latents.py` — cache saving shape info
- `fpack_cache_latents.py` — 6 print statements with latent/index details in `encode_and_save_batch_one_frame`
- `qwen_image_cache_latents.py` — pixel min/max/shape debug output + cache saving shape info

The `print()` calls in `cache_latents.py`'s `show_image`, `show_console`, `save_video`, and `show_datasets` are left as-is since those are intentional interactive UI output for `--debug_mode`.

## Testing

- [x] `ruff check` passes
- [x] `ruff format` passes (already formatted)
- [x] Ran a [smoke test script](https://github.com/belambert/musubi-tuner/blob/logging_fix_test/test_cache_latents_smoke.py) (written by Claude) against all 9 `*_cache_latents.py` scripts — creates dummy images, mocks the VAE, and runs the full encode-and-save pipeline end-to-end to verify `.safetensors` cache files are written. All 9/9 pass:

```
cache_latents.py                         OK (3 cache files)
flux_2_cache_latents.py                  OK (3 cache files)
flux_kontext_cache_latents.py            OK (3 cache files)
fpack_cache_latents.py                   OK (3 cache files)
hv_1_5_cache_latents.py                  OK (3 cache files)
kandinsky5_cache_latents.py              OK (3 cache files)
qwen_image_cache_latents.py              OK (3 cache files)
wan_cache_latents.py                     OK (3 cache files)
zimage_cache_latents.py                  OK (3 cache files)

Results: 9/9 passed, 0 failed
```