### PR TITLE
fix: reduce ERNIE-image latent cache CUDA fragmentation

### DIFF
--- a/src/musubi_tuner/ernie_image_cache_latents.py
+++ b/src/musubi_tuner/ernie_image_cache_latents.py
@@ -53,6 +53,13 @@ def encode_and_save_batch(vae: flux2_models.AutoEncoder, batch: List[ItemInfo]):
         logger.debug(f"Saving cache for {item.item_key}. Latent shape: {latent.shape}")
         save_latent_cache_ernie_image(item_info=item, latent=latent)
 
+    # Release per-batch tensors aggressively to reduce CUDA memory fragmentation
+    # during long cache runs on consumer GPUs.
+    del latents
+    del contents
+    if vae.device.type == "cuda":
+        torch.cuda.empty_cache()
+
 
 def main():
     parser = cache_latents.setup_parser_common()


### PR DESCRIPTION
## Summary

This PR adds a small memory-stability improvement to `ernie_image_cache_latents.py`.

After each batch is encoded and saved, it now:

- releases the per-batch tensors explicitly
- calls `torch.cuda.empty_cache()` on CUDA

## Why

While testing ERNIE-image latent caching on a consumer GPU, latent caching could run for a while and then fail with CUDA OOM even at `batch_size = 1`. This change helps reduce long-run CUDA memory fragmentation during cache generation.

## Scope

- No behavior change to latent contents
- Only affects ERNIE-image latent caching
- Keeps the change minimal and isolated

## Notes

A larger follow-up could also expose additional VAE memory options for ERNIE-image latent caching, but this PR intentionally keeps the fix small.
