### PR TITLE
fix(cache_latents): progress bar total count

### DIFF
--- a/src/musubi_tuner/cache_latents.py
+++ b/src/musubi_tuner/cache_latents.py
@@ -290,7 +290,8 @@ def encode_datasets(datasets: list[BaseDataset], encode: callable, args: argpars
     for i, dataset in enumerate(datasets):
         logger.info(f"Encoding dataset [{i}]")
         all_latent_cache_paths = []
-        for _, batch in tqdm(dataset.retrieve_latent_cache_batches(num_workers)):
+        total = dataset.get_total_image_count() if hasattr(dataset, "get_total_image_count") else None
+        for _, batch in tqdm(dataset.retrieve_latent_cache_batches(num_workers), total=total):
             batch: list[ItemInfo] = batch
             if not supports_alpha:
                 # make sure content has 3 channels


### PR DESCRIPTION
This change adds a `total=` argument to a `tqdm` progress bar in the cache_latents code. This allows the progress bar to show the actual percent progress, rather than just counting up from 1.

I'm not sure if `get_total_image_count()` is always one-to-one equal to the number of latents computed (e.g. if there are duplicates). But for the local datasets I'm using, the total image count seemed to always be equal to the sum of the sizes of the batches.