### PR TITLE
Refactor: introduce extension seams on NetworkTrainer (for Self-Flow + future extensions)

### DIFF
--- a/src/musubi_tuner/flux_2_train_network.py
+++ b/src/musubi_tuner/flux_2_train_network.py
@@ -9,6 +9,7 @@ from diffusers.utils.torch_utils import randn_tensor
 
 from musubi_tuner.flux_2 import flux2_models, flux2_utils
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     load_prompts,
     clean_memory_on_device,
@@ -266,7 +267,8 @@ class Flux2NetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         model: flux2_models.Flux2 = transformer
 
         bsize = latents.shape[0]
@@ -330,7 +332,7 @@ class Flux2NetworkTrainer(NetworkTrainer):
         latents = latents.to(device=accelerator.device, dtype=network_dtype)
         target = noise - latents
 
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -146,7 +146,7 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
 
         Recognised kwargs:
         - ``hidden_features`` (bool): when True, return captured features in
-          ``DiTOutput.features`` (drained from ``self._feature_extractor``).
+          ``DiTOutput.extra["features"]`` (drained from ``self._feature_extractor``).
         - ``feature_layer`` (int): which registered layer's output to return.
         - ``per_token_timesteps`` (Tensor): per-token timestep map for
           dual-timestep conditioning (paper §A.3). Requires per-token
@@ -249,6 +249,7 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         ckpt_name: str,
         save_dtype,
         metadata: dict,
+        force_sync_upload: bool,
     ) -> None:
         """Save EMA (teacher) and projection-head companion files.
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -221,8 +221,18 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         """
         if not args.self_flow:
             return super().process_batch(
-                args, accelerator, transformer, network, batch, latents, noise,
-                noise_scheduler, dit_dtype, network_dtype, vae, global_step,
+                args,
+                accelerator,
+                transformer,
+                network,
+                batch,
+                latents,
+                noise,
+                noise_scheduler,
+                dit_dtype,
+                network_dtype,
+                vae,
+                global_step,
             )
         # TODO: port PR #913's _self_flow_step body here, calling
         #       ``self.call_dit(..., hidden_features=True, feature_layer=...)``
@@ -249,7 +259,9 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         # TODO: in-place lerp_ across floating-point params; copy_ otherwise.
         raise NotImplementedError("Self-Flow EMA update — see PR #913 _update_ema_weights")
 
-    def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
+    def on_before_sample_images(
+        self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype
+    ) -> None:
         """Swap to EMA (teacher) weights before sampling when Self-Flow is active."""
         if not args.self_flow or self.ema_lora_state is None:
             return
@@ -257,7 +269,9 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         self._saved_student_state = {k: v.clone() for k, v in network.state_dict().items()}
         network.load_state_dict(self.ema_lora_state)
 
-    def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
+    def on_after_sample_images(
+        self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype
+    ) -> None:
         """Restore student weights after EMA sampling."""
         if self._saved_student_state is None:
             return

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -225,25 +225,21 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         # TODO: in-place lerp_ across floating-point params; copy_ otherwise.
         raise NotImplementedError("Self-Flow EMA update — see PR #913 _update_ema_weights")
 
-    def on_sample_images(
-        self,
-        args: argparse.Namespace,
-        accelerator: Accelerator,
-        network,
-        sample_fn,
-    ) -> None:
-        """Sample using EMA (teacher) weights when Self-Flow is active.
-
-        Swap student state -> EMA -> sample -> swap back. The teacher is
-        what users actually want to use, since the student is intentionally
-        noisier per the dual-timestep schedule.
-        """
+    def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
+        """Swap to EMA (teacher) weights before sampling when Self-Flow is active."""
         if not args.self_flow or self.ema_lora_state is None:
-            sample_fn()
             return
-        # TODO: load ema_lora_state into accelerator.unwrap_model(network),
-        #       call sample_fn(), restore student state.
-        raise NotImplementedError("Self-Flow sampling weight swap — see PR #913 sample_images_with_ema")
+        network = accelerator.unwrap_model(network)
+        self._saved_student_state = {k: v.clone() for k, v in network.state_dict().items()}
+        network.load_state_dict(self.ema_lora_state)
+
+    def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
+        """Restore student weights after EMA sampling."""
+        if self._saved_student_state is None:
+            return
+        network = accelerator.unwrap_model(network)
+        network.load_state_dict(self._saved_student_state)
+        self._saved_student_state = None
 
     def on_post_save(
         self,

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -46,7 +46,8 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
     - ``self._coupling_scheduler``: dummy LR scheduler whose "lr" is the
       teacher coupling probability (decays over training).
     - ``self._feature_extractor``: holds DiT layer outputs captured via
-      ``register_forward_hook`` (no DiT model edit required).
+      ``register_forward_hook`` (no DiT model edit required). Hooks are
+      registered in ``on_transformer_loaded``.
     - ``self._self_flow_logs``: per-step metrics dict drained by
       ``extra_step_logs``.
     """
@@ -103,6 +104,26 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         #       See PR #913 hv_train_network.py around line 2395.
         raise NotImplementedError("Self-Flow rep_proj construction — see PR #913")
 
+    def on_transformer_loaded(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        transformer,
+    ) -> None:
+        """Register feature-extraction forward hooks on the raw transformer.
+
+        Done here (rather than in ``on_train_start``) so the hooks attach
+        before ``accelerator.prepare`` / block-swap rewrap, which keeps the
+        captured tensors aligned with the unwrapped block indices the user
+        supplied via ``--student_feature_layer`` / ``--teacher_feature_layer``.
+        """
+        if not args.self_flow:
+            return
+        # TODO: register forward_hook on transformer.double_blocks[student_layer]
+        #       and transformer.double_blocks[teacher_layer], stashing outputs
+        #       into self._feature_extractor for call_dit to drain.
+        raise NotImplementedError("Self-Flow forward-hook registration — see PR #913")
+
     def on_train_start(
         self,
         args: argparse.Namespace,
@@ -120,9 +141,9 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         3. ``self.rep_proj = accelerator.prepare(self.rep_proj)``.
         4. Optionally load ``--network_weights_proj`` into ``self.rep_proj``.
         5. Build ``self._coupling_scheduler`` (constant / cosine / linear / rex).
-        6. Register forward hooks on transformer blocks at indices
-           ``args.student_feature_layer`` and ``args.teacher_feature_layer``
-           via ``register_forward_hook`` — no edit to the FLUX.2 model code.
+
+        Forward-hook registration for feature extraction lives in
+        ``on_transformer_loaded`` (runs earlier, before accelerator.prepare).
         """
         if not args.self_flow:
             return

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -245,6 +245,7 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         args: argparse.Namespace,
         accelerator: Accelerator,
         network,
+        transformer,
         sync_gradients: bool,
         global_step: int,
     ) -> None:
@@ -284,6 +285,7 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         args: argparse.Namespace,
         accelerator: Accelerator,
         network,
+        transformer,
         ckpt_name: str,
         save_dtype,
         metadata: dict,

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -48,8 +48,10 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
     - ``self._feature_extractor``: holds DiT layer outputs captured via
       ``register_forward_hook`` (no DiT model edit required). Hooks are
       registered in ``on_transformer_loaded``.
-    - ``self._self_flow_logs``: per-step metrics dict drained by
-      ``extra_step_logs``.
+    - ``self._self_flow_logs``: per-step state metrics dict drained by
+      ``extra_step_logs`` (e.g. coupling-scheduler value). Loss decomposition
+      itself (``loss/gen``, ``loss/rep``) flows through ``process_batch``'s
+      ``loss_metrics`` return, not through here.
     """
 
     def __init__(self) -> None:
@@ -196,7 +198,7 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         network_dtype: torch.dtype,
         vae,
         global_step: int,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, dict[str, float]]:
         """Self-Flow step replacing vanilla flow matching.
 
         Outline (mirrors PR #913's ``_self_flow_step``):
@@ -210,8 +212,9 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
           5. Student forward (gradients flow); collect features.
           6. ``L_gen`` (MSE w/ flow weighting) + ``gamma * L_rep`` (negative
              cosine similarity through ``self.rep_proj``).
-          7. Populate ``self._self_flow_logs`` for ``extra_step_logs``.
-          8. Return scalar combined loss.
+          7. Return ``(L_gen + gamma * L_rep, {"loss/gen": ..., "loss/rep": ...,
+             "self_flow/gamma": ...})`` so the loss decomposition lands in the
+             per-step logs.
 
         Vanilla path (when ``--self_flow`` is off) falls through to the base
         implementation so this trainer can be used for non-Self-Flow runs too.

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -1,0 +1,391 @@
+"""Self-Flow training entry point for FLUX.2.
+
+Skeleton for Self-Supervised Flow Matching (Self-Flow) on the FLUX.2 backbone.
+Each base-class extension seam is overridden here as a stub showing how the
+algorithm hooks in. Actual algorithmic logic is intentionally left as
+``NotImplementedError`` / ``# TODO`` markers — to be filled in by porting
+rockerBOO's PR #913 implementation onto these seams.
+
+Reference: https://github.com/kohya-ss/musubi-tuner/pull/913
+
+This file is the proposed extension surface, not a runnable trainer. Do not
+use it to start a training run yet.
+
+Internal extension point — no API stability guarantees. Subclasses live in
+this repo; if you fork, expect breakage on updates.
+"""
+
+import argparse
+import logging
+from typing import Optional
+
+import torch
+from accelerate import Accelerator
+
+from musubi_tuner.flux_2_train_network import Flux2NetworkTrainer, flux2_setup_parser
+from musubi_tuner.hv_train_network import (
+    DiTOutput,
+    setup_parser_common,
+    read_config_from_file,
+)
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
+    """FLUX.2 + Self-Flow.
+
+    Owned state (set during the relevant lifecycle seams, used across steps):
+    - ``self.rep_proj``: representation projection head (paper §3.3, Eq. 6).
+      Constructed in ``extra_trainable_params``, prepared in ``on_train_start``.
+    - ``self.ema_lora_state``: EMA snapshot of LoRA weights (the "teacher").
+      Initialised in ``on_train_start`` after ``accelerator.prepare`` so it
+      sits on-device. Updated by ``on_post_optimizer_step``.
+    - ``self._coupling_scheduler``: dummy LR scheduler whose "lr" is the
+      teacher coupling probability (decays over training).
+    - ``self._feature_extractor``: holds DiT layer outputs captured via
+      ``register_forward_hook`` (no DiT model edit required).
+    - ``self._self_flow_logs``: per-step metrics dict drained by
+      ``extra_step_logs``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.rep_proj: Optional[torch.nn.Module] = None
+        self.ema_lora_state: Optional[dict] = None
+        self._coupling_scheduler = None
+        self._feature_extractor = None
+        self._self_flow_logs: dict = {}
+
+    # region argument validation (existing extension point — handle_model_specific_args)
+
+    def handle_model_specific_args(self, args: argparse.Namespace) -> None:
+        super().handle_model_specific_args(args)
+        # Self-Flow CLI sanity. Paper requires student feature layer l <
+        # teacher layer k, and mask ratio R_M <= 0.5.
+        if args.self_flow:
+            if (
+                args.student_feature_layer is not None
+                and args.teacher_feature_layer is not None
+                and args.student_feature_layer >= args.teacher_feature_layer
+            ):
+                raise ValueError(
+                    f"--student_feature_layer ({args.student_feature_layer}) must be less than "
+                    f"--teacher_feature_layer ({args.teacher_feature_layer})."
+                )
+            if args.mask_ratio > 0.5:
+                raise ValueError(f"--mask_ratio ({args.mask_ratio}) must be <= 0.5 (paper constraint R_M <= 0.5)")
+
+    # endregion
+
+    # region extension seam overrides
+
+    def extra_trainable_params(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        transformer,
+        trainable_params: list,
+    ) -> list:
+        """Build the projection head and merge it into the optimizer's first group.
+
+        Self-Flow's L_rep is computed against ``rep_proj(student_features)``;
+        the projection head's parameters share the network LR schedule because
+        Prodigy and friends don't support per-group LRs.
+        """
+        if not args.self_flow:
+            return trainable_params
+
+        # TODO: build Sequential(Linear, GELU, Linear) sized from transformer.hidden_size.
+        #       See PR #913 hv_train_network.py around line 2395.
+        raise NotImplementedError("Self-Flow rep_proj construction — see PR #913")
+
+    def on_train_start(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        transformer,
+        optimizer,
+    ) -> None:
+        """Finish Self-Flow setup once everything is on-device.
+
+        Steps to perform here:
+        1. Snapshot ``network.state_dict()`` into ``self.ema_lora_state``.
+        2. If ``--network_weights_ema`` is given, load it into the network,
+           re-snapshot, then restore student weights from ``--network_weights``.
+        3. ``self.rep_proj = accelerator.prepare(self.rep_proj)``.
+        4. Optionally load ``--network_weights_proj`` into ``self.rep_proj``.
+        5. Build ``self._coupling_scheduler`` (constant / cosine / linear / rex).
+        6. Register forward hooks on transformer blocks at indices
+           ``args.student_feature_layer`` and ``args.teacher_feature_layer``
+           via ``register_forward_hook`` — no edit to the FLUX.2 model code.
+        """
+        if not args.self_flow:
+            return
+        # TODO: see PR #913 hv_train_network.py around lines 2490-2522.
+        raise NotImplementedError("Self-Flow on_train_start — see PR #913")
+
+    def call_dit(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        transformer,
+        latents: torch.Tensor,
+        batch: dict[str, torch.Tensor],
+        noise: torch.Tensor,
+        noisy_model_input: torch.Tensor,
+        timesteps: torch.Tensor,
+        network_dtype: torch.dtype,
+        **kwargs,
+    ) -> DiTOutput:
+        """Extends Flux2NetworkTrainer.call_dit.
+
+        Recognised kwargs:
+        - ``hidden_features`` (bool): when True, return captured features in
+          ``DiTOutput.features`` (drained from ``self._feature_extractor``).
+        - ``feature_layer`` (int): which registered layer's output to return.
+        - ``per_token_timesteps`` (Tensor): per-token timestep map for
+          dual-timestep conditioning (paper §A.3). Requires per-token
+          timestep support inside the FLUX.2 transformer — out of scope of
+          this skeleton, see open question (3) below.
+
+        For the skeleton we delegate to the parent and ignore kwargs; once
+        the FLUX.2 model side is wired up, this override forwards
+        per_token_timesteps and surfaces captured features.
+        """
+        return super().call_dit(
+            args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs
+        )
+
+    def process_batch(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        transformer,
+        network,
+        batch: dict[str, torch.Tensor],
+        latents: torch.Tensor,
+        noise: torch.Tensor,
+        noise_scheduler,
+        dit_dtype: torch.dtype,
+        network_dtype: torch.dtype,
+        vae,
+        global_step: int,
+    ) -> torch.Tensor:
+        """Self-Flow step replacing vanilla flow matching.
+
+        Outline (mirrors PR #913's ``_self_flow_step``):
+          1. Sample two timesteps; per-sample ``teacher = min(t_a, t_b)``,
+             ``student = max(t_a, t_b)``.
+          2. Reconstruct two noisy inputs (teacher / student) via flow
+             matching ``(1-t)*latents + t*noise``.
+          3. Apply per-token mask of cleaner (teacher) noise into student
+             input; build per-token timestep map with optional mismatch.
+          4. Teacher forward (no_grad, EMA weights swapped in).
+          5. Student forward (gradients flow); collect features.
+          6. ``L_gen`` (MSE w/ flow weighting) + ``gamma * L_rep`` (negative
+             cosine similarity through ``self.rep_proj``).
+          7. Populate ``self._self_flow_logs`` for ``extra_step_logs``.
+          8. Return scalar combined loss.
+
+        Vanilla path (when ``--self_flow`` is off) falls through to the base
+        implementation so this trainer can be used for non-Self-Flow runs too.
+        """
+        if not args.self_flow:
+            return super().process_batch(
+                args, accelerator, transformer, network, batch, latents, noise,
+                noise_scheduler, dit_dtype, network_dtype, vae, global_step,
+            )
+        # TODO: port PR #913's _self_flow_step body here, calling
+        #       ``self.call_dit(..., hidden_features=True, feature_layer=...)``
+        #       and ``self.call_dit(..., per_token_timesteps=...)`` for
+        #       teacher and student forwards respectively.
+        raise NotImplementedError("Self-Flow process_batch — see PR #913 _self_flow_step")
+
+    def on_post_optimizer_step(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        sync_gradients: bool,
+        global_step: int,
+    ) -> None:
+        """EMA update of LoRA weights only on real optimizer steps.
+
+        ema_lora_state[k].lerp_(network.state_dict()[k], 1 - args.ema_decay)
+        """
+        if not args.self_flow or not sync_gradients:
+            return
+        if self.ema_lora_state is None:
+            return
+        # TODO: in-place lerp_ across floating-point params; copy_ otherwise.
+        raise NotImplementedError("Self-Flow EMA update — see PR #913 _update_ema_weights")
+
+    def on_sample_images(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        sample_fn,
+    ) -> None:
+        """Sample using EMA (teacher) weights when Self-Flow is active.
+
+        Swap student state -> EMA -> sample -> swap back. The teacher is
+        what users actually want to use, since the student is intentionally
+        noisier per the dual-timestep schedule.
+        """
+        if not args.self_flow or self.ema_lora_state is None:
+            sample_fn()
+            return
+        # TODO: load ema_lora_state into accelerator.unwrap_model(network),
+        #       call sample_fn(), restore student state.
+        raise NotImplementedError("Self-Flow sampling weight swap — see PR #913 sample_images_with_ema")
+
+    def on_post_save(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        ckpt_name: str,
+        save_dtype,
+        metadata: dict,
+    ) -> None:
+        """Save EMA (teacher) and projection-head companion files.
+
+        - ``<ckpt_name stem>-ema.safetensors``  (LoRA-format teacher weights)
+        - ``<ckpt_name stem>-proj.safetensors`` (raw rep_proj state_dict)
+        Each follows the main checkpoint's HuggingFace upload toggle.
+        """
+        if not args.self_flow:
+            return
+        # TODO: see PR #913 hv_train_network.py around lines 2750-2774.
+        raise NotImplementedError("Self-Flow companion file saving — see PR #913")
+
+    def extra_metadata(self, args: argparse.Namespace) -> dict:
+        """Return ``ss_self_flow_*`` keys for embedding into safetensors metadata."""
+        if not args.self_flow:
+            return {}
+        return {
+            "ss_self_flow": True,
+            "ss_self_flow_gamma": args.self_flow_gamma,
+            "ss_self_flow_gamma_warmup_steps": args.self_flow_gamma_warmup_steps,
+            "ss_self_flow_mask_ratio": args.mask_ratio,
+            "ss_self_flow_ema_decay": args.ema_decay,
+            "ss_self_flow_student_layer": args.student_feature_layer,
+            "ss_self_flow_teacher_layer": args.teacher_feature_layer,
+            "ss_self_flow_teacher_coupling_prob": args.self_flow_teacher_coupling_prob,
+            "ss_self_flow_teacher_coupling_decay": args.self_flow_teacher_coupling_decay,
+            "ss_self_flow_teacher_mismatch_ratio": args.self_flow_teacher_mismatch_ratio,
+        }
+
+    def extra_step_logs(self, args: argparse.Namespace, logs: dict) -> dict:
+        """Drain per-step Self-Flow metrics into the trainer's log payload."""
+        if not args.self_flow:
+            return {}
+        # ``self._self_flow_logs`` is populated inside process_batch.
+        return dict(self._self_flow_logs)
+
+    # endregion
+
+
+def self_flow_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Self-Flow-specific CLI arguments. Mirrors PR #913's additions."""
+    parser.add_argument(
+        "--self_flow",
+        action="store_true",
+        help="Enable Self-Flow training (dual-timestep scheduling + representation alignment).",
+    )
+    parser.add_argument(
+        "--self_flow_gamma",
+        type=float,
+        default=0.8,
+        help="Weight for representation alignment loss L_rep (paper Eq. 7). 0 disables L_rep.",
+    )
+    parser.add_argument(
+        "--self_flow_gamma_warmup_steps",
+        type=int,
+        default=0,
+        help="Linearly ramp gamma from 0 to --self_flow_gamma over this many steps. 0 disables warmup.",
+    )
+    parser.add_argument(
+        "--mask_ratio",
+        type=float,
+        default=0.25,
+        help="Token mask ratio for dual-timestep scheduling (paper Eq. 4, R_M <= 0.5).",
+    )
+    parser.add_argument(
+        "--ema_decay",
+        type=float,
+        default=0.999,
+        help="EMA decay for the Self-Flow teacher LoRA weights.",
+    )
+    parser.add_argument(
+        "--student_feature_layer",
+        type=int,
+        default=None,
+        help="Global block index for student feature extraction (l in paper, must be < teacher_feature_layer). Recommended ~0.3 * num_blocks.",
+    )
+    parser.add_argument(
+        "--teacher_feature_layer",
+        type=int,
+        default=None,
+        help="Global block index for teacher feature extraction (k in paper, must be > student_feature_layer). Recommended ~0.7 * num_blocks.",
+    )
+    parser.add_argument(
+        "--self_flow_teacher_coupling_prob",
+        type=float,
+        default=0.0,
+        help="Per-step gate probability for applying timestep mismatch on masked patches. 0 disables mismatch.",
+    )
+    parser.add_argument(
+        "--self_flow_teacher_coupling_decay",
+        type=str,
+        default="constant",
+        choices=["constant", "cosine", "linear", "rex"],
+        help="Decay schedule for --self_flow_teacher_coupling_prob.",
+    )
+    parser.add_argument(
+        "--self_flow_teacher_coupling_decay_steps",
+        type=int,
+        default=None,
+        help="Steps over which to decay coupling prob to 0. Defaults to max_train_steps.",
+    )
+    parser.add_argument(
+        "--self_flow_teacher_mismatch_ratio",
+        type=float,
+        default=1.0,
+        help="When the coupling gate fires, fraction of masked patches receiving the timestep mismatch.",
+    )
+    parser.add_argument(
+        "--network_weights_ema",
+        type=str,
+        default=None,
+        help="Pretrained EMA (teacher) weights for resumption. Requires --network_weights.",
+    )
+    parser.add_argument(
+        "--network_weights_proj",
+        type=str,
+        default=None,
+        help="Pretrained projection head weights for resumption.",
+    )
+    return parser
+
+
+def main():
+    parser = setup_parser_common()
+    parser = flux2_setup_parser(parser)
+    parser = self_flow_setup_parser(parser)
+
+    args = parser.parse_args()
+    args = read_config_from_file(args, parser)
+
+    trainer = Flux2SelfFlowNetworkTrainer()
+    trainer.train(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/musubi_tuner/flux_kontext_train_network.py
+++ b/src/musubi_tuner/flux_kontext_train_network.py
@@ -10,6 +10,7 @@ from accelerate import Accelerator
 from musubi_tuner.dataset.image_video_dataset import ARCHITECTURE_FLUX_KONTEXT, ARCHITECTURE_FLUX_KONTEXT_FULL
 from musubi_tuner.flux import flux_models, flux_utils
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     load_prompts,
     clean_memory_on_device,
@@ -298,7 +299,8 @@ class FluxKontextNetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         model: flux_models.Flux = transformer
 
         bsize = latents.shape[0]
@@ -367,7 +369,7 @@ class FluxKontextNetworkTrainer(NetworkTrainer):
         # flow matching loss
         target = noise - latents
 
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/fpack_train_network.py
+++ b/src/musubi_tuner/fpack_train_network.py
@@ -22,6 +22,7 @@ from musubi_tuner.frame_pack.k_diffusion_hunyuan import sample_hunyuan
 from musubi_tuner.frame_pack.utils import crop_or_pad_yield_mask
 from musubi_tuner.dataset.image_video_dataset import resize_image_to_bucket
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     load_prompts,
     clean_memory_on_device,
@@ -532,7 +533,8 @@ class FramePackNetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         model: HunyuanVideoTransformer3DModelPacked = transformer
         device = accelerator.device
         batch_size = latents.shape[0]
@@ -587,7 +589,7 @@ class FramePackNetworkTrainer(NetworkTrainer):
         # flow matching loss
         target = noise - latents
 
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/hv_1_5_train_network.py
+++ b/src/musubi_tuner/hv_1_5_train_network.py
@@ -28,6 +28,7 @@ from musubi_tuner.hunyuan_video_1_5.hunyuan_video_1_5_models import (
 )
 from musubi_tuner.hunyuan_video_1_5.hunyuan_video_1_5_vae import VAE_LATENT_CHANNELS
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     clean_memory_on_device,
     load_prompts,
@@ -380,7 +381,8 @@ class HunyuanVideo15NetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         transformer: HunyuanVideo_1_5_DiffusionTransformer = transformer_arg
 
         # Check if this batch has I2V conditioning (first frame latents)
@@ -455,7 +457,7 @@ class HunyuanVideo15NetworkTrainer(NetworkTrainer):
         # Flow matching target: predict the velocity (noise - clean)
         # This is different from DDPM which predicts noise directly
         target = noise - latents
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -18,6 +18,7 @@ from accelerate import Accelerator
 
 from musubi_tuner import convert_lora
 from musubi_tuner.training.trainer_base import (
+    DiTOutput,
     NetworkTrainer,
     SS_METADATA_KEY_BASE_MODEL_VERSION,
     SS_METADATA_KEY_NETWORK_MODULE,
@@ -69,6 +70,7 @@ from accelerate.utils import set_seed
 
 __all__ = [
     # trainer_base
+    "DiTOutput",
     "NetworkTrainer",
     "HunyuanVideoNetworkTrainer",
     "SS_METADATA_KEY_BASE_MODEL_VERSION",
@@ -409,7 +411,8 @@ class HunyuanVideoNetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         transformer: HYVideoDiffusionTransformer = transformer_arg
         bsz = latents.shape[0]
 
@@ -455,7 +458,7 @@ class HunyuanVideoNetworkTrainer(NetworkTrainer):
         # flow matching loss
         target = noise - latents
 
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/kandinsky5_train_network.py
+++ b/src/musubi_tuner/kandinsky5_train_network.py
@@ -12,6 +12,7 @@ from musubi_tuner.utils.safetensors_utils import MemoryEfficientSafeOpen
 
 from musubi_tuner.dataset.image_video_dataset import ARCHITECTURE_KANDINSKY5, ARCHITECTURE_KANDINSKY5_FULL
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     clean_memory_on_device,
     setup_parser_common,
@@ -745,7 +746,8 @@ class Kandinsky5NetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         bsz = latents.shape[0]
         preds = []
         targets = []
@@ -900,7 +902,7 @@ class Kandinsky5NetworkTrainer(NetworkTrainer):
 
         model_pred = torch.stack(preds, dim=0)  # B, F, C, H, W
         target = torch.stack(targets, dim=0)  # B, F, C, H, W
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -616,10 +616,10 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                         args.weighting_scheme, noise_scheduler, timesteps, accelerator.device, dit_dtype
                     )
 
-                    model_pred, target = self.call_dit(
+                    output = self.call_dit(
                         args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, dit_dtype
                     )
-                    loss = torch.nn.functional.mse_loss(model_pred.to(dit_dtype), target, reduction="none")
+                    loss = torch.nn.functional.mse_loss(output.pred.to(dit_dtype), output.target, reduction="none")
 
                     if weighting is not None:
                         loss = loss * weighting

--- a/src/musubi_tuner/qwen_image_train_network.py
+++ b/src/musubi_tuner/qwen_image_train_network.py
@@ -18,6 +18,7 @@ from musubi_tuner.dataset.image_video_dataset import (
 )
 from musubi_tuner.qwen_image import qwen_image_autoencoder_kl, qwen_image_model, qwen_image_utils
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     load_prompts,
     clean_memory_on_device,
@@ -435,7 +436,8 @@ class QwenImageNetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         model: qwen_image_model.QwenImageTransformer2DModel = transformer
         is_edit = self.is_edit
 
@@ -580,7 +582,7 @@ class QwenImageNetworkTrainer(NetworkTrainer):
         target = noise - latents
 
         # print(model_pred.dtype, target.dtype)
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1077,6 +1077,52 @@ class NetworkTrainer:
 
     # endregion model specific
 
+    # region extension seams
+    # Internal extension points — no API stability guarantees.
+    # Subclasses live in this repo; if you fork, expect breakage on updates.
+
+    def process_batch(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        transformer,
+        network,
+        batch: dict[str, torch.Tensor],
+        latents: torch.Tensor,
+        noise: torch.Tensor,
+        noise_scheduler,
+        dit_dtype: torch.dtype,
+        network_dtype: torch.dtype,
+        vae,
+        global_step: int,
+    ) -> torch.Tensor:
+        """Compute scalar loss for one training batch (pre-backward).
+
+        Default implementation: vanilla flow matching.
+        Override to implement custom training logic (Self-Flow etc.).
+
+        ``latents`` is already scale-shifted; ``noise`` is already sampled.
+        """
+        noisy_model_input, timesteps = self.get_noisy_model_input_and_timesteps(
+            args, noise, latents, batch["timesteps"], noise_scheduler, accelerator.device, dit_dtype
+        )
+
+        weighting = compute_loss_weighting_for_sd3(
+            args.weighting_scheme, noise_scheduler, timesteps, accelerator.device, dit_dtype
+        )
+
+        model_pred, target = self.call_dit(
+            args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype
+        )
+        loss = torch.nn.functional.mse_loss(model_pred.to(network_dtype), target, reduction="none")
+
+        if weighting is not None:
+            loss = loss * weighting
+
+        return loss.mean()
+
+    # endregion extension seams
+
     def train(self, args):
         if not self._validate_args_and_init(args):
             return
@@ -1780,27 +1826,20 @@ class NetworkTrainer:
                     # Sample noise that we'll add to the latents
                     noise = torch.randn_like(latents)
 
-                    # calculate model input and timesteps
-                    noisy_model_input, timesteps = self.get_noisy_model_input_and_timesteps(
-                        args, noise, latents, batch["timesteps"], noise_scheduler, accelerator.device, dit_dtype
+                    loss = self.process_batch(
+                        args,
+                        accelerator,
+                        transformer,
+                        network,
+                        batch,
+                        latents,
+                        noise,
+                        noise_scheduler,
+                        dit_dtype,
+                        network_dtype,
+                        vae,
+                        global_step,
                     )
-
-                    weighting = compute_loss_weighting_for_sd3(
-                        args.weighting_scheme, noise_scheduler, timesteps, accelerator.device, dit_dtype
-                    )
-
-                    model_pred, target = self.call_dit(
-                        args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype
-                    )
-                    loss = torch.nn.functional.mse_loss(model_pred.to(network_dtype), target, reduction="none")
-
-                    if weighting is not None:
-                        loss = loss * weighting
-                    # loss = loss.mean([1, 2, 3])
-                    # # min snr gamma, scale v pred loss like noise pred, v pred like loss, debiased estimation etc.
-                    # loss = self.post_process_loss(loss, args, timesteps, noise_scheduler)
-
-                    loss = loss.mean()  # mean loss over all elements in batch
 
                     accelerator.backward(loss)
                     if accelerator.sync_gradients:

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -800,7 +800,7 @@ class NetworkTrainer:
                 line += "#" * int(w / max_weighting * CONSOLE_WIDTH)
                 print(line)
 
-    def sample_images(self, accelerator: Accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
+    def sample_images(self, accelerator: Accelerator, args, epoch, steps, vae, transformer, sample_parameters, dit_dtype):
         """architecture independent sample images"""
         if not should_sample_images(args, steps, epoch):
             return
@@ -810,8 +810,6 @@ class NetworkTrainer:
         if sample_parameters is None:
             logger.error(f"No prompt file / プロンプトファイルがありません: {args.sample_prompts}")
             return
-
-        self.on_before_sample_images(accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype)
 
         distributed_state = PartialState()  # for multi gpu distributed inference. this is a singleton, so it's safe to use it here
 
@@ -860,8 +858,6 @@ class NetworkTrainer:
 
         transformer.switch_block_swap_for_training()
         clean_memory_on_device(accelerator.device)
-
-        self.on_after_sample_images(accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype)
 
     def sample_image_inference(self, accelerator, args, transformer, dit_dtype, vae, save_dir, sample_parameter, epoch, steps):
         """architecture independent sample images"""
@@ -1210,7 +1206,6 @@ class NetworkTrainer:
         based on the generated samples.
         """
         pass
-
 
     def extra_trainable_params(
         self,
@@ -1914,9 +1909,19 @@ class NetworkTrainer:
                 os.remove(old_ckpt_file)
 
         def _do_sample(epoch_arg, steps_arg):
-            self.sample_images(
+            if not should_sample_images(args, steps_arg, epoch_arg):
+                return
+            self.on_before_sample_images(
                 accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
             )
+            try:
+                self.sample_images(
+                    accelerator, args, epoch_arg, steps_arg, vae, transformer, sample_parameters, dit_dtype
+                )
+            finally:
+                self.on_after_sample_images(
+                    accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
+                )
 
         # For --sample_at_first
         if should_sample_images(args, global_step, epoch=0):

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -800,7 +800,7 @@ class NetworkTrainer:
                 line += "#" * int(w / max_weighting * CONSOLE_WIDTH)
                 print(line)
 
-    def sample_images(self, accelerator: Accelerator, args, epoch, steps, vae, transformer, sample_parameters, dit_dtype):
+    def sample_images(self, accelerator: Accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
         """architecture independent sample images"""
         if not should_sample_images(args, steps, epoch):
             return
@@ -810,6 +810,8 @@ class NetworkTrainer:
         if sample_parameters is None:
             logger.error(f"No prompt file / プロンプトファイルがありません: {args.sample_prompts}")
             return
+
+        self.on_before_sample_images(accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype)
 
         distributed_state = PartialState()  # for multi gpu distributed inference. this is a singleton, so it's safe to use it here
 
@@ -858,6 +860,8 @@ class NetworkTrainer:
 
         transformer.switch_block_swap_for_training()
         clean_memory_on_device(accelerator.device)
+
+        self.on_after_sample_images(accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype)
 
     def sample_image_inference(self, accelerator, args, transformer, dit_dtype, vae, save_dir, sample_parameter, epoch, steps):
         """architecture independent sample images"""
@@ -1175,21 +1179,6 @@ class NetworkTrainer:
         Use for EMA updates or any post-step bookkeeping.
         """
 
-    def on_sample_images(
-        self,
-        args: argparse.Namespace,
-        accelerator: Accelerator,
-        network,
-        sample_fn,
-    ) -> None:
-        """Around-hook wrapping ``self.sample_images(...)`` calls.
-
-        Default implementation simply invokes ``sample_fn()``. Override to e.g.
-        temporarily swap student weights for EMA (teacher) weights before sampling
-        and restore them afterwards.
-        """
-        sample_fn()
-
     def on_post_save(
         self,
         args: argparse.Namespace,
@@ -1204,6 +1193,19 @@ class NetworkTrainer:
         ``ckpt_name`` is the basename written to ``args.output_dir``. Use this hook
         to write companion files (EMA weights, projection heads, etc.) alongside.
         """
+
+    def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
+        """
+
+        """
+        pass
+
+    def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
+        """
+
+        """
+        pass
+
 
     def extra_trainable_params(
         self,
@@ -1907,13 +1909,8 @@ class NetworkTrainer:
                 os.remove(old_ckpt_file)
 
         def _do_sample(epoch_arg, steps_arg):
-            self.on_sample_images(
-                args,
-                accelerator,
-                network,
-                lambda: self.sample_images(
-                    accelerator, args, epoch_arg, steps_arg, vae, transformer, sample_parameters, dit_dtype
-                ),
+            self.sample_images(
+                accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
             )
 
         # For --sample_at_first

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1119,11 +1119,17 @@ class NetworkTrainer:
         network_dtype: torch.dtype,
         vae,
         global_step: int,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, dict[str, float]]:
         """Compute scalar loss for one training batch (pre-backward).
 
-        Default implementation: vanilla flow matching.
-        Override to implement custom training logic (Self-Flow etc.).
+        Default implementation: vanilla flow matching, delegating the loss
+        formulation itself to ``compute_loss``. Override either method:
+        ``process_batch`` to change what gets fed to the model (Self-Flow's
+        dual-timestep dance, etc.), or ``compute_loss`` to swap the loss
+        formulation while keeping the standard data flow.
+
+        Returns ``(scalar_loss, loss_metrics)`` — ``loss_metrics`` is merged
+        into the per-step log dict alongside ``extra_step_logs``.
 
         ``latents`` is already scale-shifted; ``noise`` is already sampled.
         """
@@ -1131,19 +1137,40 @@ class NetworkTrainer:
             args, noise, latents, batch["timesteps"], noise_scheduler, accelerator.device, dit_dtype
         )
 
-        weighting = compute_loss_weighting_for_sd3(
-            args.weighting_scheme, noise_scheduler, timesteps, accelerator.device, dit_dtype
-        )
-
         output = self.call_dit(
             args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype
         )
-        loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
 
+        return self.compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype)
+
+    def compute_loss(
+        self,
+        args: argparse.Namespace,
+        output: DiTOutput,
+        timesteps: torch.Tensor,
+        noise_scheduler,
+        dit_dtype: torch.dtype,
+        network_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        """Reduce a ``DiTOutput`` to a scalar loss + per-step metrics dict.
+
+        Default implementation: weighted MSE between ``output.pred`` and
+        ``output.target`` with the SD3-style ``args.weighting_scheme`` applied,
+        then ``.mean()``. Override to swap the loss formulation entirely
+        (e.g. Self-Flow's L_gen + gamma * L_rep). Subclasses are responsible
+        for whatever weighting/reduction they need — this hook owns the
+        full loss computation, not just the per-element MSE.
+
+        ``loss_metrics`` defaults to empty; populate with named scalars for
+        loss-decomposition logging (e.g. ``{"loss/gen": ..., "loss/rep": ...}``).
+        """
+        weighting = compute_loss_weighting_for_sd3(
+            args.weighting_scheme, noise_scheduler, timesteps, timesteps.device, dit_dtype
+        )
+        loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
         if weighting is not None:
             loss = loss * weighting
-
-        return loss.mean()
+        return loss.mean(), {}
 
     def on_transformer_loaded(
         self,
@@ -1983,7 +2010,7 @@ class NetworkTrainer:
                     # Sample noise that we'll add to the latents
                     noise = torch.randn_like(latents)
 
-                    loss = self.process_batch(
+                    loss, loss_metrics = self.process_batch(
                         args,
                         accelerator,
                         transformer,
@@ -2071,6 +2098,7 @@ class NetworkTrainer:
                     logs = self.generate_step_logs(
                         args, current_loss, avr_loss, lr_scheduler, lr_descriptions, optimizer, keys_scaled, mean_norm, maximum_norm
                     )
+                    logs.update(loss_metrics)
                     logs.update(self.extra_step_logs(args, logs))
                     accelerator.log(logs, step=global_step)
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1121,6 +1121,65 @@ class NetworkTrainer:
 
         return loss.mean()
 
+    def on_train_start(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        transformer,
+        optimizer,
+    ) -> None:
+        """Called once after accelerator.prepare and before the training loop starts.
+
+        Use this for initializing extension state that depends on prepared models
+        (EMA copies, decay schedulers, register_forward_hook on the transformer, etc.).
+        """
+
+    def on_post_optimizer_step(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        sync_gradients: bool,
+        global_step: int,
+    ) -> None:
+        """Called after optimizer.step / lr_scheduler.step / zero_grad each inner step.
+
+        ``sync_gradients`` mirrors ``accelerator.sync_gradients`` and is True only
+        on steps where an actual optimizer update occurred (gradient accumulation aware).
+        Use for EMA updates or any post-step bookkeeping.
+        """
+
+    def on_sample_images(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        sample_fn,
+    ) -> None:
+        """Around-hook wrapping ``self.sample_images(...)`` calls.
+
+        Default implementation simply invokes ``sample_fn()``. Override to e.g.
+        temporarily swap student weights for EMA (teacher) weights before sampling
+        and restore them afterwards.
+        """
+        sample_fn()
+
+    def on_post_save(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        ckpt_name: str,
+        save_dtype,
+        metadata: dict,
+    ) -> None:
+        """Called after the main network checkpoint has been saved.
+
+        ``ckpt_name`` is the basename written to ``args.output_dir``. Use this hook
+        to write companion files (EMA weights, projection heads, etc.) alongside.
+        """
+
     # endregion extension seams
 
     def train(self, args):
@@ -1602,6 +1661,8 @@ class NetworkTrainer:
     ):
         is_main_process = accelerator.is_main_process
 
+        self.on_train_start(args, accelerator, network, transformer, optimizer)
+
         # epoch数を計算する
         num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
         num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
@@ -1777,16 +1838,28 @@ class NetworkTrainer:
             if args.huggingface_repo_id is not None:
                 huggingface_utils.upload(args, ckpt_file, "/" + ckpt_name, force_sync_upload=force_sync_upload)
 
+            self.on_post_save(args, accelerator, network, ckpt_name, save_dtype, metadata_to_save)
+
         def remove_model(old_ckpt_name):
             old_ckpt_file = os.path.join(args.output_dir, old_ckpt_name)
             if os.path.exists(old_ckpt_file):
                 accelerator.print(f"removing old checkpoint: {old_ckpt_file}")
                 os.remove(old_ckpt_file)
 
+        def _do_sample(epoch_arg, steps_arg):
+            self.on_sample_images(
+                args,
+                accelerator,
+                network,
+                lambda: self.sample_images(
+                    accelerator, args, epoch_arg, steps_arg, vae, transformer, sample_parameters, dit_dtype
+                ),
+            )
+
         # For --sample_at_first
         if should_sample_images(args, global_step, epoch=0):
             optimizer_eval_fn()
-            self.sample_images(accelerator, args, 0, global_step, vae, transformer, sample_parameters, dit_dtype)
+            _do_sample(0, global_step)
             optimizer_train_fn()
         if len(accelerator.trackers) > 0:
             # log empty object to commit the sample images to wandb
@@ -1858,6 +1931,10 @@ class NetworkTrainer:
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 
+                    self.on_post_optimizer_step(
+                        args, accelerator, network, accelerator.sync_gradients, global_step
+                    )
+
                 if args.scale_weight_norms:
                     keys_scaled, mean_norm, maximum_norm = accelerator.unwrap_model(network).apply_max_norm_regularization(
                         args.scale_weight_norms, accelerator.device
@@ -1880,7 +1957,7 @@ class NetworkTrainer:
                     if should_sampling or should_saving:
                         optimizer_eval_fn()
                         if should_sampling:
-                            self.sample_images(accelerator, args, None, global_step, vae, transformer, sample_parameters, dit_dtype)
+                            _do_sample(None, global_step)
 
                         if should_saving:
                             accelerator.wait_for_everyone()
@@ -1937,7 +2014,7 @@ class NetworkTrainer:
                     if args.save_state:
                         train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
-            self.sample_images(accelerator, args, epoch + 1, global_step, vae, transformer, sample_parameters, dit_dtype)
+            _do_sample(epoch + 1, global_step)
             optimizer_train_fn()
 
             # end of epoch

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1195,14 +1195,19 @@ class NetworkTrainer:
         """
 
     def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
-        """
+        """Called just before sample image generation begins, while the transformer is still in training mode.
 
+        The transformer is still wrapped by the accelerator at this point. Use this hook for
+        pre-inference setup such as switching auxiliary modules to eval mode or stashing training state.
         """
         pass
 
     def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
-        """
+        """Called after sample image generation completes and the transformer has been switched back to training mode.
 
+        Memory has already been cleaned via ``clean_memory_on_device``. Use this hook for
+        post-inference cleanup such as restoring auxiliary modules to train mode or updating state
+        based on the generated samples.
         """
         pass
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1194,7 +1194,7 @@ class NetworkTrainer:
         to write companion files (EMA weights, projection heads, etc.) alongside.
         """
 
-    def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
+    def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
         """Called just before sample image generation begins, while the transformer is still in training mode.
 
         The transformer is still wrapped by the accelerator at this point. Use this hook for
@@ -1202,7 +1202,7 @@ class NetworkTrainer:
         """
         pass
 
-    def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
+    def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
         """Called after sample image generation completes and the transformer has been switched back to training mode.
 
         Memory has already been cleaned via ``clean_memory_on_device``. Use this hook for

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -86,15 +86,14 @@ SS_METADATA_MINIMUM_KEYS = [
 class DiTOutput:
     """Return type for ``NetworkTrainer.call_dit``.
 
-    Internal extension point — no API stability guarantees. Fields beyond
-    ``pred`` and ``target`` are optional and used only by extension subclasses
-    (e.g. ``features`` for representation-alignment losses). Use ``extra`` as
-    a typed escape hatch for future fields without breaking signatures.
+    Internal extension point — no API stability guarantees. Vanilla flow only
+    needs ``pred`` and ``target``; extension subclasses can stash arbitrary
+    additional outputs (e.g. hidden features for representation-alignment
+    losses) in the ``extra`` dict without breaking the base signature.
     """
 
     pred: torch.Tensor
     target: torch.Tensor
-    features: Optional[torch.Tensor] = None
     extra: dict = field(default_factory=dict)
 
 
@@ -1183,11 +1182,14 @@ class NetworkTrainer:
         ckpt_name: str,
         save_dtype,
         metadata: dict,
+        force_sync_upload: bool,
     ) -> None:
         """Called after the main network checkpoint has been saved.
 
         ``ckpt_name`` is the basename written to ``args.output_dir``. Use this hook
         to write companion files (EMA weights, projection heads, etc.) alongside.
+        ``force_sync_upload`` mirrors the flag passed to the main HuggingFace upload
+        so subclasses uploading companion files can match the same behaviour.
         """
 
     def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
@@ -1900,7 +1902,7 @@ class NetworkTrainer:
             if args.huggingface_repo_id is not None:
                 huggingface_utils.upload(args, ckpt_file, "/" + ckpt_name, force_sync_upload=force_sync_upload)
 
-            self.on_post_save(args, accelerator, network, ckpt_name, save_dtype, metadata_to_save)
+            self.on_post_save(args, accelerator, network, ckpt_name, save_dtype, metadata_to_save, force_sync_upload)
 
         def remove_model(old_ckpt_name):
             old_ckpt_file = os.path.join(args.output_dir, old_ckpt_name)

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1137,9 +1137,7 @@ class NetworkTrainer:
             args, noise, latents, batch["timesteps"], noise_scheduler, accelerator.device, dit_dtype
         )
 
-        output = self.call_dit(
-            args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype
-        )
+        output = self.call_dit(args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype)
 
         return self.compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype)
 
@@ -1164,9 +1162,7 @@ class NetworkTrainer:
         ``loss_metrics`` defaults to empty; populate with named scalars for
         loss-decomposition logging (e.g. ``{"loss/gen": ..., "loss/rep": ...}``).
         """
-        weighting = compute_loss_weighting_for_sd3(
-            args.weighting_scheme, noise_scheduler, timesteps, timesteps.device, dit_dtype
-        )
+        weighting = compute_loss_weighting_for_sd3(args.weighting_scheme, noise_scheduler, timesteps, timesteps.device, dit_dtype)
         loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
         if weighting is not None:
             loss = loss * weighting
@@ -1233,7 +1229,9 @@ class NetworkTrainer:
         so subclasses uploading companion files can match the same behaviour.
         """
 
-    def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
+    def on_before_sample_images(
+        self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype
+    ) -> None:
         """Called just before sample image generation begins, while the transformer is still in training mode.
 
         The transformer is still wrapped by the accelerator at this point. Use this hook for
@@ -1241,7 +1239,9 @@ class NetworkTrainer:
         """
         pass
 
-    def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype) -> None:
+    def on_after_sample_images(
+        self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype
+    ) -> None:
         """Called after sample image generation completes and the transformer has been switched back to training mode.
 
         Memory has already been cleaned via ``clean_memory_on_device``. Use this hook for
@@ -1959,9 +1959,7 @@ class NetworkTrainer:
                 accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
             )
             try:
-                self.sample_images(
-                    accelerator, args, epoch_arg, steps_arg, vae, transformer, sample_parameters, dit_dtype
-                )
+                self.sample_images(accelerator, args, epoch_arg, steps_arg, vae, transformer, sample_parameters, dit_dtype)
             finally:
                 self.on_after_sample_images(
                     accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
@@ -2042,9 +2040,7 @@ class NetworkTrainer:
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 
-                    self.on_post_optimizer_step(
-                        args, accelerator, network, accelerator.sync_gradients, global_step
-                    )
+                    self.on_post_optimizer_step(args, accelerator, network, accelerator.sync_gradients, global_step)
 
                 if args.scale_weight_norms:
                     keys_scaled, mean_norm, maximum_norm = accelerator.unwrap_model(network).apply_max_norm_regularization(

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1145,6 +1145,20 @@ class NetworkTrainer:
 
         return loss.mean()
 
+    def on_transformer_loaded(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        transformer,
+    ) -> None:
+        """Called immediately after ``self.load_transformer(...)`` returns.
+
+        At this point the transformer is on its loading device but not yet wrapped
+        by the accelerator and not yet in eval mode. Use this hook for one-time
+        post-load setup that needs the raw module (e.g. ``register_forward_hook``
+        for feature extraction).
+        """
+
     def on_train_start(
         self,
         args: argparse.Namespace,
@@ -1450,6 +1464,7 @@ class NetworkTrainer:
         transformer = self.load_transformer(
             accelerator, args, args.dit, attn_mode, args.split_attn, loading_device, dit_weight_dtype
         )
+        self.on_transformer_loaded(args, accelerator, transformer)
         transformer.eval()
         transformer.requires_grad_(False)
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1201,6 +1201,7 @@ class NetworkTrainer:
         args: argparse.Namespace,
         accelerator: Accelerator,
         network,
+        transformer,
         sync_gradients: bool,
         global_step: int,
     ) -> None:
@@ -1208,6 +1209,9 @@ class NetworkTrainer:
 
         ``sync_gradients`` mirrors ``accelerator.sync_gradients`` and is True only
         on steps where an actual optimizer update occurred (gradient accumulation aware).
+        ``transformer`` is the accelerator-wrapped DiT — passed so subclasses doing
+        non-network (full fine-tuning) bookkeeping or EMA on transformer weights can
+        reach it without stashing a reference in ``on_train_start``.
         Use for EMA updates or any post-step bookkeeping.
         """
 
@@ -1216,6 +1220,7 @@ class NetworkTrainer:
         args: argparse.Namespace,
         accelerator: Accelerator,
         network,
+        transformer,
         ckpt_name: str,
         save_dtype,
         metadata: dict,
@@ -1225,6 +1230,8 @@ class NetworkTrainer:
 
         ``ckpt_name`` is the basename written to ``args.output_dir``. Use this hook
         to write companion files (EMA weights, projection heads, etc.) alongside.
+        ``transformer`` is the accelerator-wrapped DiT — provided so non-network
+        (full fine-tuning) subclasses can save companion artifacts derived from it.
         ``force_sync_upload`` mirrors the flag passed to the main HuggingFace upload
         so subclasses uploading companion files can match the same behaviour.
         """
@@ -1944,7 +1951,7 @@ class NetworkTrainer:
             if args.huggingface_repo_id is not None:
                 huggingface_utils.upload(args, ckpt_file, "/" + ckpt_name, force_sync_upload=force_sync_upload)
 
-            self.on_post_save(args, accelerator, network, ckpt_name, save_dtype, metadata_to_save, force_sync_upload)
+            self.on_post_save(args, accelerator, network, transformer, ckpt_name, save_dtype, metadata_to_save, force_sync_upload)
 
         def remove_model(old_ckpt_name):
             old_ckpt_file = os.path.join(args.output_dir, old_ckpt_name)
@@ -2040,7 +2047,7 @@ class NetworkTrainer:
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 
-                    self.on_post_optimizer_step(args, accelerator, network, accelerator.sync_gradients, global_step)
+                    self.on_post_optimizer_step(args, accelerator, network, transformer, accelerator.sync_gradients, global_step)
 
                 if args.scale_weight_norms:
                     keys_scaled, mean_norm, maximum_norm = accelerator.unwrap_model(network).apply_max_norm_regularization(

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1180,6 +1180,39 @@ class NetworkTrainer:
         to write companion files (EMA weights, projection heads, etc.) alongside.
         """
 
+    def extra_trainable_params(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        transformer,
+        trainable_params: list,
+    ) -> list:
+        """Optionally augment the param-group list passed to the optimizer.
+
+        Default: pass-through. Override to merge extra modules' parameters
+        (e.g. a representation projection head) into ``trainable_params``.
+        Subclasses are expected to stash any owned modules on ``self`` so
+        ``on_train_start`` and later hooks can use them.
+        """
+        return trainable_params
+
+    def extra_metadata(self, args: argparse.Namespace) -> dict:
+        """Returns extra ``ss_*`` metadata keys to embed in saved safetensors.
+
+        Default: empty dict. Override to add extension-specific metadata.
+        """
+        return {}
+
+    def extra_step_logs(self, args: argparse.Namespace, logs: dict) -> dict:
+        """Returns additional log entries to merge into the per-step log payload.
+
+        Called just before ``accelerator.log`` on logging steps. The returned
+        dict is merged into ``logs`` (existing keys are overwritten on collision).
+        Default: empty dict.
+        """
+        return {}
+
     # endregion extension seams
 
     def train(self, args):
@@ -1203,7 +1236,7 @@ class NetworkTrainer:
             lr_scheduler,
             lr_descriptions,
             train_dataloader,
-        ) = self._build_optimizer_and_dataloader(args, accelerator, network, train_dataset_group, collator)
+        ) = self._build_optimizer_and_dataloader(args, accelerator, network, train_dataset_group, collator, transformer)
         (
             transformer,
             network,
@@ -1484,11 +1517,12 @@ class NetworkTrainer:
         # net_kwargs is reconstructed in the metadata phase from args.network_args
         return network
 
-    def _build_optimizer_and_dataloader(self, args, accelerator, network, train_dataset_group, collator):
+    def _build_optimizer_and_dataloader(self, args, accelerator, network, train_dataset_group, collator, transformer):
         # prepare optimizer, data loader etc.
         accelerator.print("prepare optimizer, data loader etc.")
 
         trainable_params, lr_descriptions = network.prepare_optimizer_params(unet_lr=args.learning_rate)
+        trainable_params = self.extra_trainable_params(args, accelerator, network, transformer, trainable_params)
         optimizer_name, optimizer_args, optimizer, optimizer_train_fn, optimizer_eval_fn = self.get_optimizer(
             args, trainable_params
         )
@@ -1730,6 +1764,7 @@ class NetworkTrainer:
             "ss_sigmoid_scale": args.sigmoid_scale,
             "ss_discrete_flow_shift": args.discrete_flow_shift,
         }
+        metadata.update(self.extra_metadata(args))
 
         datasets_metadata = []
         # tag_frequency = {}  # merge tag frequency for metadata editor # TODO support tag frequency
@@ -1987,6 +2022,7 @@ class NetworkTrainer:
                     logs = self.generate_step_logs(
                         args, current_loss, avr_loss, lr_scheduler, lr_descriptions, optimizer, keys_scaled, mean_norm, maximum_norm
                     )
+                    logs.update(self.extra_step_logs(args, logs))
                     accelerator.log(logs, step=global_step)
 
                 if global_step >= args.max_train_steps:

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -17,6 +17,7 @@ import sys
 import random
 import time
 import json
+from dataclasses import dataclass, field
 from multiprocessing import Value
 from typing import Any, List, Optional
 import accelerate
@@ -79,6 +80,22 @@ SS_METADATA_MINIMUM_KEYS = [
     SS_METADATA_KEY_NETWORK_ALPHA,
     SS_METADATA_KEY_NETWORK_ARGS,
 ]
+
+
+@dataclass
+class DiTOutput:
+    """Return type for ``NetworkTrainer.call_dit``.
+
+    Internal extension point — no API stability guarantees. Fields beyond
+    ``pred`` and ``target`` are optional and used only by extension subclasses
+    (e.g. ``features`` for representation-alignment losses). Use ``extra`` as
+    a typed escape hatch for future fields without breaking signatures.
+    """
+
+    pred: torch.Tensor
+    target: torch.Tensor
+    features: Optional[torch.Tensor] = None
+    extra: dict = field(default_factory=dict)
 
 
 class NetworkTrainer:
@@ -1072,7 +1089,15 @@ class NetworkTrainer:
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
+        """Run the DiT forward and return prediction/target as a ``DiTOutput``.
+
+        ``**kwargs`` is reserved for extension subclasses to pass additional
+        conditioning (e.g. ``per_token_timesteps``) or request side outputs
+        (e.g. ``hidden_features``). Architecture implementations may ignore
+        unknown kwargs.
+        """
         raise NotImplementedError("subclass must implement `call_dit`")
 
     # endregion model specific
@@ -1111,10 +1136,10 @@ class NetworkTrainer:
             args.weighting_scheme, noise_scheduler, timesteps, accelerator.device, dit_dtype
         )
 
-        model_pred, target = self.call_dit(
+        output = self.call_dit(
             args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype
         )
-        loss = torch.nn.functional.mse_loss(model_pred.to(network_dtype), target, reduction="none")
+        loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
 
         if weighting is not None:
             loss = loss * weighting

--- a/src/musubi_tuner/wan_train_network.py
+++ b/src/musubi_tuner/wan_train_network.py
@@ -11,6 +11,7 @@ from accelerate import Accelerator
 from musubi_tuner.dataset.image_video_dataset import ARCHITECTURE_WAN, ARCHITECTURE_WAN_FULL, load_video
 from musubi_tuner.hv_generate_video import resize_image_to_bucket
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     load_prompts,
     clean_memory_on_device,
@@ -631,13 +632,16 @@ class WanNetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         if self.high_low_training:
             # high-low training case
             self.swap_high_low_weights(args, accelerator, transformer)
 
         # Call the DiT model
-        return self._call_dit(args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype)
+        return self._call_dit(
+            args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs
+        )
 
     def _call_dit(
         self,
@@ -650,7 +654,8 @@ class WanNetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         model: WanModel = transformer
 
         # I2V training and Control training
@@ -705,7 +710,7 @@ class WanNetworkTrainer(NetworkTrainer):
         # flow matching loss
         target = noise - latents
 
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
     # endregion model specific
 

--- a/src/musubi_tuner/zimage_train.py
+++ b/src/musubi_tuner/zimage_train.py
@@ -527,10 +527,10 @@ class ZImageTrainer(ZImageNetworkTrainer):
                         args.weighting_scheme, noise_scheduler, timesteps, accelerator.device, dit_dtype
                     )
 
-                    model_pred, target = self.call_dit(
+                    output = self.call_dit(
                         args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, dit_dtype
                     )
-                    loss = torch.nn.functional.mse_loss(model_pred.to(dit_dtype), target.to(dit_dtype), reduction="none")
+                    loss = torch.nn.functional.mse_loss(output.pred.to(dit_dtype), output.target.to(dit_dtype), reduction="none")
 
                     if weighting is not None:
                         loss = loss * weighting

--- a/src/musubi_tuner/zimage_train_network.py
+++ b/src/musubi_tuner/zimage_train_network.py
@@ -9,6 +9,7 @@ from accelerate import Accelerator
 from musubi_tuner.dataset.image_video_dataset import ARCHITECTURE_Z_IMAGE, ARCHITECTURE_Z_IMAGE_FULL
 from musubi_tuner.zimage import zimage_model, zimage_utils, zimage_autoencoder, zimage_config
 from musubi_tuner.hv_train_network import (
+    DiTOutput,
     NetworkTrainer,
     load_prompts,
     clean_memory_on_device,
@@ -272,7 +273,8 @@ class ZImageNetworkTrainer(NetworkTrainer):
         noisy_model_input: torch.Tensor,
         timesteps: torch.Tensor,
         network_dtype: torch.dtype,
-    ):
+        **kwargs,
+    ) -> DiTOutput:
         model: zimage_model.ZImageTransformer2DModel = accelerator.unwrap_model(transformer)
         bsize = latents.shape[0]
 
@@ -328,7 +330,7 @@ class ZImageNetworkTrainer(NetworkTrainer):
         # Target: Opposite of usual Flow matching
         target = latents - noise
 
-        return model_pred, target
+        return DiTOutput(pred=model_pred, target=target)
 
 
 def zimage_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:


### PR DESCRIPTION
## Background

Follow-up to the Self-Flow discussion in #913. As agreed there, instead of merging #913 as-is, the dev branch grows a small set of in-tree extension seams; Self-Flow then targets those seams as a subclass after dev → main.

This PR lands those seams on `dev`. **Not merging yet** — sharing first with @rockerBOO so he can flag any gaps in the seam shape before the design calcifies.

## Scope and design choice

- Mechanism: plain subclass-override, not a generic Extension protocol. Reasoning: in-tree only, fork-or-PR for third parties; YAGNI on multi-extension dispatch until we actually have two simultaneous extensions.
- All seams are no-op default. Vanilla training behaviour is preserved bit-for-bit on every architecture.
- Each seam carries an "Internal extension point — no API stability guarantees" comment so we keep the freedom to refactor.

## What's in this PR

**Phase 1 — extension seams on `NetworkTrainer`** (3 commits, all behaviour-preserving):

- `process_batch()` — replaceable inner training step (default = current vanilla flow matching).
- Lifecycle hooks: `on_train_start`, `on_post_optimizer_step`, `on_sample_images` (around-hook), `on_post_save`.
- Contributor hooks: `extra_trainable_params`, `extra_metadata`, `extra_step_logs`.

Naming convention: `on_post_*` = post-event additive hook, `extra_*` = returns dict/list to merge, `on_*` (no prefix) = lifecycle / around. CLI args and arg validation use the existing per-script `main()` and `handle_model_specific_args` patterns rather than new seams.

**Phase 2 — `call_dit` → `DiTOutput` dataclass** (1 commit):

- New `DiTOutput(pred, target, features=None, extra={})` dataclass.
- All 9 architecture `call_dit` overrides updated, plus `**kwargs` accepted for forward-compatible kwargs (e.g. `per_token_timesteps`, `hidden_features`).
- Two finetune entry scripts (`qwen_image_train.py`, `zimage_train.py`) updated at their direct `call_dit` call sites.

**Phase 3 — Self-Flow skeleton** (1 commit):

- New `flux_2_train_network_self_flow.py`: a `Flux2NetworkTrainer` subclass demonstrating how every seam gets used by Self-Flow.
- Each override is shape-only — bodies are `# TODO` + `raise NotImplementedError` referencing the corresponding lines in #913.
- The file is **not runnable yet**; it exists so @rockerBOO can judge whether the seams cover Self-Flow's actual needs before we commit to them on `main`.

## Test plan

- [x] All 9 per-arch trainers and both finetune entry scripts import cleanly
- [x] `DiTOutput` dataclass shape sanity-checked
- [x] Self-Flow skeleton parser composition + subclass MRO verified
- [x] Smoke-tested vanilla training paths on FLUX.2, Z-Image, FramePack (Phase 1)
- [x] Smoke-tested vanilla training paths on a subset of architectures (Phase 2)
- [x] Phase 4 (review responses ①–⑤): all 9 per-arch trainers and Self-Flow skeleton import cleanly after refactor
- [x] Phase 4 smoke-tested vanilla training paths on FLUX.2 and Z-Image (compute_loss extraction, sample_images hook relocation, force_sync_upload, on_transformer_loaded)

## What I'd like from review

@rockerBOO — primary asks:

1. **Does the seam set cover everything you need for Self-Flow?** Especially look at `flux_2_train_network_self_flow.py` and check whether each override actually has the data / lifecycle access it needs.
2. **One known open question, called out in `call_dit`'s docstring**: per-token timesteps need support inside the FLUX.2 transformer itself. That's a per-arch follow-up rather than a base-class seam concern, but flag if you see it differently.
3. Anything in your existing #913 implementation that doesn't have an obvious home in these seams — that's the most useful signal.

Once feedback is in and any gaps are addressed, this lands on `dev`, then `dev` → `main`, then you can target `main` directly with the split PRs (grad metrics, plateau_logit_normal, etc.) and Self-Flow on top of these seams.