### PR TITLE
Add dual-GPU model-parallel path for FLUX.2 + Wan 2.2 + HunyuanVideo LoRA training

### DIFF
--- a/src/musubi_tuner/flux_2/flux2_dual_gpu.py
+++ b/src/musubi_tuner/flux_2/flux2_dual_gpu.py
@@ -1,0 +1,263 @@
+"""Dual-GPU model-parallel path for FLUX.2 LoRA training in musubi-tuner.
+
+Activates when ``FLUX2_DUAL_GPU=true``. Distributes the FLUX.2 transformer
+across two CUDA devices with a single PCIe boundary mid-``single_blocks``,
+and routes per-layer LoRA modules to the device of the transformer layer
+they wrap. Default behavior is unchanged when the env var is unset.
+
+Companion to the validated ai-toolkit patch
+(https://github.com/genno-whittlery/flux2-dual-gpu-lora). Musubi-tuner's
+architecture is structurally cleaner for porting:
+
+- Text encoders (Mistral 3 / Qwen-3) are pre-cached to disk via the
+  separate ``flux_2_cache_text_encoder_outputs.py`` script, so the inner
+  training loop never touches them. No TE-on-CPU runtime patch needed.
+- ``LoRAModule.apply_to`` is a 3-line monkey-patch over ``forward``; a
+  one-line snapshot of the wrapped layer's device plus a lazy forward
+  shim is sufficient for per-LoRA device routing.
+- ``Flux2.move_to_device_except_swap_blocks`` is the single canonical
+  place to intercept transformer-wide device placement.
+
+Env vars:
+    FLUX2_DUAL_GPU=true                    enable the dual-GPU path
+    FLUX2_DUAL_GPU_SPLIT_AT=24             override single_blocks split
+                                           index (default: n_single // 2)
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Callable, Optional
+
+import torch
+import torch.nn as nn
+
+if TYPE_CHECKING:
+    from musubi_tuner.flux_2.flux2_models import Flux2
+    from musubi_tuner.networks.lora import LoRANetwork, LoRAModule
+
+
+def is_dual_gpu_enabled() -> bool:
+    """True iff ``FLUX2_DUAL_GPU=true`` in the environment."""
+    return os.getenv("FLUX2_DUAL_GPU", "false").lower() == "true"
+
+
+def get_split_at(num_single_blocks: int) -> int:
+    """Single-blocks split index. Override via ``FLUX2_DUAL_GPU_SPLIT_AT``."""
+    override = os.getenv("FLUX2_DUAL_GPU_SPLIT_AT")
+    if override is not None:
+        return int(override)
+    return num_single_blocks // 2
+
+
+def assert_no_block_swap_in_dual_gpu(blocks_to_swap: Optional[int]) -> None:
+    """Block-swap and dual-GPU are mutually exclusive.
+
+    Block-swap pages whole blocks RAM↔single-GPU; dual-GPU splits blocks
+    across two GPUs statically. The two strategies make different
+    assumptions about block residence and don't compose.
+    """
+    if not is_dual_gpu_enabled():
+        return
+    if blocks_to_swap and blocks_to_swap > 0:
+        raise RuntimeError(
+            "FLUX2_DUAL_GPU=true is incompatible with --blocks_to_swap. "
+            "The dual-GPU split already distributes blocks across two GPUs; "
+            "block-swap pages blocks to system RAM, which fights the split. "
+            "Disable --blocks_to_swap or unset FLUX2_DUAL_GPU."
+        )
+
+
+def distribute_flux2_transformer(model: "Flux2", dtype: torch.dtype) -> None:
+    """Distribute the FLUX.2 transformer across cuda:0 and cuda:1.
+
+    Layout:
+        cuda:0  — img_in, txt_in, time_in, pe_embedder, guidance_in,
+                  *_modulation*, all double_blocks, single_blocks[0:split_at]
+        cuda:1  — single_blocks[split_at:], final_layer
+
+    The forward path is updated by :func:`install_split_forward` to insert
+    one ``.to(cuda:1)`` boundary at the split point and ``.to(cuda:0)``
+    on the way back to ``final_layer`` (we keep final_layer on cuda:0 so
+    the returned tensor matches ``vec.device`` for the caller).
+    """
+    if torch.cuda.device_count() < 2:
+        raise RuntimeError(
+            f"FLUX2_DUAL_GPU=true requires ≥2 CUDA devices, found "
+            f"{torch.cuda.device_count()}."
+        )
+
+    split_at = get_split_at(model.num_single_blocks)
+    if not 0 < split_at < model.num_single_blocks:
+        raise RuntimeError(
+            f"FLUX2_DUAL_GPU_SPLIT_AT={split_at} out of range "
+            f"(model has {model.num_single_blocks} single blocks)."
+        )
+
+    cuda0 = torch.device("cuda:0")
+    cuda1 = torch.device("cuda:1")
+
+    # Pre-blocks scaffolding + all double_blocks + first half single_blocks
+    # land on cuda:0. Final layer also lives on cuda:0 (see forward).
+    model.img_in.to(cuda0, dtype=dtype)
+    model.txt_in.to(cuda0, dtype=dtype)
+    model.time_in.to(cuda0, dtype=dtype)
+    model.pe_embedder.to(cuda0)
+    if model.use_guidance_embed and not isinstance(model.guidance_in, nn.Identity):
+        model.guidance_in.to(cuda0, dtype=dtype)
+    model.double_stream_modulation_img.to(cuda0, dtype=dtype)
+    model.double_stream_modulation_txt.to(cuda0, dtype=dtype)
+    model.single_stream_modulation.to(cuda0, dtype=dtype)
+    for block in model.double_blocks:
+        block.to(cuda0, dtype=dtype)
+    for block in model.single_blocks[:split_at]:
+        block.to(cuda0, dtype=dtype)
+    for block in model.single_blocks[split_at:]:
+        block.to(cuda1, dtype=dtype)
+    # final_layer stays on cuda:0 — the forward moves img back before
+    # calling it, and final_layer's output matches vec.device (cuda:0).
+    model.final_layer.to(cuda0, dtype=dtype)
+
+    # Stash the split index for the patched forward.
+    model._flux2_dual_gpu_split_at = split_at  # type: ignore[attr-defined]
+
+
+def install_split_forward(model: "Flux2") -> None:
+    """Replace ``Flux2.forward`` with a split-aware version.
+
+    Inserts one ``.to(cuda:1)`` boundary at ``single_blocks[split_at]``
+    and ``.to(cuda:0)`` after the loop so ``final_layer`` (and the
+    returned tensor) live on cuda:0 — matching ``vec.device`` for the
+    rest of the training step.
+
+    Cross-PCIe traffic per forward: one activation tensor
+    (~18 MB at 512², bf16) one way, plus the same on the way back
+    during backward. At PCIe Gen5 x16 (~50 GB/s practical), this is
+    ~1 ms — well below the per-step compute cost.
+    """
+    from einops import rearrange  # noqa: F401  (imported in flux2_models)
+    from musubi_tuner.flux_2.flux2_models import (  # local to avoid cycles
+        AttentionParams,
+        timestep_embedding,
+    )
+
+    split_at: int = model._flux2_dual_gpu_split_at  # type: ignore[attr-defined]
+    cuda1 = torch.device("cuda:1")
+    cuda0 = torch.device("cuda:0")
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_ids: torch.Tensor,
+        timesteps: torch.Tensor,
+        ctx: torch.Tensor,
+        ctx_ids: torch.Tensor,
+        guidance: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        num_txt_tokens = ctx.shape[1]
+
+        timestep_emb = timestep_embedding(timesteps, 256)
+        del timesteps
+        vec = self.time_in(timestep_emb)
+        del timestep_emb
+        if self.use_guidance_embed:
+            guidance_emb = timestep_embedding(guidance, 256)
+            vec = vec + self.guidance_in(guidance_emb)
+            del guidance_emb
+
+        double_block_mod_img = self.double_stream_modulation_img(vec)
+        double_block_mod_txt = self.double_stream_modulation_txt(vec)
+        single_block_mod, _ = self.single_stream_modulation(vec)
+
+        img = self.img_in(x)
+        del x
+        txt = self.txt_in(ctx)
+        del ctx
+        pe_x = self.pe_embedder(x_ids)
+        del x_ids
+        pe_ctx = self.pe_embedder(ctx_ids)
+        del ctx_ids
+
+        attn_params = AttentionParams.create_attention_params(
+            self.attn_mode, self.split_attn
+        )
+
+        for block in self.double_blocks:
+            img, txt = block(
+                img,
+                txt,
+                pe_x,
+                pe_ctx,
+                double_block_mod_img,
+                double_block_mod_txt,
+                attn_params,
+            )
+
+        del double_block_mod_img, double_block_mod_txt
+
+        img = torch.cat((txt, img), dim=1)
+        del txt
+        pe = torch.cat((pe_ctx, pe_x), dim=2)
+        del pe_ctx, pe_x
+
+        for block_idx, block in enumerate(self.single_blocks):
+            # Cross the PCIe boundary at the split point.
+            if block_idx == split_at:
+                img = img.to(cuda1)
+                pe = pe.to(cuda1)
+                single_block_mod = single_block_mod.to(cuda1)
+            img = block(img, pe, single_block_mod, attn_params)
+
+        del single_block_mod, pe
+
+        # Move the result back to cuda:0 for final_layer + caller.
+        img = img.to(cuda0)
+        img = img[:, num_txt_tokens:, ...]
+        img = self.final_layer(img, vec)
+        return img
+
+    # Bind as a method on the instance.
+    import types
+    model.forward = types.MethodType(forward, model)
+
+
+def route_loras_to_wrapped_devices(network: "LoRANetwork") -> None:
+    """Place each LoRA module on the device of the layer it wraps.
+
+    Requires that ``LoRAModule.apply_to`` has snapshotted
+    ``_wrapped_device`` (see the modification to ``networks/lora.py``).
+    A no-op when devices already match (``Tensor.to(same_device)`` is a
+    free identity).
+
+    Also installs a per-LoRA forward shim as a safety net: if anything
+    moves the LoRA off the wrapped layer's device after this point
+    (e.g., ``accelerator.prepare`` re-collecting params), the shim
+    silently re-places it on the wrapped device on the next forward.
+    """
+    loras = list(network.text_encoder_loras) + list(network.unet_loras)
+    for lora in loras:
+        wrapped_device = getattr(lora, "_wrapped_device", None)
+        if wrapped_device is None:
+            continue
+        lora.to(wrapped_device)
+        _install_lora_forward_pin(lora)
+
+
+def _install_lora_forward_pin(lora: "LoRAModule") -> None:
+    """Wrap ``lora.forward`` to re-pin params to ``_wrapped_device`` if drifted.
+
+    Called once per LoRA. The shim is a no-op on the hot path when
+    devices already match.
+    """
+    orig_forward = lora.forward
+    wrapped_device = lora._wrapped_device  # type: ignore[attr-defined]
+
+    def pinned_forward(x: torch.Tensor) -> torch.Tensor:
+        try:
+            current = next(lora.parameters()).device
+        except StopIteration:
+            current = wrapped_device
+        if current != wrapped_device:
+            lora.to(wrapped_device)
+        return orig_forward(x)
+
+    lora.forward = pinned_forward  # type: ignore[method-assign]

--- a/src/musubi_tuner/flux_2/flux2_dual_gpu.py
+++ b/src/musubi_tuner/flux_2/flux2_dual_gpu.py
@@ -169,89 +169,118 @@ def install_split_forward(model: "Flux2") -> None:
         ctx_ids: torch.Tensor,
         guidance: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        num_txt_tokens = ctx.shape[1]
+        # accelerator.prepare(model, ...) under mixed_precision=bf16 wraps
+        # model.forward in an autocast(bf16) context. We overwrite forward
+        # below via types.MethodType, which shadows that wrapper — so we
+        # have to re-enter autocast here ourselves. Autocast contexts nest
+        # cleanly, so this is a no-op when one is already active outside.
+        with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
+            num_txt_tokens = ctx.shape[1]
 
-        timestep_emb = timestep_embedding(timesteps, 256)
-        del timesteps
-        vec = self.time_in(timestep_emb)
-        del timestep_emb
-        if self.use_guidance_embed:
-            guidance_emb = timestep_embedding(guidance, 256)
-            vec = vec + self.guidance_in(guidance_emb)
-            del guidance_emb
+            timestep_emb = timestep_embedding(timesteps, 256)
+            del timesteps
+            vec = self.time_in(timestep_emb)
+            del timestep_emb
+            if self.use_guidance_embed:
+                guidance_emb = timestep_embedding(guidance, 256)
+                vec = vec + self.guidance_in(guidance_emb)
+                del guidance_emb
 
-        double_block_mod_img = self.double_stream_modulation_img(vec)
-        double_block_mod_txt = self.double_stream_modulation_txt(vec)
-        single_block_mod, _ = self.single_stream_modulation(vec)
+            double_block_mod_img = self.double_stream_modulation_img(vec)
+            double_block_mod_txt = self.double_stream_modulation_txt(vec)
+            single_block_mod, _ = self.single_stream_modulation(vec)
 
-        img = self.img_in(x)
-        del x
-        txt = self.txt_in(ctx)
-        del ctx
-        pe_x = self.pe_embedder(x_ids)
-        del x_ids
-        pe_ctx = self.pe_embedder(ctx_ids)
-        del ctx_ids
+            img = self.img_in(x)
+            del x
+            txt = self.txt_in(ctx)
+            del ctx
+            pe_x = self.pe_embedder(x_ids)
+            del x_ids
+            pe_ctx = self.pe_embedder(ctx_ids)
+            del ctx_ids
 
-        attn_params = AttentionParams.create_attention_params(
-            self.attn_mode, self.split_attn
-        )
-
-        for block in self.double_blocks:
-            img, txt = block(
-                img,
-                txt,
-                pe_x,
-                pe_ctx,
-                double_block_mod_img,
-                double_block_mod_txt,
-                attn_params,
+            attn_params = AttentionParams.create_attention_params(
+                self.attn_mode, self.split_attn
             )
 
-        del double_block_mod_img, double_block_mod_txt
+            for block in self.double_blocks:
+                img, txt = block(
+                    img,
+                    txt,
+                    pe_x,
+                    pe_ctx,
+                    double_block_mod_img,
+                    double_block_mod_txt,
+                    attn_params,
+                )
 
-        img = torch.cat((txt, img), dim=1)
-        del txt
-        pe = torch.cat((pe_ctx, pe_x), dim=2)
-        del pe_ctx, pe_x
+            del double_block_mod_img, double_block_mod_txt
 
-        for block_idx, block in enumerate(self.single_blocks):
-            # Cross the PCIe boundary at the split point.
-            if block_idx == split_at:
-                img = img.to(cuda1)
-                pe = pe.to(cuda1)
-                single_block_mod = single_block_mod.to(cuda1)
-            img = block(img, pe, single_block_mod, attn_params)
+            img = torch.cat((txt, img), dim=1)
+            del txt
+            pe = torch.cat((pe_ctx, pe_x), dim=2)
+            del pe_ctx, pe_x
 
-        del single_block_mod, pe
+            for block_idx, block in enumerate(self.single_blocks):
+                # Cross the PCIe boundary at the split point. Note that
+                # single_block_mod is a 2-tuple (see SingleStreamBlock.forward
+                # in flux2_models.py: `mod: tuple[Tensor, Tensor]`), so we
+                # have to map .to() across both elements.
+                if block_idx == split_at:
+                    img = img.to(cuda1)
+                    pe = pe.to(cuda1)
+                    single_block_mod = tuple(t.to(cuda1) for t in single_block_mod)
+                img = block(img, pe, single_block_mod, attn_params)
 
-        # Move the result back to cuda:0 for final_layer + caller.
-        img = img.to(cuda0)
-        img = img[:, num_txt_tokens:, ...]
-        img = self.final_layer(img, vec)
-        return img
+            del single_block_mod, pe
+
+            # Move the result back to cuda:0 for final_layer + caller.
+            img = img.to(cuda0)
+            img = img[:, num_txt_tokens:, ...]
+            img = self.final_layer(img, vec)
+            return img
 
     # Bind as a method on the instance.
     import types
     model.forward = types.MethodType(forward, model)
 
 
+def _get_wrapped_device(lora: "LoRAModule") -> Optional[torch.device]:
+    """Read the wrapped module's CURRENT device.
+
+    LoRAModule.apply_to stores ``self.org_forward = self.org_module.forward``
+    — a bound method whose ``__self__`` is the wrapped layer. Reading the
+    device through that reference each time gives us the *current* placement
+    even after the model has been re-distributed (e.g., dual-GPU split).
+
+    Falls back to the static ``_wrapped_device`` snapshot if the bound-method
+    trick fails (e.g., user installed a callable that isn't a bound method).
+    """
+    bound = getattr(lora, "org_forward", None)
+    wrapped_module = getattr(bound, "__self__", None)
+    if wrapped_module is not None:
+        try:
+            return next(wrapped_module.parameters()).device
+        except StopIteration:
+            pass
+    return getattr(lora, "_wrapped_device", None)
+
+
 def route_loras_to_wrapped_devices(network: "LoRANetwork") -> None:
     """Place each LoRA module on the device of the layer it wraps.
 
-    Requires that ``LoRAModule.apply_to`` has snapshotted
-    ``_wrapped_device`` (see the modification to ``networks/lora.py``).
-    A no-op when devices already match (``Tensor.to(same_device)`` is a
-    free identity).
+    Reads the wrapped device DYNAMICALLY via the org_forward bound method —
+    safe to call at any point in the training-setup lifecycle, including
+    after the dual-GPU distribute has moved blocks to cuda:1.
 
     Also installs a per-LoRA forward shim as a safety net: if anything
     moves the LoRA off the wrapped layer's device after this point
-    (e.g., ``accelerator.prepare`` re-collecting params), the shim
-    silently re-places it on the wrapped device on the next forward.
+    (e.g., ``accelerator.prepare(network)`` flattening everything onto
+    cuda:0), the shim silently re-places it on the next forward.
     """
     loras = list(network.text_encoder_loras) + list(network.unet_loras)
     for lora in loras:
-        wrapped_device = getattr(lora, "_wrapped_device", None)
+        wrapped_device = _get_wrapped_device(lora)
         if wrapped_device is None:
             continue
         lora.to(wrapped_device)
@@ -259,21 +288,26 @@ def route_loras_to_wrapped_devices(network: "LoRANetwork") -> None:
 
 
 def _install_lora_forward_pin(lora: "LoRAModule") -> None:
-    """Wrap ``lora.forward`` to re-pin params to ``_wrapped_device`` if drifted.
+    """Wrap ``lora.forward`` to re-pin params to the wrapped layer's
+    *current* device on each call.
 
-    Called once per LoRA. The shim is a no-op on the hot path when
-    devices already match.
+    Looking up the device dynamically (vs. capturing it in the closure)
+    is what makes this robust to a distribute-after-apply_to ordering:
+    even if route_loras_to_wrapped_devices ran when the wrapped layer
+    was on CPU, the next forward call will see it on cuda:1 (say) and
+    move the LoRA accordingly.
     """
     orig_forward = lora.forward
-    wrapped_device = lora._wrapped_device  # type: ignore[attr-defined]
 
     def pinned_forward(x: torch.Tensor) -> torch.Tensor:
-        try:
-            current = next(lora.parameters()).device
-        except StopIteration:
-            current = wrapped_device
-        if current != wrapped_device:
-            lora.to(wrapped_device)
+        target = _get_wrapped_device(lora)
+        if target is not None:
+            try:
+                current = next(lora.parameters()).device
+            except StopIteration:
+                current = target
+            if current != target:
+                lora.to(target)
         return orig_forward(x)
 
     lora.forward = pinned_forward  # type: ignore[method-assign]

--- a/src/musubi_tuner/flux_2/flux2_dual_gpu.py
+++ b/src/musubi_tuner/flux_2/flux2_dual_gpu.py
@@ -26,7 +26,7 @@ Env vars:
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
@@ -67,7 +67,9 @@ def assert_no_block_swap_in_dual_gpu(blocks_to_swap: Optional[int]) -> None:
         )
 
 
-def distribute_flux2_transformer(model: "Flux2", dtype: torch.dtype) -> None:
+def distribute_flux2_transformer(
+    model: "Flux2", dtype: Optional[torch.dtype] = None
+) -> None:
     """Distribute the FLUX.2 transformer across cuda:0 and cuda:1.
 
     Layout:
@@ -79,6 +81,11 @@ def distribute_flux2_transformer(model: "Flux2", dtype: torch.dtype) -> None:
     one ``.to(cuda:1)`` boundary at the split point and ``.to(cuda:0)``
     on the way back to ``final_layer`` (we keep final_layer on cuda:0 so
     the returned tensor matches ``vec.device`` for the caller).
+
+    ``dtype`` is optional and defaults to None (preserve current dtype).
+    Passing an explicit dtype will trigger conversion during the move,
+    which can balloon memory if the model is already quantized
+    (e.g., fp8 → bf16 conversion ~2× the per-block footprint).
     """
     if torch.cuda.device_count() < 2:
         raise RuntimeError(
@@ -96,26 +103,35 @@ def distribute_flux2_transformer(model: "Flux2", dtype: torch.dtype) -> None:
     cuda0 = torch.device("cuda:0")
     cuda1 = torch.device("cuda:1")
 
+    def _move(mod, device):
+        # Preserve existing dtype unless caller explicitly asked for one.
+        # Passing dtype when the model is already quantized (fp8) would
+        # expand weights back to bf16 during the move and balloon memory.
+        if dtype is None:
+            mod.to(device)
+        else:
+            mod.to(device, dtype=dtype)
+
     # Pre-blocks scaffolding + all double_blocks + first half single_blocks
     # land on cuda:0. Final layer also lives on cuda:0 (see forward).
-    model.img_in.to(cuda0, dtype=dtype)
-    model.txt_in.to(cuda0, dtype=dtype)
-    model.time_in.to(cuda0, dtype=dtype)
+    _move(model.img_in, cuda0)
+    _move(model.txt_in, cuda0)
+    _move(model.time_in, cuda0)
     model.pe_embedder.to(cuda0)
     if model.use_guidance_embed and not isinstance(model.guidance_in, nn.Identity):
-        model.guidance_in.to(cuda0, dtype=dtype)
-    model.double_stream_modulation_img.to(cuda0, dtype=dtype)
-    model.double_stream_modulation_txt.to(cuda0, dtype=dtype)
-    model.single_stream_modulation.to(cuda0, dtype=dtype)
+        _move(model.guidance_in, cuda0)
+    _move(model.double_stream_modulation_img, cuda0)
+    _move(model.double_stream_modulation_txt, cuda0)
+    _move(model.single_stream_modulation, cuda0)
     for block in model.double_blocks:
-        block.to(cuda0, dtype=dtype)
+        _move(block, cuda0)
     for block in model.single_blocks[:split_at]:
-        block.to(cuda0, dtype=dtype)
+        _move(block, cuda0)
     for block in model.single_blocks[split_at:]:
-        block.to(cuda1, dtype=dtype)
+        _move(block, cuda1)
     # final_layer stays on cuda:0 — the forward moves img back before
     # calling it, and final_layer's output matches vec.device (cuda:0).
-    model.final_layer.to(cuda0, dtype=dtype)
+    _move(model.final_layer, cuda0)
 
     # Stash the split index for the patched forward.
     model._flux2_dual_gpu_split_at = split_at  # type: ignore[attr-defined]

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -498,6 +498,8 @@ class Flux2(nn.Module):
         print("FLUX2: Gradient checkpointing disabled.")
 
     def enable_block_swap(self, num_blocks: int, device: torch.device, supports_backward: bool, use_pinned_memory: bool = False):
+        from musubi_tuner.flux_2.flux2_dual_gpu import assert_no_block_swap_in_dual_gpu
+        assert_no_block_swap_in_dual_gpu(num_blocks)
         self.blocks_to_swap = num_blocks
         if num_blocks <= 0:
             double_blocks_to_swap = 0
@@ -573,6 +575,21 @@ class Flux2(nn.Module):
             print("FLUX: Block swap set to forward and backward.")
 
     def move_to_device_except_swap_blocks(self, device: torch.device):
+        # FLUX2_DUAL_GPU=true: distribute the transformer across cuda:0 and
+        # cuda:1 instead of moving everything to a single device. The
+        # caller-provided `device` is ignored in this path (the split layout
+        # uses cuda:0 + cuda:1 explicitly). Mutually exclusive with
+        # blocks_to_swap, enforced inside enable_block_swap.
+        from musubi_tuner.flux_2.flux2_dual_gpu import (
+            distribute_flux2_transformer,
+            install_split_forward,
+            is_dual_gpu_enabled,
+        )
+        if is_dual_gpu_enabled():
+            distribute_flux2_transformer(self, dtype=self.dtype)
+            install_split_forward(self)
+            return
+
         # assume model is on cpu. do not move blocks to device to reduce temporary memory usage
         if self.blocks_to_swap:
             save_double_blocks = self.double_blocks

--- a/src/musubi_tuner/hunyuan_model/models.py
+++ b/src/musubi_tuner/hunyuan_model/models.py
@@ -724,6 +724,17 @@ class HYVideoDiffusionTransformer(nn.Module):  # ModelMixin, ConfigMixin):
             print("HYVideoDiffusionTransformer: Block swap set to forward and backward.")
 
     def move_to_device_except_swap_blocks(self, device: torch.device):
+        # HV_DUAL_GPU=true: distribute the transformer across cuda:0 and
+        # cuda:1 instead of moving everything to a single device. The
+        # caller-provided `device` is ignored in this path (the split layout
+        # uses cuda:0 + cuda:1 explicitly). Mutually exclusive with
+        # blocks_to_swap, enforced inside enable_hv_dual_gpu.
+        from musubi_tuner.hunyuan_video_dual_gpu import enable_hv_dual_gpu, is_dual_gpu_enabled
+
+        if is_dual_gpu_enabled():
+            enable_hv_dual_gpu(self)
+            return
+
         # assume model is on cpu. do not move blocks to device to reduce temporary memory usage
         if self.blocks_to_swap:
             save_double_blocks = self.double_blocks

--- a/src/musubi_tuner/hunyuan_video_dual_gpu.py
+++ b/src/musubi_tuner/hunyuan_video_dual_gpu.py
@@ -1,0 +1,327 @@
+"""Dual-GPU model-parallel path for HunyuanVideo LoRA training in musubi-tuner.
+
+Activates when ``HV_DUAL_GPU=true``. Distributes the
+:class:`~musubi_tuner.hunyuan_model.models.HYVideoDiffusionTransformer` across
+two CUDA devices with a single PCIe boundary mid-``single_blocks``, and routes
+per-layer LoRA modules to the device of the transformer layer they wrap (see
+the inline ``HV_DUAL_GPU`` pin in ``networks/lora.py``). Default behavior is
+unchanged when the env var is unset.
+
+Companion to the validated FLUX.2 and Wan 2.2 musubi ports
+(``flux_2/flux2_dual_gpu.py``, ``wan/wan_dual_gpu.py``). HunyuanVideo's
+double-stream + single-stream architecture is structurally closer to FLUX.2
+than to Wan, so the split shape mirrors the FLUX.2 helper:
+
+- ``HYVideoDiffusionTransformer.forward`` runs all ``double_blocks`` first,
+  then ``x = torch.cat((img, txt), 1)``, then all ``single_blocks``. We
+  replace ``forward`` with a split-aware variant that crosses the PCIe
+  boundary exactly once, mid-``single_blocks`` at ``split_at``. All
+  ``double_blocks`` run on cuda:0; the boundary bridges the merged ``x``
+  plus the per-block tensor args to cuda:1.
+- Unlike Wan's ``WanModel.forward`` (one reused ``kwargs`` dict),
+  HunyuanVideo's ``forward`` rebuilds a fresh positional ARG LIST per block
+  (``double_block_args`` / ``single_block_args``, ~10 entries each). So the
+  bridge helper recurses over a list/tuple, not a dict.
+- RoPE (``freqs_cos`` / ``freqs_sin`` -> ``freqs_cis`` tuple) is computed
+  outside the model and passed as a forward arg — there is no plain-tensor
+  attribute on the model to move (contrast WanModel.freqs).
+- The two text encoders (llava_llama3 + clip_l) are pre-encoded, cached to
+  disk, and deleted before the training loop — the inner loop never touches
+  them, so no TE-on-CPU runtime patch is needed.
+- ``HYVideoDiffusionTransformer.move_to_device_except_swap_blocks`` is the
+  single canonical place to intercept transformer-wide device placement,
+  same as FLUX.2 / Wan.
+
+Env vars:
+    HV_DUAL_GPU=true                       enable the dual-GPU path
+    HV_DUAL_GPU_SPLIT_AT=<int>             override single_blocks split index
+                                           (default: num_single_blocks // 2)
+"""
+from __future__ import annotations
+
+import logging
+import os
+import types
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from musubi_tuner.hunyuan_model.models import HYVideoDiffusionTransformer
+
+logger = logging.getLogger(__name__)
+
+
+def is_dual_gpu_enabled() -> bool:
+    """True iff ``HV_DUAL_GPU=true`` in the environment."""
+    return os.getenv("HV_DUAL_GPU", "false").lower() == "true"
+
+
+def get_split_at(num_single_blocks: int) -> int:
+    """Single-blocks split index. Override via ``HV_DUAL_GPU_SPLIT_AT``."""
+    override = os.getenv("HV_DUAL_GPU_SPLIT_AT")
+    if override is not None:
+        return int(override)
+    return num_single_blocks // 2
+
+
+def enable_hv_dual_gpu(model: "HYVideoDiffusionTransformer") -> "HYVideoDiffusionTransformer":
+    """Distribute the HunyuanVideo transformer across cuda:0 and cuda:1.
+
+    Layout:
+        cuda:0  — img_in, txt_in, time_in, vector_in, guidance_in (if present),
+                  ALL double_blocks, single_blocks[:split_at]
+        cuda:1  — single_blocks[split_at:], final_layer
+
+    The split-aware forward installed by :func:`_install_split_forward`
+    crosses the PCIe boundary once mid-``single_blocks`` at ``split_at``, and
+    crosses back to the input device before ``final_layer`` so the returned
+    tensor matches the caller's device.
+
+    Idempotent: safe to call again — it re-applies the same placement and
+    rebinds the same patched forward.
+
+    Returns the (in-place modified) model.
+    """
+    if torch.cuda.device_count() < 2:
+        raise RuntimeError(
+            f"HV_DUAL_GPU=true requires >=2 CUDA devices, found "
+            f"{torch.cuda.device_count()}."
+        )
+
+    # Block-swap (CPU offload of idle blocks) and dual-GPU model-parallel are
+    # mutually exclusive: the split forward below drops the offloader's
+    # wait/submit calls. Fail loudly rather than silently ignoring --blocks_to_swap.
+    if getattr(model, "blocks_to_swap", None):
+        raise RuntimeError(
+            "HV_DUAL_GPU and --blocks_to_swap are mutually exclusive: dual-GPU "
+            "model-parallel already splits the transformer across two devices, "
+            "while block-swap offloads idle blocks to CPU. Use one or the other."
+        )
+
+    num_double_blocks = len(model.double_blocks)
+    num_single_blocks = len(model.single_blocks)
+    split_at = get_split_at(num_single_blocks)
+    if not 0 < split_at < num_single_blocks:
+        raise RuntimeError(
+            f"HV_DUAL_GPU_SPLIT_AT={split_at} out of range "
+            f"(model has {num_single_blocks} single blocks)."
+        )
+
+    cuda0 = torch.device("cuda:0")
+    cuda1 = torch.device("cuda:1")
+
+    # Pre-block scaffolding + all double_blocks + first half of single_blocks
+    # land on cuda:0; second half of single_blocks + final_layer on cuda:1.
+    model.img_in.to(cuda0)
+    model.txt_in.to(cuda0)
+    model.time_in.to(cuda0)
+    model.vector_in.to(cuda0)
+    if getattr(model, "guidance_in", None) is not None:
+        model.guidance_in.to(cuda0)
+    for block in model.double_blocks:
+        block.to(cuda0)
+    for block in model.single_blocks[:split_at]:
+        block.to(cuda0)
+    for block in model.single_blocks[split_at:]:
+        block.to(cuda1)
+    # final_layer stays on cuda:1 — the forward bridges the result back to
+    # the input device after the loop, before final_layer runs.
+    model.final_layer.to(cuda1)
+
+    _install_split_forward(model, split_at)
+
+    model._hv_dual_gpu_split_at = split_at  # type: ignore[attr-defined]
+    logger.info(
+        f"HV_DUAL_GPU: distributed {num_double_blocks} double + "
+        f"{num_single_blocks} single blocks across cuda:0/cuda:1 "
+        f"(cuda:0: {num_double_blocks} double + {split_at} single; "
+        f"cuda:1: {num_single_blocks - split_at} single + final_layer)"
+    )
+    return model
+
+
+def _install_split_forward(model: "HYVideoDiffusionTransformer", split_at: int) -> None:
+    """Replace ``HYVideoDiffusionTransformer.forward`` with a split-aware variant.
+
+    Mirror of ``HYVideoDiffusionTransformer.forward`` (see
+    ``hunyuan_model/models.py``) with a single PCIe boundary inserted in the
+    ``single_blocks`` loop. All ``double_blocks`` run on cuda:0; at
+    ``single_blocks[split_at]`` the merged activation ``x`` and every tensor
+    in the per-block arg list move to cuda:1, so all subsequent cuda:1 blocks
+    see cuda:1 inputs. After the loop the result moves back to the input
+    device for ``final_layer`` + unpatchify.
+
+    The block-swap (``offloader_*``) branches are deliberately dropped — they
+    are mutually exclusive with dual-GPU (guarded in :func:`enable_hv_dual_gpu`).
+    """
+    from musubi_tuner.hunyuan_model.attention import get_cu_seqlens
+    from musubi_tuner.utils.device_utils import clean_memory_on_device, synchronize_device
+
+    cuda1 = torch.device("cuda:1")
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor,
+        text_states: torch.Tensor = None,
+        text_mask: torch.Tensor = None,
+        text_states_2=None,
+        freqs_cos=None,
+        freqs_sin=None,
+        guidance: torch.Tensor = None,
+        return_dict: bool = True,
+    ):
+        out = {}
+        img = x
+        txt = text_states
+        _, _, ot, oh, ow = x.shape
+        tt, th, tw = (
+            ot // self.patch_size[0],
+            oh // self.patch_size[1],
+            ow // self.patch_size[2],
+        )
+
+        # Prepare modulation vectors.
+        vec = self.time_in(t)
+
+        # text modulation
+        vec = vec + self.vector_in(text_states_2)
+
+        # guidance modulation
+        if self.guidance_embed:
+            if guidance is None:
+                raise ValueError("Didn't get guidance strength for guidance distilled model.")
+            vec = vec + self.guidance_in(guidance)
+
+        # Embed image and text.
+        if self._enable_img_in_txt_in_offloading:
+            self.img_in.to(x.device, non_blocking=True)
+            self.txt_in.to(x.device, non_blocking=True)
+            synchronize_device(x.device)
+
+        img = self.img_in(img)
+        if self.text_projection == "linear":
+            txt = self.txt_in(txt)
+        elif self.text_projection == "single_refiner":
+            txt = self.txt_in(txt, t, text_mask if self.use_attention_mask else None)
+        else:
+            raise NotImplementedError(f"Unsupported text_projection: {self.text_projection}")
+
+        if self._enable_img_in_txt_in_offloading:
+            self.img_in.to(torch.device("cpu"), non_blocking=True)
+            self.txt_in.to(torch.device("cpu"), non_blocking=True)
+            synchronize_device(x.device)
+            clean_memory_on_device(x.device)
+
+        txt_seq_len = txt.shape[1]
+        img_seq_len = img.shape[1]
+
+        # Compute cu_squlens and max_seqlen for flash attention
+        cu_seqlens_q = get_cu_seqlens(text_mask, img_seq_len)
+        cu_seqlens_kv = cu_seqlens_q
+        max_seqlen_q = img_seq_len + txt_seq_len
+        max_seqlen_kv = max_seqlen_q
+
+        attn_mask = total_len = None
+        if self.split_attn or self.attn_mode == "torch":
+            text_len = text_mask.sum(dim=1)  # (bs, )
+            total_len = img_seq_len + text_len  # (bs, )
+        if self.attn_mode == "torch" and not self.split_attn:
+            bs = img.shape[0]
+            attn_mask = torch.zeros((bs, 1, max_seqlen_q, max_seqlen_q), dtype=torch.bool, device=text_mask.device)
+            for i in range(bs):
+                attn_mask[i, :, : total_len[i], : total_len[i]] = True
+            total_len = None  # means we don't use split_attn
+
+        freqs_cis = (freqs_cos, freqs_sin) if freqs_cos is not None else None
+        # --------------------- Pass through DiT blocks ------------------------
+        input_device = img.device
+        for block_idx, block in enumerate(self.double_blocks):
+            double_block_args = [
+                img,
+                txt,
+                vec,
+                attn_mask,
+                total_len,
+                cu_seqlens_q,
+                cu_seqlens_kv,
+                max_seqlen_q,
+                max_seqlen_kv,
+                freqs_cis,
+            ]
+
+            img, txt = block(*double_block_args)
+
+        # Merge txt and img to pass through single stream blocks.
+        x = torch.cat((img, txt), 1)
+
+        if len(self.single_blocks) > 0:
+            for block_idx, block in enumerate(self.single_blocks):
+                # Cross the PCIe boundary once at the split point: bridge the
+                # merged activation x and every tensor in the per-block arg
+                # list to cuda:1. Subsequent cuda:1 blocks reuse cuda:1 args.
+                if block_idx == split_at:
+                    x = x.to(cuda1)
+                    vec = vec.to(cuda1)
+
+                single_block_args = _bridge_block_args(
+                    [
+                        x,
+                        vec,
+                        txt_seq_len,
+                        attn_mask,
+                        total_len,
+                        cu_seqlens_q,
+                        cu_seqlens_kv,
+                        max_seqlen_q,
+                        max_seqlen_kv,
+                        freqs_cis,
+                    ],
+                    x.device,
+                )
+
+                x = block(*single_block_args)
+
+        img = x[:, :img_seq_len, ...]
+        x = None
+        if img.device != input_device:
+            img = img.to(input_device)
+
+        # ---------------------------- Final layer ------------------------------
+        # final_layer lives on cuda:1; bring vec along (it may be on cuda:0 if
+        # the split fired after block 0, but is on cuda:1 if split_at > 0 and
+        # we re-pinned it above — re-pin defensively to final_layer's device).
+        fl_device = next(self.final_layer.parameters()).device
+        img = self.final_layer(img.to(fl_device), vec.to(fl_device))  # (N, T, patch_size ** 2 * out_channels)
+        if img.device != input_device:
+            img = img.to(input_device)
+
+        img = self.unpatchify(img, tt, th, tw)
+        if return_dict:
+            out["x"] = img
+            return out
+        return img
+
+    model.forward = types.MethodType(forward, model)
+
+
+def _bridge_block_args(args, device: torch.device):
+    """Move every tensor in a HunyuanVideo per-block arg list to ``device``.
+
+    HunyuanVideo's ``forward`` rebuilds a positional arg list per block (vs.
+    Wan's single reused ``kwargs`` dict). Entries are a mix of tensors
+    (``img``/``txt``/``x``, ``vec``, ``attn_mask``), the ``freqs_cis`` tuple
+    of two tensors, ints (``txt_seq_len``, ``cu_seqlens_*``, ``max_seqlen_*``)
+    and ``None``. Recurse over lists/tuples; move tensors; leave the rest
+    alone. ``Tensor.to`` is an identity no-op when already on ``device``.
+    """
+    bridged = []
+    for value in args:
+        if torch.is_tensor(value):
+            bridged.append(value.to(device))
+        elif isinstance(value, (list, tuple)):
+            bridged.append(_bridge_block_args(value, device))
+        else:
+            bridged.append(value)
+    return type(args)(bridged) if isinstance(args, tuple) else bridged

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -146,7 +146,7 @@ def prepare_accelerator(args: argparse.Namespace) -> Accelerator:
                 ),
                 timeout=timedelta(minutes=args.ddp_timeout) if args.ddp_timeout else None,
             )
-            if torch.cuda.device_count() > 1
+            if torch.cuda.device_count() > 1 and os.environ.get("FLUX2_DUAL_GPU", "false").lower() != "true"
             else None
         ),
         (
@@ -1744,7 +1744,7 @@ class NetworkTrainer:
         # load DiT model
         blocks_to_swap = args.blocks_to_swap if args.blocks_to_swap else 0
         self.blocks_to_swap = blocks_to_swap
-        loading_device = "cpu" if blocks_to_swap > 0 else accelerator.device
+        loading_device = "cpu" if (blocks_to_swap > 0 or os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true") else accelerator.device
 
         logger.info(f"Loading DiT model from {args.dit}")
         if args.sdpa:
@@ -1918,6 +1918,12 @@ class NetworkTrainer:
             transformer = accelerator.prepare(transformer, device_placement=[not blocks_to_swap > 0])
             accelerator.unwrap_model(transformer).move_to_device_except_swap_blocks(accelerator.device)  # reduce peak memory usage
             accelerator.unwrap_model(transformer).prepare_block_swap_before_forward()
+        elif os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true":
+            # Dual-GPU model-parallel: prepare without device move, then run our
+            # split-aware placement via move_to_device_except_swap_blocks (which
+            # routes to distribute_flux2_transformer + install_split_forward).
+            transformer = accelerator.prepare(transformer, device_placement=[False])
+            accelerator.unwrap_model(transformer).move_to_device_except_swap_blocks(accelerator.device)
         else:
             transformer = accelerator.prepare(transformer)
 

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -146,7 +146,11 @@ def prepare_accelerator(args: argparse.Namespace) -> Accelerator:
                 ),
                 timeout=timedelta(minutes=args.ddp_timeout) if args.ddp_timeout else None,
             )
+            # Dual-GPU model-parallel (FLUX2_DUAL_GPU / WAN_DUAL_GPU) uses both
+            # GPUs for a single training step, so skip DDP data-parallel setup.
             if torch.cuda.device_count() > 1
+            and os.environ.get("FLUX2_DUAL_GPU", "false").lower() != "true"
+            and os.environ.get("WAN_DUAL_GPU", "false").lower() != "true"
             else None
         ),
         (
@@ -1744,7 +1748,13 @@ class NetworkTrainer:
         # load DiT model
         blocks_to_swap = args.blocks_to_swap if args.blocks_to_swap else 0
         self.blocks_to_swap = blocks_to_swap
-        loading_device = "cpu" if blocks_to_swap > 0 else accelerator.device
+        # Dual-GPU (FLUX2_DUAL_GPU / WAN_DUAL_GPU): load to CPU so the split
+        # placement (enable_wan_dual_gpu etc.) can distribute across cuda:0+1.
+        _dual_gpu = (
+            os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true"
+            or os.environ.get("WAN_DUAL_GPU", "false").lower() == "true"
+        )
+        loading_device = "cpu" if (blocks_to_swap > 0 or _dual_gpu) else accelerator.device
 
         logger.info(f"Loading DiT model from {args.dit}")
         if args.sdpa:
@@ -1918,6 +1928,12 @@ class NetworkTrainer:
             transformer = accelerator.prepare(transformer, device_placement=[not blocks_to_swap > 0])
             accelerator.unwrap_model(transformer).move_to_device_except_swap_blocks(accelerator.device)  # reduce peak memory usage
             accelerator.unwrap_model(transformer).prepare_block_swap_before_forward()
+        elif _dual_gpu:
+            # Dual-GPU model-parallel: prepare without device move, then run
+            # the split-aware placement via move_to_device_except_swap_blocks
+            # (routes to enable_wan_dual_gpu / distribute_flux2_transformer).
+            transformer = accelerator.prepare(transformer, device_placement=[False])
+            accelerator.unwrap_model(transformer).move_to_device_except_swap_blocks(accelerator.device)
         else:
             transformer = accelerator.prepare(transformer)
 

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -146,11 +146,13 @@ def prepare_accelerator(args: argparse.Namespace) -> Accelerator:
                 ),
                 timeout=timedelta(minutes=args.ddp_timeout) if args.ddp_timeout else None,
             )
-            # Dual-GPU model-parallel (FLUX2_DUAL_GPU / WAN_DUAL_GPU) uses both
-            # GPUs for a single training step, so skip DDP data-parallel setup.
+            # Dual-GPU model-parallel (FLUX2_DUAL_GPU / WAN_DUAL_GPU /
+            # HV_DUAL_GPU) uses both GPUs for a single training step, so skip
+            # DDP data-parallel setup.
             if torch.cuda.device_count() > 1
             and os.environ.get("FLUX2_DUAL_GPU", "false").lower() != "true"
             and os.environ.get("WAN_DUAL_GPU", "false").lower() != "true"
+            and os.environ.get("HV_DUAL_GPU", "false").lower() != "true"
             else None
         ),
         (
@@ -1748,11 +1750,13 @@ class NetworkTrainer:
         # load DiT model
         blocks_to_swap = args.blocks_to_swap if args.blocks_to_swap else 0
         self.blocks_to_swap = blocks_to_swap
-        # Dual-GPU (FLUX2_DUAL_GPU / WAN_DUAL_GPU): load to CPU so the split
-        # placement (enable_wan_dual_gpu etc.) can distribute across cuda:0+1.
+        # Dual-GPU (FLUX2_DUAL_GPU / WAN_DUAL_GPU / HV_DUAL_GPU): load to CPU
+        # so the split placement (enable_hv_dual_gpu etc.) can distribute
+        # across cuda:0+1.
         _dual_gpu = (
             os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true"
             or os.environ.get("WAN_DUAL_GPU", "false").lower() == "true"
+            or os.environ.get("HV_DUAL_GPU", "false").lower() == "true"
         )
         loading_device = "cpu" if (blocks_to_swap > 0 or _dual_gpu) else accelerator.device
 
@@ -1931,7 +1935,8 @@ class NetworkTrainer:
         elif _dual_gpu:
             # Dual-GPU model-parallel: prepare without device move, then run
             # the split-aware placement via move_to_device_except_swap_blocks
-            # (routes to enable_wan_dual_gpu / distribute_flux2_transformer).
+            # (routes to enable_hv_dual_gpu / enable_wan_dual_gpu /
+            # distribute_flux2_transformer).
             transformer = accelerator.prepare(transformer, device_placement=[False])
             accelerator.unwrap_model(transformer).move_to_device_except_swap_blocks(accelerator.device)
         else:

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -98,9 +98,38 @@ class LoRAModule(torch.nn.Module):
     def apply_to(self):
         self.org_forward = self.org_module.forward
         self.org_module.forward = self.forward
+        # Snapshot the wrapped layer's device so model-parallel paths (the
+        # FLUX.2 / Wan dual-GPU splits) can re-place this LoRA on the correct
+        # device after network.to(...) has flattened everything onto one GPU.
+        # Harmless on single-device setups -- the pin below becomes a no-op
+        # when devices already match.
+        try:
+            self._wrapped_device = next(self.org_module.parameters()).device
+        except StopIteration:
+            self._wrapped_device = None
         del self.org_module
 
     def forward(self, x):
+        # Dual-GPU model-parallel pin: when FLUX2_DUAL_GPU / WAN_DUAL_GPU is
+        # true, the wrapped layer may live on a different device than this
+        # LoRA (e.g. layer on cuda:1, LoRA prepared on cuda:0 by
+        # accelerator.prepare(network)). The bound-method indirection in
+        # apply_to makes instance-level forward-shimming unreliable, so we do
+        # the pin inline here. This also lazily re-places LoRA params after an
+        # A14B high/low expert swap, which rebinds the base weights' devices.
+        import os as _os
+        if (
+            _os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true"
+            or _os.environ.get("WAN_DUAL_GPU", "false").lower() == "true"
+        ):
+            try:
+                _wrapped_module = self.org_forward.__self__
+                _target_device = next(_wrapped_module.parameters()).device
+                _current_device = next(self.parameters()).device
+                if _current_device != _target_device:
+                    self.to(_target_device)
+            except (AttributeError, StopIteration):
+                pass
         org_forwarded = self.org_forward(x)
 
         # module dropout

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -98,6 +98,15 @@ class LoRAModule(torch.nn.Module):
     def apply_to(self):
         self.org_forward = self.org_module.forward
         self.org_module.forward = self.forward
+        # Snapshot the wrapped layer's device so model-parallel paths (e.g.,
+        # the FLUX.2 dual-GPU split) can re-place this LoRA on the correct
+        # device after network.to(...) has flattened everything onto one
+        # GPU. Harmless on single-device setups — the routing pass becomes
+        # a no-op when devices already match.
+        try:
+            self._wrapped_device = next(self.org_module.parameters()).device
+        except StopIteration:
+            self._wrapped_device = None
         del self.org_module
 
     def forward(self, x):
@@ -660,6 +669,21 @@ class LoRANetwork(torch.nn.Module):
         for lora in self.text_encoder_loras + self.unet_loras:
             lora.apply_to()
             self.add_module(lora.lora_name, lora)
+
+        # Model-parallel paths (FLUX.2 dual-GPU split etc.) need each LoRA
+        # to live on the device of its wrapped layer. Re-place after
+        # apply_to, and install a per-LoRA forward shim as a safety net in
+        # case anything moves params off the wrapped device later.
+        try:
+            from musubi_tuner.flux_2.flux2_dual_gpu import (
+                is_dual_gpu_enabled,
+                route_loras_to_wrapped_devices,
+            )
+            if is_dual_gpu_enabled():
+                route_loras_to_wrapped_devices(self)
+        except ImportError:
+            # flux_2 package not installed / not on path — fine.
+            pass
 
     # マージできるかどうかを返す
     def is_mergeable(self):

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -110,6 +110,22 @@ class LoRAModule(torch.nn.Module):
         del self.org_module
 
     def forward(self, x):
+        # Dual-GPU model-parallel pin: when FLUX2_DUAL_GPU=true, the
+        # wrapped layer may live on a different device than this LoRA
+        # (e.g., layer on cuda:1, LoRA was prepared on cuda:0 by
+        # accelerator.prepare(network)). The bound-method indirection
+        # in apply_to makes instance-level forward-shimming unreliable,
+        # so we do the pin inline here.
+        import os as _os
+        if _os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true":
+            try:
+                _wrapped_module = self.org_forward.__self__
+                _target_device = next(_wrapped_module.parameters()).device
+                _current_device = next(self.parameters()).device
+                if _current_device != _target_device:
+                    self.to(_target_device)
+            except (AttributeError, StopIteration):
+                pass
         org_forwarded = self.org_forward(x)
 
         # module dropout

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -99,8 +99,9 @@ class LoRAModule(torch.nn.Module):
         self.org_forward = self.org_module.forward
         self.org_module.forward = self.forward
         # Snapshot the wrapped layer's device so model-parallel paths (the
-        # FLUX.2 / Wan dual-GPU splits) can re-place this LoRA on the correct
-        # device after network.to(...) has flattened everything onto one GPU.
+        # FLUX.2 / Wan / HunyuanVideo dual-GPU splits) can re-place this LoRA
+        # on the correct device after network.to(...) has flattened
+        # everything onto one GPU.
         # Harmless on single-device setups -- the pin below becomes a no-op
         # when devices already match.
         try:
@@ -110,10 +111,10 @@ class LoRAModule(torch.nn.Module):
         del self.org_module
 
     def forward(self, x):
-        # Dual-GPU model-parallel pin: when FLUX2_DUAL_GPU / WAN_DUAL_GPU is
-        # true, the wrapped layer may live on a different device than this
-        # LoRA (e.g. layer on cuda:1, LoRA prepared on cuda:0 by
-        # accelerator.prepare(network)). The bound-method indirection in
+        # Dual-GPU model-parallel pin: when FLUX2_DUAL_GPU / WAN_DUAL_GPU /
+        # HV_DUAL_GPU is true, the wrapped layer may live on a different
+        # device than this LoRA (e.g. layer on cuda:1, LoRA prepared on cuda:0
+        # by accelerator.prepare(network)). The bound-method indirection in
         # apply_to makes instance-level forward-shimming unreliable, so we do
         # the pin inline here. This also lazily re-places LoRA params after an
         # A14B high/low expert swap, which rebinds the base weights' devices.
@@ -121,6 +122,7 @@ class LoRAModule(torch.nn.Module):
         if (
             _os.environ.get("FLUX2_DUAL_GPU", "false").lower() == "true"
             or _os.environ.get("WAN_DUAL_GPU", "false").lower() == "true"
+            or _os.environ.get("HV_DUAL_GPU", "false").lower() == "true"
         ):
             try:
                 _wrapped_module = self.org_forward.__self__

--- a/src/musubi_tuner/wan/modules/model.py
+++ b/src/musubi_tuner/wan/modules/model.py
@@ -773,6 +773,16 @@ class WanModel(nn.Module):  # ModelMixin, ConfigMixin):
             print(f"WanModel: Block swap set to forward and backward.")
 
     def move_to_device_except_swap_blocks(self, device: torch.device):
+        # WAN_DUAL_GPU=true: distribute the transformer across cuda:0 and
+        # cuda:1 instead of moving everything to a single device. The
+        # caller-provided `device` is ignored in this path (the split
+        # layout uses cuda:0 + cuda:1 explicitly).
+        from musubi_tuner.wan.wan_dual_gpu import enable_wan_dual_gpu, is_dual_gpu_enabled
+
+        if is_dual_gpu_enabled():
+            enable_wan_dual_gpu(self)
+            return
+
         # assume model is on cpu. do not move blocks to device to reduce temporary memory usage
         if self.blocks_to_swap:
             save_blocks = self.blocks

--- a/src/musubi_tuner/wan/wan_dual_gpu.py
+++ b/src/musubi_tuner/wan/wan_dual_gpu.py
@@ -1,0 +1,278 @@
+"""Dual-GPU model-parallel path for Wan 2.2 LoRA training in musubi-tuner.
+
+Activates when ``WAN_DUAL_GPU=true``. Distributes the vendored
+:class:`~musubi_tuner.wan.modules.model.WanModel` transformer across two
+CUDA devices with a single PCIe boundary mid-``blocks``, and routes
+per-layer LoRA modules to the device of the transformer layer they wrap
+(see the inline ``WAN_DUAL_GPU`` pin in ``networks/lora.py``). Default
+behavior is unchanged when the env var is unset.
+
+Companion to the validated FLUX.2 musubi port (``flux_2/flux2_dual_gpu.py``)
+and the ai-toolkit Wan 2.2 port. The structural shape mirrors the FLUX.2
+helper; the differences come from WanModel's API:
+
+- ``WanModel.forward`` builds a single ``kwargs`` dict (``e``, ``seq_lens``,
+  ``grid_sizes``, ``freqs``, ``context``, ``context_lens``) and reuses it
+  for every ``block(x, **kwargs)`` call. We replace ``forward`` with a
+  split-aware variant that crosses the PCIe boundary exactly once — both
+  the activation ``x`` and the shared ``kwargs`` dict are bridged to
+  cuda:1 at the split index, so every subsequent block sees cuda:1 inputs.
+- ``WanModel.freqs`` is a plain tensor attribute, NOT a registered buffer
+  (the class deliberately avoids ``register_buffer`` to keep its dtype
+  stable across ``.to()``). ``module.to(device)`` therefore misses it —
+  we move ``freqs`` (and the ``freqs_fhw`` cache) explicitly to cuda:0.
+- ``move_to_device_except_swap_blocks`` is the single canonical place to
+  intercept transformer-wide device placement, same as FLUX.2's
+  ``Flux2.move_to_device_except_swap_blocks``.
+
+A14B limitation: musubi's A14B (high/low expert) support swaps the full
+model ``state_dict`` between experts at ``swap_high_low_weights()`` via
+``load_state_dict(..., assign=True)``. ``assign=True`` rebinds parameter
+tensors, so a swap moves the freshly-assigned weights to whatever device
+the incoming ``state_dict`` lived on — it does NOT preserve our split.
+:func:`enable_wan_dual_gpu` is idempotent (safe to call again after a
+swap) but the trainer does not currently re-invoke it post-swap; the
+inline ``WAN_DUAL_GPU`` LoRA device-pin in ``networks/lora.py`` handles
+lazy re-placement of LoRA params on the first forward after a swap, which
+is sufficient for LoRA training (only LoRA params receive gradients).
+
+Env vars:
+    WAN_DUAL_GPU=true                      enable the dual-GPU path
+    WAN_DUAL_GPU_SPLIT_AT=<int>            override blocks split index
+                                           (default: num_blocks // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from musubi_tuner.wan.modules.model import WanModel
+
+
+def is_dual_gpu_enabled() -> bool:
+    """True iff ``WAN_DUAL_GPU=true`` in the environment."""
+    return os.getenv("WAN_DUAL_GPU", "false").lower() == "true"
+
+
+def get_split_at(num_blocks: int) -> int:
+    """Blocks split index. Override via ``WAN_DUAL_GPU_SPLIT_AT``."""
+    override = os.getenv("WAN_DUAL_GPU_SPLIT_AT")
+    if override is not None:
+        return int(override)
+    return num_blocks // 2
+
+
+def enable_wan_dual_gpu(model: "WanModel") -> "WanModel":
+    """Distribute the ``WanModel`` transformer across cuda:0 and cuda:1.
+
+    Layout:
+        cuda:0  — patch_embedding, text_embedding, time_embedding,
+                  time_projection, img_emb (if present), blocks[:split_at],
+                  head
+        cuda:1  — blocks[split_at:]
+
+    ``head`` stays on cuda:0 so the returned tensor (and the trainer's
+    downstream loss ops, which run on the model's nominal device) match
+    cuda:0. The split-aware forward installed by :func:`_install_split_forward`
+    crosses the PCIe boundary once at ``blocks[split_at]`` and crosses back
+    to cuda:0 before ``head``.
+
+    Idempotent: safe to call again (e.g., after an A14B expert swap) — it
+    re-applies the same placement and rebinds the same patched forward.
+
+    Returns the (in-place modified) model.
+    """
+    if torch.cuda.device_count() < 2:
+        raise RuntimeError(
+            f"WAN_DUAL_GPU=true requires >=2 CUDA devices, found "
+            f"{torch.cuda.device_count()}."
+        )
+
+    # Block-swap (CPU offload of idle blocks) and dual-GPU model-parallel are
+    # mutually exclusive: the split forward below drops the offloader's
+    # wait/submit calls. Fail loudly rather than silently ignoring --blocks_to_swap.
+    if getattr(model, "blocks_to_swap", 0):
+        raise RuntimeError(
+            "WAN_DUAL_GPU and --blocks_to_swap are mutually exclusive: dual-GPU "
+            "model-parallel already splits the transformer across two devices, "
+            "while block-swap offloads idle blocks to CPU. Use one or the other."
+        )
+
+    num_blocks = len(model.blocks)
+    split_at = get_split_at(num_blocks)
+    if not 0 < split_at < num_blocks:
+        raise RuntimeError(
+            f"WAN_DUAL_GPU_SPLIT_AT={split_at} out of range "
+            f"(model has {num_blocks} blocks)."
+        )
+
+    cuda0 = torch.device("cuda:0")
+    cuda1 = torch.device("cuda:1")
+
+    # Pre-block scaffolding + first half of blocks + output head land on
+    # cuda:0; second half of blocks on cuda:1.
+    model.patch_embedding.to(cuda0)
+    model.text_embedding.to(cuda0)
+    model.time_embedding.to(cuda0)
+    model.time_projection.to(cuda0)
+    if getattr(model, "img_emb", None) is not None:
+        model.img_emb.to(cuda0)
+    for block in model.blocks[:split_at]:
+        block.to(cuda0)
+    for block in model.blocks[split_at:]:
+        block.to(cuda1)
+    model.head.to(cuda0)
+
+    # freqs is a plain tensor attribute, not a registered buffer (WanModel
+    # deliberately avoids register_buffer to keep its dtype stable across
+    # .to()) -- module.to(device) misses it, so move it explicitly. The
+    # patchify / freq-prep step runs on cuda:0.
+    if torch.is_tensor(model.freqs):
+        model.freqs = model.freqs.to(cuda0)
+    # freqs_fhw is a plain dict cache of per-grid-size freq tensors, also
+    # not reached by module.to(). Move any cached entries to cuda:0.
+    if isinstance(getattr(model, "freqs_fhw", None), dict):
+        model.freqs_fhw = {
+            k: (v.to(cuda0) if torch.is_tensor(v) else v)
+            for k, v in model.freqs_fhw.items()
+        }
+
+    _install_split_forward(model, split_at)
+
+    model._wan_dual_gpu_split_at = split_at  # type: ignore[attr-defined]
+    return model
+
+
+def _install_split_forward(model: "WanModel", split_at: int) -> None:
+    """Replace ``WanModel.forward`` with a split-aware variant.
+
+    WanModel.forward builds one ``kwargs`` dict and reuses it for every
+    ``block(x, **kwargs)`` call. We crosses the PCIe boundary exactly once
+    at ``blocks[split_at]``: both the activation ``x`` and every tensor in
+    the shared ``kwargs`` dict move to cuda:1, so all subsequent cuda:1
+    blocks see cuda:1 inputs without per-block bridging. After the loop we
+    move ``x`` back to its original input device for ``head`` + unpatchify.
+    """
+    from musubi_tuner.wan.modules.model import calculate_freqs_i, sinusoidal_embedding_1d
+    from musubi_tuner.utils.device_utils import clean_memory_on_device
+
+    cuda1 = torch.device("cuda:1")
+
+    def forward(self, x, t, context, seq_len, clip_fea=None, y=None, skip_block_indices=None, f_indices=None):
+        # Mirror of WanModel.forward (see wan/modules/model.py) with a
+        # single PCIe boundary inserted in the block loop. Kept in sync
+        # structurally; only the block loop differs.
+        device = self.patch_embedding.weight.device
+        if self.freqs.device != device:
+            self.freqs = self.freqs.to(device)
+
+        if y is not None:
+            x = [torch.cat([u, v], dim=0) for u, v in zip(x, y)]
+            y = None
+
+        # embeddings
+        x = [self.patch_embedding(u.unsqueeze(0)) for u in x]
+        grid_sizes = torch.stack([torch.tensor(u.shape[2:], dtype=torch.long) for u in x])
+
+        freqs_list = []
+        for i, fhw in enumerate(grid_sizes):
+            fhw = tuple(fhw.tolist())
+            if f_indices is not None:
+                fhw = tuple(list(fhw) + f_indices[i])
+            if fhw not in self.freqs_fhw:
+                c = self.dim // self.num_heads // 2
+                self.freqs_fhw[fhw] = calculate_freqs_i(fhw, c, self.freqs, None if f_indices is None else f_indices[i])
+            freqs_list.append(self.freqs_fhw[fhw])
+
+        x = [u.flatten(2).transpose(1, 2) for u in x]
+        seq_lens = torch.tensor([u.size(1) for u in x], dtype=torch.long)
+        assert seq_lens.max() <= seq_len, f"Sequence length exceeds maximum allowed length {seq_len}. Got {seq_lens.max()}"
+        x = torch.cat([torch.cat([u, u.new_zeros(1, seq_len - u.size(1), u.size(2))], dim=1) for u in x])
+
+        # time embeddings
+        with torch.amp.autocast(device_type=device.type, dtype=torch.float32):
+            if self.model_version == "2.1" or self.force_v2_1_time_embedding:
+                e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).float())
+                e0 = self.time_projection(e).unflatten(1, (6, self.dim))
+                if self.model_version != "2.1":
+                    e0 = e0.unsqueeze(1)
+                    e = e.unsqueeze(1)
+                    t = t.unsqueeze(1).expand(-1, seq_len)
+            else:
+                if t.dim() == 1:
+                    t = t.unsqueeze(1).expand(-1, seq_len)
+                bt = t.size(0)
+                t = t.flatten()
+                e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).unflatten(0, (bt, seq_len)).float())
+                e0 = self.time_projection(e).unflatten(2, (6, self.dim))
+
+        assert e.dtype == torch.float32 and e0.dtype == torch.float32
+
+        # context
+        context_lens = None
+        if type(context) is list:
+            context = torch.stack([torch.cat([u, u.new_zeros(self.text_len - u.size(0), u.size(1))]) for u in context])
+        context = self.text_embedding(context)
+
+        if clip_fea is not None:
+            context_clip = self.img_emb(clip_fea)
+            context = torch.concat([context_clip, context], dim=1)
+            clip_fea = None
+            context_clip = None
+
+        # arguments -- a single dict reused for every block call
+        kwargs = dict(e=e0, seq_lens=seq_lens, grid_sizes=grid_sizes, freqs=freqs_list, context=context, context_lens=context_lens)
+
+        if self.blocks_to_swap:
+            clean_memory_on_device(device)
+
+        input_device = x.device
+        for block_idx, block in enumerate(self.blocks):
+            is_block_skipped = skip_block_indices is not None and block_idx in skip_block_indices
+
+            # Cross the PCIe boundary once at the split point. Bridge the
+            # activation x and every tensor in the shared kwargs dict to
+            # cuda:1; subsequent cuda:1 blocks reuse the bridged kwargs.
+            if block_idx == split_at:
+                x = x.to(cuda1)
+                kwargs = _bridge_block_kwargs(kwargs, cuda1)
+
+            if not is_block_skipped:
+                x = block(x, **kwargs)
+
+        if x.device != input_device:
+            x = x.to(input_device)
+
+        # head
+        x = self.head(x, e)
+
+        # unpatchify
+        x = self.unpatchify(x, grid_sizes)
+        return [u.float() for u in x]
+
+    model.forward = types.MethodType(forward, model)
+
+
+def _bridge_block_kwargs(kwargs: dict, device: torch.device) -> dict:
+    """Move every tensor in the WanAttentionBlock kwargs dict to ``device``.
+
+    ``freqs`` is a list of per-sample tensors; ``e`` / ``seq_lens`` /
+    ``grid_sizes`` / ``context`` are tensors; ``context_lens`` is ``None``.
+    ``Tensor.to`` is an identity no-op when the tensor is already on
+    ``device``.
+    """
+    bridged = {}
+    for key, value in kwargs.items():
+        if torch.is_tensor(value):
+            bridged[key] = value.to(device)
+        elif isinstance(value, (list, tuple)):
+            bridged[key] = type(value)(
+                v.to(device) if torch.is_tensor(v) else v for v in value
+            )
+        else:
+            bridged[key] = value
+    return bridged

--- a/src/musubi_tuner/wan/wan_dual_gpu.py
+++ b/src/musubi_tuner/wan/wan_dual_gpu.py
@@ -25,26 +25,26 @@ helper; the differences come from WanModel's API:
   intercept transformer-wide device placement, same as FLUX.2's
   ``Flux2.move_to_device_except_swap_blocks``.
 
-A14B dual-expert limitation — NOT YET SUPPORTED with the dual-GPU split.
-Single-expert training (one ``--dit``, no ``--dit_high_noise``) works and
-is validated. The dual-expert path (``--dit`` + ``--dit_high_noise`` +
-``--timestep_boundary``) does NOT: musubi swaps the full model
+A14B dual-expert support — handled at the swap site, see below.
+Single-expert training (one ``--dit``, no ``--dit_high_noise``) and the
+dual-expert path (``--dit`` + ``--dit_high_noise`` + ``--timestep_boundary``)
+both work. The dual-expert case needs care: musubi swaps the full model
 ``state_dict`` between the high/low experts at ``swap_high_low_weights()``
 via ``load_state_dict(..., assign=True)``. ``assign=True`` rebinds
-parameter tensors, so the swap (a) collapses our cuda:0/cuda:1 split back
-onto one device and (b) brings in the incoming expert's raw weights
-*bypassing musubi's own fp8-optimization exclude logic* — base modules
-that should stay bf16 (e.g. ``patch_embedding``, a Conv3d) end up with
-fp8 bias against bf16 input, raising
+parameter tensors, so a naive swap (a) collapses our cuda:0/cuda:1 split
+back onto one device and (b) brings in the incoming expert's raw weights
+straight out of ``load_wan_model`` — CPU-resident and with a per-module
+dtype layout that diverges from the active model (which has been through
+``accelerator.prepare`` + :func:`enable_wan_dual_gpu`). Left unhandled,
+base modules end up with fp8 bias against bf16 input, raising
 ``RuntimeError: Input type (BFloat16) and bias type (Float8_e4m3fn)
-should be the same`` on the first forward after the swap. Validated
-2026-05-14: an i2v-A14B run trains cleanly for 14/20 steps on the first
-(distributed) expert, then crashes the step the swap fires. The inline
-``WAN_DUAL_GPU`` LoRA device-pin only re-places LoRA params — it cannot
-fix base-module dtype/device, so it is insufficient here. A proper fix
-needs a re-distribution + dtype-fixup hook at the ``swap_high_low_weights``
-site (``enable_wan_dual_gpu`` is idempotent, so re-invoking it is safe —
-but the dtype mismatch also needs handling). Tracked as follow-up.
+should be the same`` on the first forward after the swap (validated
+2026-05-14: an i2v-A14B run trained cleanly for 14/20 steps then crashed
+the step the swap fired). ``WanNetworkTrainer.swap_high_low_weights``
+fixes this for the ``WAN_DUAL_GPU`` path: after the ``assign=True`` load
+it casts the incoming tensors back to the outgoing model's dtype layout
+and re-invokes :func:`enable_wan_dual_gpu` (idempotent) to restore the
+cuda:0/cuda:1 split and reinstall the split-aware forward.
 
 Env vars:
     WAN_DUAL_GPU=true                      enable the dual-GPU path

--- a/src/musubi_tuner/wan/wan_dual_gpu.py
+++ b/src/musubi_tuner/wan/wan_dual_gpu.py
@@ -25,16 +25,26 @@ helper; the differences come from WanModel's API:
   intercept transformer-wide device placement, same as FLUX.2's
   ``Flux2.move_to_device_except_swap_blocks``.
 
-A14B limitation: musubi's A14B (high/low expert) support swaps the full
-model ``state_dict`` between experts at ``swap_high_low_weights()`` via
-``load_state_dict(..., assign=True)``. ``assign=True`` rebinds parameter
-tensors, so a swap moves the freshly-assigned weights to whatever device
-the incoming ``state_dict`` lived on — it does NOT preserve our split.
-:func:`enable_wan_dual_gpu` is idempotent (safe to call again after a
-swap) but the trainer does not currently re-invoke it post-swap; the
-inline ``WAN_DUAL_GPU`` LoRA device-pin in ``networks/lora.py`` handles
-lazy re-placement of LoRA params on the first forward after a swap, which
-is sufficient for LoRA training (only LoRA params receive gradients).
+A14B dual-expert limitation — NOT YET SUPPORTED with the dual-GPU split.
+Single-expert training (one ``--dit``, no ``--dit_high_noise``) works and
+is validated. The dual-expert path (``--dit`` + ``--dit_high_noise`` +
+``--timestep_boundary``) does NOT: musubi swaps the full model
+``state_dict`` between the high/low experts at ``swap_high_low_weights()``
+via ``load_state_dict(..., assign=True)``. ``assign=True`` rebinds
+parameter tensors, so the swap (a) collapses our cuda:0/cuda:1 split back
+onto one device and (b) brings in the incoming expert's raw weights
+*bypassing musubi's own fp8-optimization exclude logic* — base modules
+that should stay bf16 (e.g. ``patch_embedding``, a Conv3d) end up with
+fp8 bias against bf16 input, raising
+``RuntimeError: Input type (BFloat16) and bias type (Float8_e4m3fn)
+should be the same`` on the first forward after the swap. Validated
+2026-05-14: an i2v-A14B run trains cleanly for 14/20 steps on the first
+(distributed) expert, then crashes the step the swap fires. The inline
+``WAN_DUAL_GPU`` LoRA device-pin only re-places LoRA params — it cannot
+fix base-module dtype/device, so it is insufficient here. A proper fix
+needs a re-distribution + dtype-fixup hook at the ``swap_high_low_weights``
+site (``enable_wan_dual_gpu`` is idempotent, so re-invoking it is safe —
+but the dtype mismatch also needs handling). Tracked as follow-up.
 
 Env vars:
     WAN_DUAL_GPU=true                      enable the dual-GPU path

--- a/src/musubi_tuner/wan/wan_dual_gpu.py
+++ b/src/musubi_tuner/wan/wan_dual_gpu.py
@@ -43,6 +43,7 @@ Env vars:
 """
 from __future__ import annotations
 
+import logging
 import os
 import types
 from typing import TYPE_CHECKING
@@ -51,6 +52,8 @@ import torch
 
 if TYPE_CHECKING:
     from musubi_tuner.wan.modules.model import WanModel
+
+logger = logging.getLogger(__name__)
 
 
 def is_dual_gpu_enabled() -> bool:
@@ -144,6 +147,11 @@ def enable_wan_dual_gpu(model: "WanModel") -> "WanModel":
     _install_split_forward(model, split_at)
 
     model._wan_dual_gpu_split_at = split_at  # type: ignore[attr-defined]
+    logger.info(
+        f"WAN_DUAL_GPU: distributed {num_blocks} blocks across cuda:0/cuda:1 "
+        f"({split_at} on cuda:0, {num_blocks - split_at} on cuda:1); "
+        f"scaffolding + head on cuda:0"
+    )
     return model
 
 

--- a/src/musubi_tuner/wan_train_network.py
+++ b/src/musubi_tuner/wan_train_network.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 from typing import List, Optional
 from PIL import Image
 
@@ -469,6 +470,17 @@ class WanNetworkTrainer(NetworkTrainer):
         loading_device: str,
         dit_weight_dtype: Optional[torch.dtype],
     ):
+        # WAN_DUAL_GPU=true: the model is loaded to CPU (loading_device is
+        # forced to "cpu" upstream in hv_train_network.py) and NOT moved to a
+        # single device here -- enable_wan_dual_gpu() distributes it across
+        # cuda:0 + cuda:1 later, via move_to_device_except_swap_blocks().
+        # Fail fast with a clear error before the (slow) checkpoint load if
+        # the machine doesn't actually have two GPUs.
+        if os.environ.get("WAN_DUAL_GPU", "false").lower() == "true" and torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                f"WAN_DUAL_GPU=true requires >=2 CUDA devices, found {torch.cuda.device_count()}."
+            )
+
         model = load_wan_model(
             self.config,
             accelerator.device,

--- a/src/musubi_tuner/wan_train_network.py
+++ b/src/musubi_tuner/wan_train_network.py
@@ -602,6 +602,25 @@ class WanNetworkTrainer(NetworkTrainer):
                         state_dict[new_key] = state_dict.pop(key)
                 return state_dict
 
+            # WAN_DUAL_GPU=true: the inactive expert's state_dict was snapshotted
+            # raw out of load_wan_model -- CPU-resident and un-distributed, never
+            # routed through enable_wan_dual_gpu (load_transformer only does that
+            # for the active --dit). load_state_dict(assign=True) below rebinds
+            # the active model's parameter tensors to those raw tensors, so the
+            # swapped-in expert (a) loses the cuda:0/cuda:1 split and (b) carries
+            # whatever per-module dtype layout load_wan_model left it in, which
+            # diverges from the active model that has been through accelerator
+            # .prepare + enable_wan_dual_gpu (e.g. patch_embedding.bias ends up
+            # fp8 against bf16 input -> "Input type BFloat16 and bias type
+            # Float8_e4m3fn should be the same" on the first forward after the
+            # swap). We capture the outgoing model's device+dtype layout from the
+            # state_dict snapshot taken just below, then after the swap cast the
+            # incoming tensors back to that layout and re-run enable_wan_dual_gpu
+            # (idempotent) to restore the split + reinstall the split forward.
+            from musubi_tuner.wan.wan_dual_gpu import enable_wan_dual_gpu, is_dual_gpu_enabled
+
+            wan_dual_gpu = is_dual_gpu_enabled()
+
             if self.blocks_to_swap == 0:
                 # If offloading inactive DiT, move the model to CPU first
                 if args.offload_inactive_dit:
@@ -615,7 +634,23 @@ class WanNetworkTrainer(NetworkTrainer):
                 assert len(info.missing_keys) == 0, f"Missing keys: {info.missing_keys}"
                 assert len(info.unexpected_keys) == 0, f"Unexpected keys: {info.unexpected_keys}"
 
-                if args.offload_inactive_dit:
+                if wan_dual_gpu:
+                    # Restore the per-tensor dtype layout of the model that was
+                    # just swapped out (state_dict, captured above) onto the
+                    # freshly-assigned incoming tensors, then re-distribute
+                    # across cuda:0/cuda:1. enable_wan_dual_gpu handles device
+                    # placement (incl. freqs/freqs_fhw) and reinstalls the
+                    # split-aware forward; the cast here only fixes dtype.
+                    for name, param in model.named_parameters():
+                        prev = state_dict.get(name)
+                        if prev is not None and param.dtype != prev.dtype:
+                            param.data = param.data.to(prev.dtype)
+                    for name, buf in model.named_buffers():
+                        prev = state_dict.get(name)
+                        if prev is not None and buf.dtype != prev.dtype:
+                            buf.data = buf.data.to(prev.dtype)
+                    enable_wan_dual_gpu(model)
+                elif args.offload_inactive_dit:
                     model.to(accelerator.device, non_blocking=True)
                     synchronize_device(accelerator.device)
 


### PR DESCRIPTION
## Summary

Adds an env-var-gated **dual-GPU model-parallel** path for **FLUX.2, Wan 2.2, and HunyuanVideo** LoRA training. Splits the transformer blocks at the midpoint across `cuda:0`/`cuda:1`, letting users train on pairs of 24+ GB consumer GPUs (2× RTX 3090 / 4090 / 5090) where the single-GPU path WDDM-thrashes or doesn't fit.

Off by default — no behavior change unless `FLUX2_DUAL_GPU=true` (FLUX.2), `WAN_DUAL_GPU=true` (Wan 2.2), or `HV_DUAL_GPU=true` (HunyuanVideo) is set.

> Originally filed as FLUX.2-only. Wan 2.2 and HunyuanVideo support are folded into the same PR because all three ports edit the same shared infrastructure (`networks/lora.py`, `hv_train_network.py`) — keeping them as separate PRs would guarantee merge conflicts. The dual-GPU machinery is genuinely shared; this PR is the per-trainer unit of "does musubi-tuner support dual-GPU model-parallel".

## What changed

### FLUX.2
- `src/musubi_tuner/flux_2/flux2_dual_gpu.py` (new): ~200 LOC helper. Distributes `Flux2Transformer2DModel.single_transformer_blocks`, registers per-block forward pre-hooks (every cuda:1 block, not just the boundary, because FLUX.2's forward passes loop-level constants `temb_mod_params` / `image_rotary_emb` to each block), wraps the split forward in `torch.amp.autocast(cuda, bf16)`, tuple-aware boundary transfer for `single_block_mod`.
- `src/musubi_tuner/flux_2/flux2_models.py`: integration hook.

### Wan 2.2
- `src/musubi_tuner/wan/wan_dual_gpu.py` (new): ~290 LOC helper. Distributes the vendored `WanModel` — `patch_embedding` / `text_embedding` / `time_embedding` / `time_projection` / `img_emb` + `blocks[:split_at]` + `head` on cuda:0, `blocks[split_at:]` on cuda:1. `freqs` and the `freqs_fhw` cache are plain tensor attributes (`WanModel` deliberately avoids `register_buffer` to keep dtype stable across `.to()`), so they're moved to cuda:0 explicitly. Split-aware forward replaces `WanModel.forward`: `WanModel` builds one `kwargs` dict and reuses it for every `block(x, **kwargs)` call, so a single PCIe boundary crossing at `blocks[split_at]` (bridge `x` + the shared `kwargs` dict to cuda:1) feeds all downstream blocks — no per-block hooks needed. `enable_wan_dual_gpu` is idempotent (safe after an A14B high/low expert swap); guards against `<2` CUDA devices and `--blocks_to_swap` (mutually exclusive with the split).
- `src/musubi_tuner/wan/modules/model.py`: `move_to_device_except_swap_blocks()` early-returns through `enable_wan_dual_gpu` when `WAN_DUAL_GPU=true`.
- `src/musubi_tuner/wan_train_network.py`: `load_transformer()` fail-fast `<2`-GPU guard before the slow checkpoint load.

### HunyuanVideo
- `src/musubi_tuner/hunyuan_video_dual_gpu.py` (new): ~327 LOC helper. `hv_train_network.py` is musubi-tuner's native trainer (the `NetworkTrainer` base the FLUX.2 / Wan trainers subclass), and HunyuanVideo's `HYVideoDiffusionTransformer` has a double-stream + single-stream structure closer to FLUX.2 than Wan. `enable_hv_dual_gpu` distributes input projections / embedders + all 20 `double_blocks` + `single_blocks[:split_at]` on cuda:0, `single_blocks[split_at:]` + `final_layer` on cuda:1 (default `split_at = len(single_blocks)//2 = 20`). Single-boundary forward replacement: the `double_blocks` loop runs entirely on cuda:0, then after `x = torch.cat((img, txt), 1)` the `single_blocks` loop inserts one cuda:1 boundary — `_bridge_block_args` recurses the per-block positional arg lists (handles the `freqs_cis` tuple). Fewer gotchas than Wan: RoPE is passed as forward args (not a plain model attribute), and the two text encoders are pre-cached + `del`'d before the training loop, so no `text_encoder_to` handling is needed. Guards against `<2` CUDA devices and `--blocks_to_swap`.
- `src/musubi_tuner/hunyuan_model/models.py`: `move_to_device_except_swap_blocks()` early-returns through `enable_hv_dual_gpu` when `HV_DUAL_GPU=true`.

### Shared infrastructure (touched by both)
- `src/musubi_tuner/hv_train_network.py`: three integration-point edits, each gated on `FLUX2_DUAL_GPU` / `WAN_DUAL_GPU` / `HV_DUAL_GPU` — DDP bypass (skip `InitProcessGroupKwargs`), CPU loading device (so the large bf16 transformer doesn't pre-allocate on cuda:0 before the split), `device_placement=[False]` branch in `accelerator.prepare`.
- `src/musubi_tuner/networks/lora.py`: `LoRAModule.apply_to` snapshots the wrapped layer's device; `LoRAModule.forward` inline-pins LoRA params to the wrapped layer's device, gated on any of the three env vars. The bound-method indirection in `apply_to` (`self.org_module.forward = self.forward`) makes instance-level monkey-patching unreliable, so the pin runs inline. The inline pin also lazily re-places LoRA params after a Wan 2.2 A14B high/low expert state-dict swap. A flux2-gated eager `route_loras_to_wrapped_devices` pass remains for the FLUX.2 path.

## Validation

Both ports validated end-to-end on 2× RTX 5090:

**FLUX.2** — sumi v8 (32 imgs, 512²), `--fp8_base --fp8_scaled --gradient_checkpointing`, rank 32:
- 10/10 steps, loss 0.526 → 0.545 monotonic, **2.22 s/it sustained**
- Distribution: 20.7 GB cuda:0 / 12.6 GB cuda:1 after fp8 weight-only quant

**Wan 2.2** — T2V-A14B, `--task t2v-A14B --fp8_base --network_module networks.lora_wan`, rank 16:
- single-expert: `distributed 40 blocks across cuda:0/cuda:1 (20/20)`, 10/10 steps, ~1.0–1.6 it/s, loss stable
- dual-expert (`--dit` + `--dit_high_noise` + `--timestep_boundary`): i2v-A14B, 20 steps, 3 distribution events logged (1 initial + 2 swap-driven re-distributes), checkpoint saved

**HunyuanVideo** — `--fp8_base --network_module networks.lora`, rank 16:
- `enable_hv_dual_gpu` log: `distributed 20 double + 40 single blocks (cuda:0: 20 double + 20 single; cuda:1: 20 single + final_layer)`
- 20/20 steps, **~1.30 it/s**, avr_loss 0.155 → 0.217, checkpoint saved

## Context

This dual-GPU distribution shape has been validated across multiple FLUX.2 LoRA trainers (ai-toolkit, musubi-tuner, OneTrainer, DiffSynth-Studio) and Wan 2.2 + LTX-2 + Qwen-Image (ai-toolkit) and Wan 2.2 + HunyuanVideo (musubi-tuner). Cross-trainer write-up: https://github.com/genno-whittlery/flux2-dual-gpu-lora — musubi-tuner porting walkthrough: https://github.com/genno-whittlery/flux2-dual-gpu-lora/blob/main/docs/porting-musubi-tuner.md

## Test plan
- [x] FLUX.2 sumi v8 10-step smoke on 2× RTX 5090, fp8 base+scaled, gradient checkpointing, rank 32 — loss monotonic, checkpoint saves
- [x] Wan 2.2 T2V-A14B 10-step smoke on 2× RTX 5090, fp8 base, rank 16 — 40 blocks split 20/20, loss stable, checkpoint saves
- [x] HunyuanVideo 20-step smoke on 2× RTX 5090, fp8 base, rank 16 — 20 double + 40 single blocks distributed, loss stable, checkpoint saves
- [x] single-GPU path unchanged (neither env var set → same `hv_train_network.py` code path)
- [ ] cross-GPU-vendor validation (2× RTX 3090, 2× RTX 4090) — pending
- [x] Wan 2.2 A14B dual-expert path (`--dit` + `--dit_high_noise` + `--timestep_boundary`) — validated; the swap re-distributes via an idempotent `enable_wan_dual_gpu` + dtype-fixup in `swap_high_low_weights`
