### PR TITLE
Fused QKNorm + RoPE and packed QKV

### DIFF
--- a/notes/2026-06-10-triton-reference-f32.md
+++ b/notes/2026-06-10-triton-reference-f32.md
@@ -1,0 +1,92 @@
+# Triton fused norm+rope: reference path diverged from original (2026-06-10)
+
+Branch: `packed`. Files: `src/musubi_tuner/kernels/fused_norm_rope.py`,
+`tests/test_packed_vs_original.py`, `tests/test_fused_norm_rope.py`,
+`tests/test_fused_norm_rope_gradients.py`.
+
+## Context
+
+The `packed` branch adds a fused QK-norm + RoPE Triton kernel for FLUX.2
+(`SingleStreamBlock` / `DoubleStreamBlock` in `flux2_models.py`). The kernel has
+a pure-PyTorch "reference" that doubles as:
+
+1. the **production fallback** (no Triton, `MUSUBI_DISABLE_TRITON=1`, or CPU tensors), and
+2. the **test oracle** for the Triton kernel.
+
+## The bug
+
+Commit `a329d5e` ("Simplify RMSNorm: remove intermediate dtype casts") changed
+the reference to compute RMSNorm entirely in float32:
+
+```python
+x = x * rrms * weight.float()   # all fp32
+```
+
+But `main`'s original RMSNorm rounds back to the input dtype **before** the
+scale multiply, and QKNorm then casts again:
+
+```python
+# RMSNorm.forward
+return (x.float() * rrms).to(x_dtype) * self.scale
+# QKNorm.forward
+return q.to(v), k.to(v)
+```
+
+So the fallback no longer matched `main`'s numerics in bf16 (an extra bf16
+rounding of the normalized tensor before/at the scale multiply was dropped). The
+RoPE math itself was fine and equivalent.
+
+Two extra problems made this hard to see:
+
+- `reference_norm_rope`'s docstring still **claimed** it matched the cast path.
+- The test helper `_original_path._rmsnorm` in `test_packed_vs_original.py` had
+  *also* been changed to the simplified fp32 math, so the "reference vs original"
+  tests were actually "simplified vs simplified" — they documented a bf16 "gap"
+  that mostly wasn't `main`'s.
+
+## Decision
+
+- The **fused Triton kernel stays fp32** (unchanged) — this is the desired,
+  more-accurate path matching the TensorRT-LLM formulation.
+- The **reference / fallback must be byte-identical to `main`** so that turning
+  Triton off reproduces original behavior exactly.
+- Consequence accepted: with the fallback now bf16-faithful and the kernel fp32,
+  the kernel no longer equals its old reference. So the kernel needs a separate
+  fp32 oracle for tests.
+
+## Changes
+
+`kernels/fused_norm_rope.py`
+- `reference_norm_rope` / `reference_packed_qk_norm_rope` → reproduce `main`
+  exactly: `(x.float()*rrms).to(orig_dtype) * weight`, then `.to(orig_dtype)`
+  (QKNorm `.to(v)`), then RoPE in float32, then cast back. Docstring corrected.
+- Added `reference_norm_rope_fp32` / `reference_packed_qk_norm_rope_fp32` —
+  float32-throughout oracle that matches the fused kernel. Use these to verify
+  the kernel; use the non-`_fp32` ones as the production fallback.
+
+Tests
+- `test_packed_vs_original.py`: fixed `_original_path._rmsnorm` to `main`'s real
+  `(x*rrms).to(dtype)*scale`; added `_reference_fp32_path`; tightened the bf16
+  forward/backward "gap" tests to assert exact equality (they now match);
+  pointed the fused-vs-reference CUDA tests at the fp32 oracle.
+- `test_fused_norm_rope.py` and `test_fused_norm_rope_gradients.py`: kernel
+  comparison tests now use the `_fp32` oracle instead of the bf16-faithful
+  reference.
+
+## Verification
+
+`MUSUBI_DISABLE_TRITON=1 uv run --extra cu132 pytest tests/test_packed_vs_original.py tests/test_fused_norm_rope.py tests/test_fused_norm_rope_gradients.py`
+
+- 21 CPU tests pass; 31 Triton/CUDA tests skip (no GPU on this machine).
+- Forward gap reference-vs-original = **0.0 exactly** in both fp32 and bf16.
+- Backward gap: 0.0 for qkv; ~1e-5 for q/k scale (float accumulation order from
+  the `[B,H,L,D]` vs `[B,L,H,D]` layout in `apply_rope`'s reduction — not a
+  precision-path difference).
+
+## Follow-ups
+
+- The Triton/CUDA tests were rewired to the fp32 oracle but not executed here —
+  run them on a CUDA box to confirm.
+- Be aware: enabling vs. disabling fusion now gives slightly different numerics
+  (fp32 kernel vs bf16-faithful fallback). This is intentional per the decision
+  above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ cu130 = [
     "torch>=2.9.1",
     "torchvision>=0.24.1",
 ]
+cu132 = [
+    "torch>=2.12",
+    "torchvision>=0.27",
+]
 gui = [
     "gradio>=4.0.0, <6.0.0",
 ]
@@ -49,6 +53,7 @@ conflicts = [
     { extra = "cu124" },
     { extra = "cu128" },
     { extra = "cu130" },
+    { extra = "cu132" },
   ],
 ]
 
@@ -70,11 +75,13 @@ torch = [
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
   { index = "pytorch-cu130", extra = "cu130" },
+  { index = "pytorch-cu132", extra = "cu132" },
 ]
 torchvision = [
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
   { index = "pytorch-cu130", extra = "cu130" },
+  { index = "pytorch-cu132", extra = "cu132" },
 ]
 
 [[tool.uv.index]]
@@ -90,6 +97,11 @@ explicit = true
 [[tool.uv.index]]
 name = "pytorch-cu130"
 url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu132"
+url = "https://download.pytorch.org/whl/cu132"
 explicit = true
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
   "tensorboard",
   "prompt-toolkit==3.0.51",
   "ruff>=0.12.10",
+  "pytest",
 ]
 
 [build-system]

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -11,7 +11,7 @@ from torch.utils.checkpoint import checkpoint
 from musubi_tuner.modules.attention import AttentionParams
 from musubi_tuner.modules.custom_offloading_utils import ModelOffloader
 from musubi_tuner.modules.attention import attention as unified_attention
-from musubi_tuner.kernels.fused_norm_rope import fused_qkv_norm_rope, extract_cos_sin
+from musubi_tuner.kernels.fused_norm_rope import fused_packed_qk_norm_rope, extract_cos_sin
 
 from musubi_tuner.utils.model_utils import create_cpu_offloading_wrapper
 
@@ -757,7 +757,7 @@ class SingleStreamBlock(nn.Module):
         qkv = qkv.contiguous().reshape(*qkv.shape[:2], 3, self.num_heads, -1)  # [B, L, 3, H, D]
         cos, sin = extract_cos_sin(pe)
         del pe
-        qkv = fused_qkv_norm_rope(qkv, self.norm.query_norm.scale, self.norm.key_norm.scale, cos, sin)
+        qkv = fused_packed_qk_norm_rope(qkv, self.norm.query_norm.scale, self.norm.key_norm.scale, cos, sin)
 
         attn = unified_attention(qkv, attn_params=attn_params)
         del qkv
@@ -844,7 +844,7 @@ class DoubleStreamBlock(nn.Module):
         img_qkv = img_qkv.contiguous().reshape(*img_qkv.shape[:2], 3, self.num_heads, -1)  # [B, L_img, 3, H, D]
         img_cos, img_sin = extract_cos_sin(pe)
         del pe
-        img_qkv = fused_qkv_norm_rope(img_qkv, self.img_attn.norm.query_norm.scale, self.img_attn.norm.key_norm.scale, img_cos, img_sin)
+        img_qkv = fused_packed_qk_norm_rope(img_qkv, self.img_attn.norm.query_norm.scale, self.img_attn.norm.key_norm.scale, img_cos, img_sin)
 
         # prepare txt for attention
         txt_modulated = self.txt_norm1(txt)
@@ -855,7 +855,7 @@ class DoubleStreamBlock(nn.Module):
         txt_qkv = txt_qkv.contiguous().reshape(*txt_qkv.shape[:2], 3, self.num_heads, -1)  # [B, L_txt, 3, H, D]
         txt_cos, txt_sin = extract_cos_sin(pe_ctx)
         del pe_ctx
-        txt_qkv = fused_qkv_norm_rope(txt_qkv, self.txt_attn.norm.query_norm.scale, self.txt_attn.norm.key_norm.scale, txt_cos, txt_sin)
+        txt_qkv = fused_packed_qk_norm_rope(txt_qkv, self.txt_attn.norm.query_norm.scale, self.txt_attn.norm.key_norm.scale, txt_cos, txt_sin)
 
         # Concatenate packed QKV along sequence dim, then run attention once
         txt_len = txt_qkv.shape[1]

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -11,6 +11,7 @@ from torch.utils.checkpoint import checkpoint
 from musubi_tuner.modules.attention import AttentionParams
 from musubi_tuner.modules.custom_offloading_utils import ModelOffloader
 from musubi_tuner.modules.attention import attention as unified_attention
+from musubi_tuner.kernels.fused_norm_rope import fused_qkv_norm_rope, extract_cos_sin
 
 from musubi_tuner.utils.model_utils import create_cpu_offloading_wrapper
 
@@ -752,14 +753,14 @@ class SingleStreamBlock(nn.Module):
 
         qkv, mlp = torch.split(self.linear1(x_mod), [3 * self.hidden_size, self.mlp_hidden_dim * self.mlp_mult_factor], dim=-1)
 
-        q, k, v = rearrange(qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
-        del qkv
-        q, k = self.norm(q, k, v)
+        # torch.split returns a non-contiguous view; contiguous() makes a compact copy
+        qkv = qkv.contiguous().reshape(*qkv.shape[:2], 3, self.num_heads, -1)  # [B, L, 3, H, D]
+        cos, sin = extract_cos_sin(pe)
+        del pe
+        qkv = fused_qkv_norm_rope(qkv, self.norm.query_norm.scale, self.norm.key_norm.scale, cos, sin)
 
-        qkv_list = [q, k, v]
-        del q, k, v
-        attn = attention(qkv_list, pe, attn_params)
-        del qkv_list, pe
+        attn = unified_attention(qkv, attn_params=attn_params)
+        del qkv
 
         # compute activation in mlp stream, cat again and run second linear layer
         output = self.linear2(torch.cat((attn, self.mlp_act(mlp)), 2))
@@ -840,9 +841,10 @@ class DoubleStreamBlock(nn.Module):
 
         img_qkv = self.img_attn.qkv(img_modulated)
         del img_modulated
-        img_q, img_k, img_v = rearrange(img_qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
-        del img_qkv
-        img_q, img_k = self.img_attn.norm(img_q, img_k, img_v)
+        img_qkv = img_qkv.contiguous().reshape(*img_qkv.shape[:2], 3, self.num_heads, -1)  # [B, L_img, 3, H, D]
+        img_cos, img_sin = extract_cos_sin(pe)
+        del pe
+        img_qkv = fused_qkv_norm_rope(img_qkv, self.img_attn.norm.query_norm.scale, self.img_attn.norm.key_norm.scale, img_cos, img_sin)
 
         # prepare txt for attention
         txt_modulated = self.txt_norm1(txt)
@@ -850,24 +852,18 @@ class DoubleStreamBlock(nn.Module):
         del txt_mod1_scale, txt_mod1_shift
         txt_qkv = self.txt_attn.qkv(txt_modulated)
         del txt_modulated
-        txt_q, txt_k, txt_v = rearrange(txt_qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
-        del txt_qkv
-        txt_q, txt_k = self.txt_attn.norm(txt_q, txt_k, txt_v)
-
-        txt_len = txt_q.shape[2]
-        q = torch.cat((txt_q, img_q), dim=2)
-        del txt_q, img_q
-        k = torch.cat((txt_k, img_k), dim=2)
-        del txt_k, img_k
-        v = torch.cat((txt_v, img_v), dim=2)
-        del txt_v, img_v
-
-        pe = torch.cat((pe_ctx, pe), dim=2)
+        txt_qkv = txt_qkv.contiguous().reshape(*txt_qkv.shape[:2], 3, self.num_heads, -1)  # [B, L_txt, 3, H, D]
+        txt_cos, txt_sin = extract_cos_sin(pe_ctx)
         del pe_ctx
-        qkv_list = [q, k, v]
-        del q, k, v
-        attn = attention(qkv_list, pe, attn_params)
-        del qkv_list, pe
+        txt_qkv = fused_qkv_norm_rope(txt_qkv, self.txt_attn.norm.query_norm.scale, self.txt_attn.norm.key_norm.scale, txt_cos, txt_sin)
+
+        # Concatenate packed QKV along sequence dim, then run attention once
+        txt_len = txt_qkv.shape[1]
+        qkv = torch.cat((txt_qkv, img_qkv), dim=1)  # [B, L_total, 3, H, D]
+        del txt_qkv, img_qkv
+
+        attn = unified_attention(qkv, attn_params=attn_params)
+        del qkv
         txt_attn, img_attn = attn[:, :txt_len], attn[:, txt_len:]
         del attn
 

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -24,12 +24,21 @@ def reference_norm_rope(
     sin: torch.Tensor,     # [B, L, D//2]
     eps: float = 1e-6,
 ) -> torch.Tensor:
-    """Reference: RMSNorm then RoPE, pure PyTorch (no Triton)."""
+    """Reference: RMSNorm then RoPE, pure PyTorch (no Triton).
+
+    Matches the original Flux2 precision path:
+      1. RMSNorm: (x * rrms).to(x_dtype) * weight  — intermediate cast
+      2. QKNorm .to(v): cast to input dtype
+      3. RoPE in float32, output cast to input dtype
+    """
     orig_dtype = x.dtype
     x = x.float()
     # RMSNorm over last dim
     rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
-    x = x * rrms * weight.float()
+    # Match original RMSNorm: (x * rrms).to(x_dtype) * weight
+    x = (x * rrms).to(orig_dtype) * weight.float()
+    # Match QKNorm .to(v) cast
+    x = x.to(orig_dtype).float()
     # RoPE: reshape to expose pairs
     x = x.reshape(*x.shape[:-1], -1, 2)   # [B, L, H, D//2, 2]
     x1, x2 = x[..., 0], x[..., 1]         # each [B, L, H, D//2]
@@ -111,17 +120,27 @@ def _rmsnorm_backward(
     weight: torch.Tensor,  # [D] float32
     dnormed: torch.Tensor, # [B, L, H, D] float32 — grad w.r.t. RMSNorm output
     eps: float,
+    input_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Backward through RMSNorm: y = x * rsqrt(mean(x²) + eps) * w.
+
+    When ``input_dtype`` is provided, the dw computation uses
+    ``(x * rrms).to(input_dtype)`` to match the original RMSNorm which
+    quantizes before the scale multiply: ``(x * rrms).to(x_dtype) * w``.
 
     Returns (dx, dw).
     """
     D = x.shape[-1]
     rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)  # [B, L, H, 1]
-    # dw: sum over (B, L, H) of x * rrms * dnormed
-    dw = (dnormed * x * rrms).sum(dim=(0, 1, 2))  # [D]
-    # dx: standard RMSNorm gradient
+    normed = x * rrms
+    # dw: match original RMSNorm's intermediate cast for weight gradient
+    if input_dtype is not None:
+        normed_for_dw = normed.to(input_dtype).float()
+    else:
+        normed_for_dw = normed
+    dw = (dnormed * normed_for_dw).sum(dim=(0, 1, 2))  # [D]
+    # dx: standard RMSNorm gradient (STE through casts doesn't change dx)
     dot = (dnormed * weight * x).sum(-1, keepdim=True)  # [B, L, H, 1]
     dx = rrms * (dnormed * weight - (rrms**2 / D) * x * dot)
     return dx, dw
@@ -138,6 +157,7 @@ if HAS_TRITON:
         H, L, D, D2,        # D2 = D // 2
         eps,
         BLOCK_D2: tl.constexpr,   # power of 2, >= D2
+        INPUT_DTYPE: tl.constexpr,  # input dtype for intermediate casts
     ):
         pid = tl.program_id(0)
         h = pid % H
@@ -162,8 +182,12 @@ if HAS_TRITON:
         w1 = tl.load(w_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
         w2 = tl.load(w_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
 
-        n1 = x1 * rrms * w1
-        n2 = x2 * rrms * w2
+        # Match original RMSNorm: (x * rrms).to(x_dtype) * weight
+        n1 = (x1 * rrms).to(INPUT_DTYPE).to(tl.float32) * w1
+        n2 = (x2 * rrms).to(INPUT_DTYPE).to(tl.float32) * w2
+        # Match QKNorm .to(v) cast
+        n1 = n1.to(INPUT_DTYPE).to(tl.float32)
+        n2 = n2.to(INPUT_DTYPE).to(tl.float32)
 
         # RoPE
         c = tl.load(cos_ptr + cos_base + cols, mask=mask, other=1.0).to(tl.float32)
@@ -184,6 +208,7 @@ if HAS_TRITON:
         H, L, D, D2,        # D2 = D // 2
         eps,
         BLOCK_D2: tl.constexpr,   # power of 2, >= D2
+        INPUT_DTYPE: tl.constexpr,  # input dtype for intermediate casts
     ):
         """One program per (b, l, h) row. Processes Q and K, copies V.
 
@@ -197,9 +222,9 @@ if HAS_TRITON:
 
         # Base offsets into [B, L, 3, H, D]
         row_base  = b * (L * 3 * H * D) + l * (3 * H * D) + h * D
-        q_base    = row_base + 0 * H * D   # K index 0
+        q_base    = row_base + 0 * H * D   # Q index 0
         k_base    = row_base + 1 * H * D   # K index 1
-        v_base    = row_base + 2 * H * D   # K index 2
+        v_base    = row_base + 2 * H * D   # V index 2
         cos_base  = b * (L * D2) + l * D2
 
         cols = tl.arange(0, BLOCK_D2)
@@ -216,8 +241,11 @@ if HAS_TRITON:
         rrms_q = tl.rsqrt(ss_q / D + eps)
         wq1 = tl.load(wq_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
         wq2 = tl.load(wq_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
-        nq1 = q1 * rrms_q * wq1
-        nq2 = q2 * rrms_q * wq2
+        # Match original RMSNorm: (x * rrms).to(x_dtype) * weight, then .to(v) cast
+        nq1 = (q1 * rrms_q).to(INPUT_DTYPE).to(tl.float32) * wq1
+        nq2 = (q2 * rrms_q).to(INPUT_DTYPE).to(tl.float32) * wq2
+        nq1 = nq1.to(INPUT_DTYPE).to(tl.float32)
+        nq2 = nq2.to(INPUT_DTYPE).to(tl.float32)
         oq1 = c * nq1 - s * nq2
         oq2 = s * nq1 + c * nq2
         tl.store(out_ptr + q_base + cols * 2,     oq1, mask=mask)
@@ -230,8 +258,11 @@ if HAS_TRITON:
         rrms_k = tl.rsqrt(ss_k / D + eps)
         wk1 = tl.load(wk_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
         wk2 = tl.load(wk_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
-        nk1 = k1 * rrms_k * wk1
-        nk2 = k2 * rrms_k * wk2
+        # Match original RMSNorm: (x * rrms).to(x_dtype) * weight, then .to(v) cast
+        nk1 = (k1 * rrms_k).to(INPUT_DTYPE).to(tl.float32) * wk1
+        nk2 = (k2 * rrms_k).to(INPUT_DTYPE).to(tl.float32) * wk2
+        nk1 = nk1.to(INPUT_DTYPE).to(tl.float32)
+        nk2 = nk2.to(INPUT_DTYPE).to(tl.float32)
         ok1 = c * nk1 - s * nk2
         ok2 = s * nk1 + c * nk2
         tl.store(out_ptr + k_base + cols * 2,     ok1, mask=mask)
@@ -248,7 +279,19 @@ if HAS_TRITON:
 # autograd.Function wrappers (Triton forward, PyTorch backward)
 # ---------------------------------------------------------------------------
 
+_TORCH_TO_TRITON_DTYPE = {
+    torch.float32: "fp32",
+    torch.float16: "fp16",
+    torch.bfloat16: "bf16",
+}
+
 if HAS_TRITON:
+    _TRITON_DTYPE_MAP = {
+        "fp32": tl.float32,
+        "fp16": tl.float16,
+        "bf16": tl.bfloat16,
+    }
+
     class _FusedNormRopeFunction(torch.autograd.Function):
         @staticmethod
         def forward(ctx, x, weight, cos, sin, eps):
@@ -260,10 +303,12 @@ if HAS_TRITON:
             D2 = D // 2
             BLOCK_D2 = triton.next_power_of_2(D2)
             out_f32 = torch.empty(B, L, H, D, dtype=torch.float32, device=x.device)
+            triton_dtype = _TRITON_DTYPE_MAP[_TORCH_TO_TRITON_DTYPE[x.dtype]]
             fused_norm_rope_kernel[(B * L * H,)](
                 x, out_f32, weight.float(), cos, sin,
                 H, L, D, D2, eps,
                 BLOCK_D2=BLOCK_D2,
+                INPUT_DTYPE=triton_dtype,
             )
             return out_f32.to(x.dtype)
 
@@ -271,17 +316,19 @@ if HAS_TRITON:
         def backward(ctx, grad_output):
             x, weight, cos, sin = ctx.saved_tensors
             eps = ctx.eps
+            input_dtype = x.dtype
 
-            x_f = x.float()
             dout_f = grad_output.float()
 
             # RoPE backward (transpose rotation)
             dnormed = _rope_backward(dout_f, cos, sin)
+            # Match QKNorm .to(v) backward: gradient quantized through bf16 cast
+            dnormed = dnormed.to(input_dtype).float()
 
-            # RMSNorm backward
-            dx_f, dw_f = _rmsnorm_backward(x_f, weight.float(), dnormed, eps)
+            # RMSNorm backward (pass input_dtype for matching intermediate casts)
+            dx_f, dw_f = _rmsnorm_backward(x.float(), weight.float(), dnormed, eps, input_dtype=input_dtype)
 
-            grad_x = dx_f.to(x.dtype) if ctx.needs_input_grad[0] else None
+            grad_x = dx_f.to(input_dtype) if ctx.needs_input_grad[0] else None
             grad_w = dw_f.to(weight.dtype) if ctx.needs_input_grad[1] else None
             return grad_x, grad_w, None, None, None  # cos, sin, eps: no grad
 
@@ -296,10 +343,12 @@ if HAS_TRITON:
             D2 = D // 2
             BLOCK_D2 = triton.next_power_of_2(D2)
             out_f32 = torch.empty(B, L, 3, H, D, dtype=torch.float32, device=qkv.device)
+            triton_dtype = _TRITON_DTYPE_MAP[_TORCH_TO_TRITON_DTYPE[qkv.dtype]]
             fused_qkv_norm_rope_kernel[(B * L * H,)](
                 qkv, out_f32, q_weight.float(), k_weight.float(), cos, sin,
                 H, L, D, D2, eps,
                 BLOCK_D2=BLOCK_D2,
+                INPUT_DTYPE=triton_dtype,
             )
             return out_f32.to(qkv.dtype)
 
@@ -307,6 +356,7 @@ if HAS_TRITON:
         def backward(ctx, grad_output):
             qkv, q_weight, k_weight, cos, sin = ctx.saved_tensors
             eps = ctx.eps
+            input_dtype = qkv.dtype
 
             need_grad_qkv = ctx.needs_input_grad[0]
             need_grad_wq  = ctx.needs_input_grad[1]
@@ -323,7 +373,9 @@ if HAS_TRITON:
                 q_f    = qkv[:, :, 0].float()          # [B, L, H, D] fp32
                 dout_q = grad_output[:, :, 0].float()
                 dnormed_q = _rope_backward(dout_q, cos, sin)
-                dq_f, dw_q_f = _rmsnorm_backward(q_f, q_weight.float(), dnormed_q, eps)
+                # Match QKNorm .to(v) backward: gradient quantized through input dtype cast
+                dnormed_q = dnormed_q.to(input_dtype).float()
+                dq_f, dw_q_f = _rmsnorm_backward(q_f, q_weight.float(), dnormed_q, eps, input_dtype=input_dtype)
                 if need_grad_wq:
                     grad_wq = dw_q_f.to(q_weight.dtype)
 
@@ -331,7 +383,9 @@ if HAS_TRITON:
                 k_f    = qkv[:, :, 1].float()
                 dout_k = grad_output[:, :, 1].float()
                 dnormed_k = _rope_backward(dout_k, cos, sin)
-                dk_f, dw_k_f = _rmsnorm_backward(k_f, k_weight.float(), dnormed_k, eps)
+                # Match QKNorm .to(v) backward: gradient quantized through input dtype cast
+                dnormed_k = dnormed_k.to(input_dtype).float()
+                dk_f, dw_k_f = _rmsnorm_backward(k_f, k_weight.float(), dnormed_k, eps, input_dtype=input_dtype)
                 if need_grad_wk:
                     grad_wk = dw_k_f.to(k_weight.dtype)
 

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -10,15 +10,11 @@ logger = logging.getLogger(__name__)
 try:
     import triton
     import triton.language as tl
-    if os.environ.get("MUSUBI_DISABLE_TRITON", "0") == "1":
-        HAS_TRITON = False
-        logger.info("Triton disabled (MUSUBI_DISABLE_TRITON=1) — using PyTorch reference")
-    else:
-        HAS_TRITON = True
-        logger.info("Triton fused kernel enabled")
+    HAS_TRITON = os.environ.get("MUSUBI_DISABLE_TRITON", "0") != "1"
 except ImportError:
     HAS_TRITON = False
-    logger.info("Triton not installed — using PyTorch reference")
+
+_kernel_logged = False
 
 import torch
 
@@ -398,6 +394,17 @@ def fused_norm_rope(
     torch.Tensor
         Same shape and dtype as *x*.
     """
+    global _kernel_logged
+    if not _kernel_logged:
+        _kernel_logged = True
+        if HAS_TRITON and x.is_cuda:
+            logger.info("QKNorm+RoPE: using Triton fused kernel")
+        elif not HAS_TRITON:
+            reason = "MUSUBI_DISABLE_TRITON=1" if os.environ.get("MUSUBI_DISABLE_TRITON") == "1" else "Triton not installed"
+            logger.info("QKNorm+RoPE: using PyTorch reference (%s)", reason)
+        else:
+            logger.info("QKNorm+RoPE: using PyTorch reference (non-CUDA tensor)")
+
     if not HAS_TRITON or not x.is_cuda:
         return reference_norm_rope(x, weight, cos, sin, eps)
 
@@ -447,6 +454,17 @@ def fused_packed_qk_norm_rope(
         Shape ``[B, L, 3, H, D]``, same dtype as *qkv*.  Q and K are
         normalised and rotated; V is unchanged.
     """
+    global _kernel_logged
+    if not _kernel_logged:
+        _kernel_logged = True
+        if HAS_TRITON and qkv.is_cuda:
+            logger.info("QKNorm+RoPE: using Triton fused kernel")
+        elif not HAS_TRITON:
+            reason = "MUSUBI_DISABLE_TRITON=1" if os.environ.get("MUSUBI_DISABLE_TRITON") == "1" else "Triton not installed"
+            logger.info("QKNorm+RoPE: using PyTorch reference (%s)", reason)
+        else:
+            logger.info("QKNorm+RoPE: using PyTorch reference (non-CUDA tensor)")
+
     if not HAS_TRITON or not qkv.is_cuda:
         return reference_packed_qk_norm_rope(qkv, q_weight, k_weight, cos, sin, eps)
 

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -31,21 +31,33 @@ def reference_norm_rope(
     sin: torch.Tensor,     # [B, L, D//2]
     eps: float = 1e-6,
 ) -> torch.Tensor:
-    """Reference: RMSNorm then RoPE, pure PyTorch (no Triton).
+    """Reference RMSNorm + RoPE — byte-for-byte match of the original Flux2 path.
 
-    Matches the original Flux2 precision path:
-      1. RMSNorm: (x * rrms).to(x_dtype) * weight  — intermediate cast
-      2. QKNorm .to(v): cast to input dtype
-      3. RoPE in float32, output cast to input dtype
+    This is the production fallback used whenever the Triton kernel is
+    unavailable (Triton not installed, ``MUSUBI_DISABLE_TRITON=1``, or a
+    non-CUDA tensor), so it reproduces the *exact* numerics of the pre-fusion
+    code in ``flux2_models.py``:
+
+      1. ``RMSNorm.forward``: ``(x.float() * rrms).to(x_dtype) * scale`` — the
+         normalized value is rounded back to the input dtype **before** the
+         scale multiply.
+      2. ``QKNorm.forward``: ``.to(v)`` — cast to v's (the qkv) dtype.
+      3. ``apply_rope``: computed in float32, result ``type_as`` the input.
+
+    For the float32-throughout variant that matches the fused Triton kernel,
+    use :func:`reference_norm_rope_fp32`.
     """
     orig_dtype = x.dtype
-    x = x.float()
+    xf = x.float()
     # RMSNorm over last dim
-    rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
-    x = x * rrms * weight.float()
-    # RoPE: reshape to expose pairs
-    x = x.reshape(*x.shape[:-1], -1, 2)   # [B, L, H, D//2, 2]
-    x1, x2 = x[..., 0], x[..., 1]         # each [B, L, H, D//2]
+    rrms = torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps)
+    # Original RMSNorm: round to input dtype, then multiply by scale.
+    normed = (xf * rrms).to(orig_dtype) * weight
+    # Original QKNorm .to(v): cast to the qkv dtype.
+    normed = normed.to(orig_dtype)
+    # Original apply_rope: float32 compute, then cast back to input dtype.
+    nf = normed.float().reshape(*normed.shape[:-1], -1, 2)  # [B, L, H, D//2, 2]
+    x1, x2 = nf[..., 0], nf[..., 1]       # each [B, L, H, D//2]
     # broadcast cos/sin over H dim: [B, L, 1, D//2]
     c = cos.unsqueeze(2).float()
     s = sin.unsqueeze(2).float()
@@ -63,9 +75,65 @@ def reference_packed_qk_norm_rope(
     sin: torch.Tensor,      # [B, L, D//2]
     eps: float = 1e-6,
 ) -> torch.Tensor:
-    """Reference: packed QKV input — RMSNorm+RoPE on Q and K, V copied unchanged."""
+    """Packed QKV reference (production fallback) — matches the original Flux2
+    path exactly: RMSNorm+RoPE on Q and K, V copied unchanged.
+
+    See :func:`reference_norm_rope` for the precise precision path.  The fused
+    Triton kernel is verified against :func:`reference_packed_qk_norm_rope_fp32`
+    instead, since the kernel stays in float32 throughout.
+    """
     q = reference_norm_rope(qkv[:, :, 0], q_weight, cos, sin, eps)
     k = reference_norm_rope(qkv[:, :, 1], k_weight, cos, sin, eps)
+    v = qkv[:, :, 2].to(q.dtype)
+    return torch.stack([q, k, v], dim=2)
+
+
+# ---------------------------------------------------------------------------
+# Float32 oracle (matches the fused Triton kernel, NOT the original Flux2 path)
+# ---------------------------------------------------------------------------
+
+
+def reference_norm_rope_fp32(
+    x: torch.Tensor,       # [B, L, H, D]
+    weight: torch.Tensor,  # [D]
+    cos: torch.Tensor,     # [B, L, D//2]
+    sin: torch.Tensor,     # [B, L, D//2]
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Float32-throughout RMSNorm + RoPE — oracle for the fused Triton kernel.
+
+    Unlike :func:`reference_norm_rope` (which reproduces the original Flux2
+    intermediate dtype casts), this keeps RMSNorm and the scale multiply
+    entirely in float32 with no intermediate rounding, casting to the input
+    dtype only on the final output — exactly what the Triton kernel does.
+    Use this to verify the kernel; use :func:`reference_norm_rope` as the
+    production fallback.
+    """
+    orig_dtype = x.dtype
+    x = x.float()
+    rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    x = x * rrms * weight.float()
+    x = x.reshape(*x.shape[:-1], -1, 2)   # [B, L, H, D//2, 2]
+    x1, x2 = x[..., 0], x[..., 1]         # each [B, L, H, D//2]
+    c = cos.unsqueeze(2).float()
+    s = sin.unsqueeze(2).float()
+    o1 = c * x1 - s * x2
+    o2 = s * x1 + c * x2
+    out = torch.stack([o1, o2], dim=-1).reshape(*o1.shape[:-1], -1)  # [B,L,H,D]
+    return out.to(orig_dtype)
+
+
+def reference_packed_qk_norm_rope_fp32(
+    qkv: torch.Tensor,      # [B, L, 3, H, D]
+    q_weight: torch.Tensor, # [D]
+    k_weight: torch.Tensor, # [D]
+    cos: torch.Tensor,      # [B, L, D//2]
+    sin: torch.Tensor,      # [B, L, D//2]
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Float32 packed oracle for the fused kernel (see :func:`reference_norm_rope_fp32`)."""
+    q = reference_norm_rope_fp32(qkv[:, :, 0], q_weight, cos, sin, eps)
+    k = reference_norm_rope_fp32(qkv[:, :, 1], k_weight, cos, sin, eps)
     v = qkv[:, :, 2].to(q.dtype)
     return torch.stack([q, k, v], dim=2)
 

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 try:
     import triton
     import triton.language as tl
-    # MUSUBI_DISABLE_TRITON=1 forces the pure-PyTorch reference path for debugging
-    HAS_TRITON = os.environ.get("MUSUBI_DISABLE_TRITON", "0") != "1"
+    if os.environ.get("MUSUBI_DISABLE_TRITON", "0") == "1":
+        HAS_TRITON = False
+        logger.info("Triton disabled (MUSUBI_DISABLE_TRITON=1) — using PyTorch reference")
+    else:
+        HAS_TRITON = True
+        logger.info("Triton fused kernel enabled")
 except ImportError:
     HAS_TRITON = False
+    logger.info("Triton not installed — using PyTorch reference")
 
 import torch
 

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
+
 try:
     import triton
     import triton.language as tl
-    HAS_TRITON = True
+    # MUSUBI_DISABLE_TRITON=1 forces the pure-PyTorch reference path for debugging
+    HAS_TRITON = os.environ.get("MUSUBI_DISABLE_TRITON", "0") != "1"
 except ImportError:
     HAS_TRITON = False
 
@@ -139,6 +142,7 @@ if HAS_TRITON:
         H, L, D, D2,        # D2 = D // 2
         eps,
         BLOCK_D2: tl.constexpr,
+        STORE_DTYPE: tl.constexpr,
     ):
         pid = tl.program_id(0)
         h = pid % H
@@ -173,9 +177,8 @@ if HAS_TRITON:
         o1 = c * n1 - s * n2
         o2 = s * n1 + c * n2
 
-        # store interleaved pairs — cast back to float32; wrapper converts to original dtype
-        tl.store(out_ptr + x_base + cols * 2,     o1, mask=mask)
-        tl.store(out_ptr + x_base + cols * 2 + 1, o2, mask=mask)
+        tl.store(out_ptr + x_base + cols * 2,     o1.to(STORE_DTYPE), mask=mask)
+        tl.store(out_ptr + x_base + cols * 2 + 1, o2.to(STORE_DTYPE), mask=mask)
 
     @triton.jit
     def fused_packed_qk_norm_rope_kernel(
@@ -185,6 +188,7 @@ if HAS_TRITON:
         H, L, D, D2,        # D2 = D // 2
         eps,
         BLOCK_D2: tl.constexpr,
+        STORE_DTYPE: tl.constexpr,
     ):
         """One program per (b, l, h) row. Processes Q and K, copies V.
 
@@ -221,8 +225,8 @@ if HAS_TRITON:
         nq2 = q2 * rrms_q * wq2
         oq1 = c * nq1 - s * nq2
         oq2 = s * nq1 + c * nq2
-        tl.store(out_ptr + q_base + cols * 2,     oq1, mask=mask)
-        tl.store(out_ptr + q_base + cols * 2 + 1, oq2, mask=mask)
+        tl.store(out_ptr + q_base + cols * 2,     oq1.to(STORE_DTYPE), mask=mask)
+        tl.store(out_ptr + q_base + cols * 2 + 1, oq2.to(STORE_DTYPE), mask=mask)
 
         # --- Process K ---
         k1 = tl.load(qkv_ptr + k_base + cols * 2,     mask=mask, other=0.0).to(tl.float32)
@@ -235,8 +239,8 @@ if HAS_TRITON:
         nk2 = k2 * rrms_k * wk2
         ok1 = c * nk1 - s * nk2
         ok2 = s * nk1 + c * nk2
-        tl.store(out_ptr + k_base + cols * 2,     ok1, mask=mask)
-        tl.store(out_ptr + k_base + cols * 2 + 1, ok2, mask=mask)
+        tl.store(out_ptr + k_base + cols * 2,     ok1.to(STORE_DTYPE), mask=mask)
+        tl.store(out_ptr + k_base + cols * 2 + 1, ok2.to(STORE_DTYPE), mask=mask)
 
         # --- Copy V unchanged ---
         v1 = tl.load(qkv_ptr + v_base + cols * 2,     mask=mask, other=0.0)
@@ -260,13 +264,14 @@ if HAS_TRITON:
             B, L, H, D = x.shape
             D2 = D // 2
             BLOCK_D2 = triton.next_power_of_2(D2)
-            out_f32 = torch.empty(B, L, H, D, dtype=torch.float32, device=x.device)
+            out = torch.empty(B, L, H, D, dtype=x.dtype, device=x.device)
             fused_norm_rope_kernel[(B * L * H,)](
-                x, out_f32, weight.float(), cos, sin,
+                x, out, weight.float(), cos, sin,
                 H, L, D, D2, eps,
                 BLOCK_D2=BLOCK_D2,
+                STORE_DTYPE=tl.bfloat16 if x.dtype == torch.bfloat16 else tl.float16 if x.dtype == torch.float16 else tl.float32,
             )
-            return out_f32.to(x.dtype)
+            return out
 
         @staticmethod
         def backward(ctx, grad_output):
@@ -290,13 +295,14 @@ if HAS_TRITON:
             B, L, _, H, D = qkv.shape
             D2 = D // 2
             BLOCK_D2 = triton.next_power_of_2(D2)
-            out_f32 = torch.empty(B, L, 3, H, D, dtype=torch.float32, device=qkv.device)
+            out = torch.empty(B, L, 3, H, D, dtype=qkv.dtype, device=qkv.device)
             fused_packed_qk_norm_rope_kernel[(B * L * H,)](
-                qkv, out_f32, q_weight.float(), k_weight.float(), cos, sin,
+                qkv, out, q_weight.float(), k_weight.float(), cos, sin,
                 H, L, D, D2, eps,
                 BLOCK_D2=BLOCK_D2,
+                STORE_DTYPE=tl.bfloat16 if qkv.dtype == torch.bfloat16 else tl.float16 if qkv.dtype == torch.float16 else tl.float32,
             )
-            return out_f32.to(qkv.dtype)
+            return out
 
         @staticmethod
         def backward(ctx, grad_output):
@@ -313,15 +319,32 @@ if HAS_TRITON:
             dq_f     = None
             dk_f     = None
 
+            _nan_debug = os.environ.get("MUSUBI_NAN_DEBUG", "0") == "1"
+            if _nan_debug:
+                def _has_nan(t, label):
+                    if torch.isnan(t).any():
+                        print(f"[PackedQKNorm bwd] NaN in {label}  shape={tuple(t.shape)}")
+                        return True
+                    return False
+                _has_nan(grad_output[:, :, 0], "grad_output[Q]")
+                _has_nan(grad_output[:, :, 1], "grad_output[K]")
+                _has_nan(grad_output[:, :, 2], "grad_output[V]")
+                _has_nan(qkv[:, :, 0], "saved qkv[Q]")
+                _has_nan(qkv[:, :, 1], "saved qkv[K]")
+
             if need_grad_qkv or need_grad_wq:
                 dnormed_q = _rope_backward(grad_output[:, :, 0].float(), cos, sin)
+                if _nan_debug: _has_nan(dnormed_q, "dnormed_q (after rope bwd)")
                 dq_f, dw_q_f = _rmsnorm_backward(qkv[:, :, 0].float(), q_weight.float(), dnormed_q, eps)
+                if _nan_debug: _has_nan(dq_f, "dq_f (after rmsnorm bwd)")
                 if need_grad_wq:
                     grad_wq = dw_q_f.to(q_weight.dtype)
 
             if need_grad_qkv or need_grad_wk:
                 dnormed_k = _rope_backward(grad_output[:, :, 1].float(), cos, sin)
+                if _nan_debug: _has_nan(dnormed_k, "dnormed_k (after rope bwd)")
                 dk_f, dw_k_f = _rmsnorm_backward(qkv[:, :, 1].float(), k_weight.float(), dnormed_k, eps)
+                if _nan_debug: _has_nan(dk_f, "dk_f (after rmsnorm bwd)")
                 if need_grad_wk:
                     grad_wk = dw_k_f.to(k_weight.dtype)
 

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -1,0 +1,305 @@
+"""Fused QKNorm (RMSNorm per head) + RoPE Triton kernel — forward only.
+
+The kernel fuses two sequential operations applied to Q and K tensors before
+flash attention in the Flux2 model:
+
+1. RMSNorm (per-head, with a learned scale weight)
+2. RoPE rotation using cos/sin extracted from freqs_cis
+
+Usage
+-----
+Extract cos/sin from freqs_cis once, then call fused_norm_rope for each of Q and K::
+
+    cos, sin = extract_cos_sin(freqs_cis)                   # [B, L, D//2]
+    q = fused_norm_rope(q, query_norm_scale, cos, sin)      # [B, L, H, D]
+    k = fused_norm_rope(k, key_norm_scale,   cos, sin)      # [B, L, H, D]
+
+Input tensor layout expected by the wrapper: **[B, L, H, D]** (after the
+transpose that is normally done before flash-attention, but *before* the
+QKNorm + RoPE steps).  This avoids the non-view rearrange otherwise needed
+when working in [B, H, L, D] layout.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+# ---------------------------------------------------------------------------
+# Triton kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def fused_qk_norm_rope_kernel(
+    x_ptr,       # input  [B, L, H, D] – bf16 / fp16 / fp32
+    out_ptr,     # output [B, L, H, D] – same dtype as input
+    w_ptr,       # RMSNorm scale weight [D]
+    cos_ptr,     # cos values [B, L, D//2] – float32
+    sin_ptr,     # sin values [B, L, D//2] – float32
+    # Strides (in elements, not bytes)
+    stride_x_b,    # x stride along batch dim
+    stride_x_l,    # x stride along sequence dim
+    stride_x_h,    # x stride along head dim (D is stride-1)
+    stride_cos_b,  # cos stride along batch
+    stride_cos_l,  # cos stride along sequence (D//2 is stride-1)
+    # Runtime scalars
+    H,  # num_heads
+    L,  # seq_len
+    # Compile-time constants
+    D: tl.constexpr,        # head dimension
+    D_HALF: tl.constexpr,   # D // 2
+    eps: tl.constexpr,      # RMSNorm epsilon
+    BLOCK_D: tl.constexpr,  # next_power_of_2(D), >= D
+):
+    """One Triton program handles one (b, l, h) row of D elements.
+
+    Algorithm
+    ---------
+    1. Load x[b, l, h, :] → fp32.
+    2. Compute RMSNorm with scale weight → x_norm.
+    3. Load cos/sin for position l (shape D//2).
+    4. Expand cos/sin to full D: pair d → positions 2d and 2d+1 share the same
+       cos[d]/sin[d].
+    5. Compute the RoPE rotation in a vectorised, fully register-based pass:
+          out[2d]   = cos[d]*x_norm[2d]   - sin[d]*x_norm[2d+1]
+          out[2d+1] = sin[d]*x_norm[2d]   + cos[d]*x_norm[2d+1]
+    6. Store output (cast back to input dtype).
+    """
+    row = tl.program_id(0)
+
+    # --- Decode (b, l, h) from flat row index ---
+    LH = L * H
+    b = row // LH
+    rem = row - b * LH
+    l = rem // H  # noqa: E741
+    h = rem - l * H
+
+    x_offset = b * stride_x_b + l * stride_x_l + h * stride_x_h
+    cos_offset = b * stride_cos_b + l * stride_cos_l
+
+    # --- Step 1: Load D elements → fp32 ---
+    d_idx = tl.arange(0, BLOCK_D)
+    mask_d = d_idx < D
+    x_vals = tl.load(x_ptr + x_offset + d_idx, mask=mask_d, other=0.0).to(tl.float32)
+
+    # --- Step 2: RMSNorm ---
+    w_vals = tl.load(w_ptr + d_idx, mask=mask_d, other=1.0).to(tl.float32)
+    sum_sq = tl.sum(x_vals * x_vals, axis=0)
+    mean_sq = sum_sq / D
+    rrms = 1.0 / tl.sqrt(mean_sq + eps)
+    x_norm = x_vals * rrms * w_vals  # [BLOCK_D], fp32
+
+    # --- Step 3: Load cos/sin [D_HALF] ---
+    half_idx = tl.arange(0, BLOCK_D // 2)
+    mask_half = half_idx < D_HALF
+    cos_half = tl.load(cos_ptr + cos_offset + half_idx, mask=mask_half, other=1.0)
+    sin_half = tl.load(sin_ptr + cos_offset + half_idx, mask=mask_half, other=0.0)
+
+    # --- Step 4: Expand cos/sin from D_HALF → D using pair-wise indexing.
+    #
+    # For pair d:
+    #   even position 2d   → cos_half[d], sin_half[d]
+    #   odd  position 2d+1 → cos_half[d], sin_half[d]
+    #
+    # We achieve this with an index map: pair_idx[i] = i // 2.
+    # Then cos_full[i] = cos_half[pair_idx[i]], etc.
+    #
+    pair_idx = d_idx // 2  # [0, 0, 1, 1, 2, 2, ...]  shape [BLOCK_D]
+    mask_pair = pair_idx < D_HALF
+    cos_full = tl.load(cos_ptr + cos_offset + pair_idx, mask=mask_pair, other=1.0)
+    sin_full = tl.load(sin_ptr + cos_offset + pair_idx, mask=mask_pair, other=0.0)
+
+    # --- Step 5: Compute rotation for all D positions simultaneously.
+    #
+    # For each position i:
+    #   - If i is even (i = 2d): partner is i+1.
+    #   - If i is odd  (i = 2d+1): partner is i-1.
+    #
+    # Build the partner value (x_norm shifted by ±1 within each pair).
+    # Triton cannot do dynamic gather from registers, so we use the
+    # "interleave-shift" trick:
+    #   - x_even[d] = x_norm[2d]   → expand to [BLOCK_D] by doubling: index (d_idx & ~1)
+    #   - x_odd [d] = x_norm[2d+1] → expand to [BLOCK_D] by doubling: index (d_idx | 1)
+    # Then:
+    #   is_even_mask = (d_idx % 2 == 0)
+    #   out = where(is_even,
+    #               cos*x_even - sin*x_odd,   # even output
+    #               sin*x_even + cos*x_odd)   # odd  output
+    #
+    even_partner_idx = d_idx & ~1   # for pos i: 2*(i//2)   → [0, 0, 2, 2, 4, 4, ...]
+    odd_partner_idx = d_idx | 1    # for pos i: 2*(i//2)+1 → [1, 1, 3, 3, 5, 5, ...]
+
+    x_even_partner = tl.load(
+        x_ptr + x_offset + even_partner_idx, mask=even_partner_idx < D, other=0.0
+    ).to(tl.float32)
+    x_odd_partner = tl.load(
+        x_ptr + x_offset + odd_partner_idx, mask=odd_partner_idx < D, other=0.0
+    ).to(tl.float32)
+
+    # Apply RMSNorm to partners (same rrms, but different weight positions)
+    w_even = tl.load(w_ptr + even_partner_idx, mask=even_partner_idx < D, other=1.0).to(tl.float32)
+    w_odd = tl.load(w_ptr + odd_partner_idx, mask=odd_partner_idx < D, other=1.0).to(tl.float32)
+
+    x_even_norm = x_even_partner * rrms * w_even
+    x_odd_norm = x_odd_partner * rrms * w_odd
+
+    # even position output: cos*x_even - sin*x_odd
+    out_even = cos_full * x_even_norm - sin_full * x_odd_norm
+    # odd  position output: sin*x_even + cos*x_odd
+    out_odd = sin_full * x_even_norm + cos_full * x_odd_norm
+
+    # Select based on whether position is even or odd
+    is_even = (d_idx % 2) == 0
+    out_vals = tl.where(is_even, out_even, out_odd)
+
+    # --- Step 6: Store (auto-cast fp32 → output dtype) ---
+    tl.store(out_ptr + x_offset + d_idx, out_vals, mask=mask_d)
+
+
+# ---------------------------------------------------------------------------
+# Helper: extract cos/sin from freqs_cis
+# ---------------------------------------------------------------------------
+
+
+def extract_cos_sin(freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Extract cos and sin arrays from the freqs_cis rotation-matrix tensor.
+
+    Parameters
+    ----------
+    freqs_cis:
+        Shape ``[B, 1, L, D//2, 2, 2]`` (float32).  The last two dims are the
+        2×2 rotation matrix::
+
+            [[cos, -sin],
+             [sin,  cos]]
+
+    Returns
+    -------
+    cos : torch.Tensor, shape ``[B, L, D//2]``, float32.
+    sin : torch.Tensor, shape ``[B, L, D//2]``, float32.
+    """
+    # freqs_cis[b, 0, l, d, 0, 0] = cos
+    # freqs_cis[b, 0, l, d, 1, 0] = sin
+    cos = freqs_cis[:, 0, :, :, 0, 0].contiguous()  # [B, L, D//2]
+    sin = freqs_cis[:, 0, :, :, 1, 0].contiguous()  # [B, L, D//2]
+    return cos, sin
+
+
+# ---------------------------------------------------------------------------
+# Python wrapper
+# ---------------------------------------------------------------------------
+
+
+def fused_norm_rope(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Apply fused RMSNorm + RoPE to a single Q or K tensor.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Shape ``[B, L, H, D]``.  bfloat16, float16, or float32.
+    weight : torch.Tensor
+        RMSNorm scale (``query_norm.scale`` or ``key_norm.scale``).
+        Shape ``[D]``.  Same dtype as *x*.
+    cos : torch.Tensor
+        Shape ``[B, L, D//2]``, float32.  From :func:`extract_cos_sin`.
+    sin : torch.Tensor
+        Shape ``[B, L, D//2]``, float32.  From :func:`extract_cos_sin`.
+    eps : float
+        RMSNorm epsilon (default ``1e-6``).
+
+    Returns
+    -------
+    torch.Tensor
+        Same shape and dtype as *x*.
+    """
+    B, L, H, D = x.shape
+    assert D % 2 == 0, f"Head dim D={D} must be even for RoPE"
+    D_HALF = D // 2
+
+    x = x.contiguous()
+    weight = weight.contiguous()
+    cos = cos.contiguous()
+    sin = sin.contiguous()
+
+    out = torch.empty_like(x)
+
+    BLOCK_D = triton.next_power_of_2(D)
+
+    grid = (B * L * H,)
+
+    fused_qk_norm_rope_kernel[grid](
+        x,
+        out,
+        weight,
+        cos,
+        sin,
+        x.stride(0),    # stride_x_b
+        x.stride(1),    # stride_x_l
+        x.stride(2),    # stride_x_h
+        cos.stride(0),  # stride_cos_b
+        cos.stride(1),  # stride_cos_l
+        H,
+        L,
+        D=D,
+        D_HALF=D_HALF,
+        eps=eps,
+        BLOCK_D=BLOCK_D,
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pure-PyTorch reference implementation (for testing / fallback)
+# ---------------------------------------------------------------------------
+
+
+def _rms_norm_ref(x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """RMSNorm over last dim, with learned scale ``weight``."""
+    x_fp32 = x.float()
+    rrms = torch.rsqrt(x_fp32.pow(2).mean(dim=-1, keepdim=True) + eps)
+    return (x_fp32 * rrms).to(x.dtype) * weight
+
+
+def _apply_rope_ref(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    """Apply RoPE given pre-extracted cos/sin.
+
+    Parameters
+    ----------
+    x   : ``[B, L, H, D]``
+    cos : ``[B, L, D//2]``
+    sin : ``[B, L, D//2]``
+    """
+    B, L, H, D = x.shape
+    D_HALF = D // 2
+    cos = cos.unsqueeze(2).expand(B, L, H, D_HALF)  # [B, L, H, D//2]
+    sin = sin.unsqueeze(2).expand(B, L, H, D_HALF)
+
+    x1 = x[..., 0::2].float()   # even positions → [B, L, H, D//2]
+    x2 = x[..., 1::2].float()   # odd  positions → [B, L, H, D//2]
+
+    out1 = cos * x1 - sin * x2
+    out2 = sin * x1 + cos * x2
+
+    out = torch.stack([out1, out2], dim=-1)  # [B, L, H, D//2, 2]
+    return out.reshape(B, L, H, D).to(x.dtype)
+
+
+def qk_norm_rope_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Reference: RMSNorm then RoPE, pure PyTorch (no Triton)."""
+    x_normed = _rms_norm_ref(x, weight, eps)
+    return _apply_rope_ref(x_normed, cos, sin)

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -51,7 +51,7 @@ def reference_norm_rope(
     return out.to(orig_dtype)
 
 
-def reference_qkv_norm_rope(
+def reference_packed_qk_norm_rope(
     qkv: torch.Tensor,      # [B, L, 3, H, D]
     q_weight: torch.Tensor, # [D]
     k_weight: torch.Tensor, # [D]
@@ -59,7 +59,7 @@ def reference_qkv_norm_rope(
     sin: torch.Tensor,      # [B, L, D//2]
     eps: float = 1e-6,
 ) -> torch.Tensor:
-    """Reference: packed QKV — RMSNorm+RoPE on Q and K, V copied unchanged."""
+    """Reference: packed QKV input — RMSNorm+RoPE on Q and K, V copied unchanged."""
     q = reference_norm_rope(qkv[:, :, 0], q_weight, cos, sin, eps)
     k = reference_norm_rope(qkv[:, :, 1], k_weight, cos, sin, eps)
     v = qkv[:, :, 2].to(q.dtype)
@@ -201,7 +201,7 @@ if HAS_TRITON:
         tl.store(out_ptr + x_base + cols * 2 + 1, o2, mask=mask)
 
     @triton.jit
-    def fused_qkv_norm_rope_kernel(
+    def fused_packed_qk_norm_rope_kernel(
         qkv_ptr, out_ptr,
         wq_ptr, wk_ptr,     # [D] norm weights for Q and K respectively
         cos_ptr, sin_ptr,   # [B, L, D//2]
@@ -332,7 +332,7 @@ if HAS_TRITON:
             grad_w = dw_f.to(weight.dtype) if ctx.needs_input_grad[1] else None
             return grad_x, grad_w, None, None, None  # cos, sin, eps: no grad
 
-    class _FusedQKVNormRopeFunction(torch.autograd.Function):
+    class _FusedPackedQKNormRopeFunction(torch.autograd.Function):
         @staticmethod
         def forward(ctx, qkv, q_weight, k_weight, cos, sin, eps):
             # qkv: [B, L, 3, H, D]
@@ -344,7 +344,7 @@ if HAS_TRITON:
             BLOCK_D2 = triton.next_power_of_2(D2)
             out_f32 = torch.empty(B, L, 3, H, D, dtype=torch.float32, device=qkv.device)
             triton_dtype = _TRITON_DTYPE_MAP[_TORCH_TO_TRITON_DTYPE[qkv.dtype]]
-            fused_qkv_norm_rope_kernel[(B * L * H,)](
+            fused_packed_qk_norm_rope_kernel[(B * L * H,)](
                 qkv, out_f32, q_weight.float(), k_weight.float(), cos, sin,
                 H, L, D, D2, eps,
                 BLOCK_D2=BLOCK_D2,
@@ -433,7 +433,7 @@ def fused_norm_rope(
     torch.Tensor
         Same shape and dtype as *x*.
     """
-    if not HAS_TRITON:
+    if not HAS_TRITON or not x.is_cuda:
         return reference_norm_rope(x, weight, cos, sin, eps)
 
     assert x.is_contiguous(), "x must be contiguous"
@@ -443,7 +443,7 @@ def fused_norm_rope(
     return _FusedNormRopeFunction.apply(x, weight, cos, sin, eps)
 
 
-def fused_qkv_norm_rope(
+def fused_packed_qk_norm_rope(
     qkv: torch.Tensor,      # [B, L, 3, H, D] contiguous, any float dtype
     q_weight: torch.Tensor, # [D] RMSNorm scale for Q
     k_weight: torch.Tensor, # [D] RMSNorm scale for K
@@ -482,12 +482,12 @@ def fused_qkv_norm_rope(
         Shape ``[B, L, 3, H, D]``, same dtype as *qkv*.  Q and K are
         normalised and rotated; V is unchanged.
     """
-    if not HAS_TRITON:
-        return reference_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin, eps)
+    if not HAS_TRITON or not qkv.is_cuda:
+        return reference_packed_qk_norm_rope(qkv, q_weight, k_weight, cos, sin, eps)
 
     assert qkv.is_contiguous(), "qkv must be contiguous"
     assert qkv.shape[2] == 3, f"Expected packed QKV with dim-2 == 3, got {qkv.shape}"
     B, L, _, H, D = qkv.shape
     assert D % 2 == 0, f"Head dim D={D} must be even for RoPE"
 
-    return _FusedQKVNormRopeFunction.apply(qkv, q_weight, k_weight, cos, sin, eps)
+    return _FusedPackedQKNormRopeFunction.apply(qkv, q_weight, k_weight, cos, sin, eps)

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -1,177 +1,71 @@
-"""Fused QKNorm (RMSNorm per head) + RoPE Triton kernel — forward only.
-
-The kernel fuses two sequential operations applied to Q and K tensors before
-flash attention in the Flux2 model:
-
-1. RMSNorm (per-head, with a learned scale weight)
-2. RoPE rotation using cos/sin extracted from freqs_cis
-
-Usage
------
-Extract cos/sin from freqs_cis once, then call fused_norm_rope for each of Q and K::
-
-    cos, sin = extract_cos_sin(freqs_cis)                   # [B, L, D//2]
-    q = fused_norm_rope(q, query_norm_scale, cos, sin)      # [B, L, H, D]
-    k = fused_norm_rope(k, key_norm_scale,   cos, sin)      # [B, L, H, D]
-
-Input tensor layout expected by the wrapper: **[B, L, H, D]** (after the
-transpose that is normally done before flash-attention, but *before* the
-QKNorm + RoPE steps).  This avoids the non-view rearrange otherwise needed
-when working in [B, H, L, D] layout.
-"""
+"""Fused RMSNorm + RoPE kernel for Q and K in Flux2-style attention."""
 
 from __future__ import annotations
 
+try:
+    import triton
+    import triton.language as tl
+    HAS_TRITON = True
+except ImportError:
+    HAS_TRITON = False
+
 import torch
-import triton
-import triton.language as tl
 
 
 # ---------------------------------------------------------------------------
-# Triton kernel
+# Reference implementation (always available, used as fallback)
 # ---------------------------------------------------------------------------
 
 
-@triton.jit
-def fused_qk_norm_rope_kernel(
-    x_ptr,       # input  [B, L, H, D] – bf16 / fp16 / fp32
-    out_ptr,     # output [B, L, H, D] – same dtype as input
-    w_ptr,       # RMSNorm scale weight [D]
-    cos_ptr,     # cos values [B, L, D//2] – float32
-    sin_ptr,     # sin values [B, L, D//2] – float32
-    # Strides (in elements, not bytes)
-    stride_x_b,    # x stride along batch dim
-    stride_x_l,    # x stride along sequence dim
-    stride_x_h,    # x stride along head dim (D is stride-1)
-    stride_cos_b,  # cos stride along batch
-    stride_cos_l,  # cos stride along sequence (D//2 is stride-1)
-    # Runtime scalars
-    H,  # num_heads
-    L,  # seq_len
-    # Compile-time constants
-    D: tl.constexpr,        # head dimension
-    D_HALF: tl.constexpr,   # D // 2
-    eps: tl.constexpr,      # RMSNorm epsilon
-    BLOCK_D: tl.constexpr,  # next_power_of_2(D), >= D
-):
-    """One Triton program handles one (b, l, h) row of D elements.
-
-    Algorithm
-    ---------
-    1. Load x[b, l, h, :] → fp32.
-    2. Compute RMSNorm with scale weight → x_norm.
-    3. Load cos/sin for position l (shape D//2).
-    4. Expand cos/sin to full D: pair d → positions 2d and 2d+1 share the same
-       cos[d]/sin[d].
-    5. Compute the RoPE rotation in a vectorised, fully register-based pass:
-          out[2d]   = cos[d]*x_norm[2d]   - sin[d]*x_norm[2d+1]
-          out[2d+1] = sin[d]*x_norm[2d]   + cos[d]*x_norm[2d+1]
-    6. Store output (cast back to input dtype).
-    """
-    row = tl.program_id(0)
-
-    # --- Decode (b, l, h) from flat row index ---
-    LH = L * H
-    b = row // LH
-    rem = row - b * LH
-    l = rem // H  # noqa: E741
-    h = rem - l * H
-
-    x_offset = b * stride_x_b + l * stride_x_l + h * stride_x_h
-    cos_offset = b * stride_cos_b + l * stride_cos_l
-
-    # --- Step 1: Load D elements → fp32 ---
-    d_idx = tl.arange(0, BLOCK_D)
-    mask_d = d_idx < D
-    x_vals = tl.load(x_ptr + x_offset + d_idx, mask=mask_d, other=0.0).to(tl.float32)
-
-    # --- Step 2: RMSNorm ---
-    w_vals = tl.load(w_ptr + d_idx, mask=mask_d, other=1.0).to(tl.float32)
-    sum_sq = tl.sum(x_vals * x_vals, axis=0)
-    mean_sq = sum_sq / D
-    rrms = 1.0 / tl.sqrt(mean_sq + eps)
-    x_norm = x_vals * rrms * w_vals  # [BLOCK_D], fp32
-
-    # --- Step 3: Load cos/sin [D_HALF] ---
-    half_idx = tl.arange(0, BLOCK_D // 2)
-    mask_half = half_idx < D_HALF
-    cos_half = tl.load(cos_ptr + cos_offset + half_idx, mask=mask_half, other=1.0)
-    sin_half = tl.load(sin_ptr + cos_offset + half_idx, mask=mask_half, other=0.0)
-
-    # --- Step 4: Expand cos/sin from D_HALF → D using pair-wise indexing.
-    #
-    # For pair d:
-    #   even position 2d   → cos_half[d], sin_half[d]
-    #   odd  position 2d+1 → cos_half[d], sin_half[d]
-    #
-    # We achieve this with an index map: pair_idx[i] = i // 2.
-    # Then cos_full[i] = cos_half[pair_idx[i]], etc.
-    #
-    pair_idx = d_idx // 2  # [0, 0, 1, 1, 2, 2, ...]  shape [BLOCK_D]
-    mask_pair = pair_idx < D_HALF
-    cos_full = tl.load(cos_ptr + cos_offset + pair_idx, mask=mask_pair, other=1.0)
-    sin_full = tl.load(sin_ptr + cos_offset + pair_idx, mask=mask_pair, other=0.0)
-
-    # --- Step 5: Compute rotation for all D positions simultaneously.
-    #
-    # For each position i:
-    #   - If i is even (i = 2d): partner is i+1.
-    #   - If i is odd  (i = 2d+1): partner is i-1.
-    #
-    # Build the partner value (x_norm shifted by ±1 within each pair).
-    # Triton cannot do dynamic gather from registers, so we use the
-    # "interleave-shift" trick:
-    #   - x_even[d] = x_norm[2d]   → expand to [BLOCK_D] by doubling: index (d_idx & ~1)
-    #   - x_odd [d] = x_norm[2d+1] → expand to [BLOCK_D] by doubling: index (d_idx | 1)
-    # Then:
-    #   is_even_mask = (d_idx % 2 == 0)
-    #   out = where(is_even,
-    #               cos*x_even - sin*x_odd,   # even output
-    #               sin*x_even + cos*x_odd)   # odd  output
-    #
-    even_partner_idx = d_idx & ~1   # for pos i: 2*(i//2)   → [0, 0, 2, 2, 4, 4, ...]
-    odd_partner_idx = d_idx | 1    # for pos i: 2*(i//2)+1 → [1, 1, 3, 3, 5, 5, ...]
-
-    x_even_partner = tl.load(
-        x_ptr + x_offset + even_partner_idx, mask=even_partner_idx < D, other=0.0
-    ).to(tl.float32)
-    x_odd_partner = tl.load(
-        x_ptr + x_offset + odd_partner_idx, mask=odd_partner_idx < D, other=0.0
-    ).to(tl.float32)
-
-    # Apply RMSNorm to partners (same rrms, but different weight positions)
-    w_even = tl.load(w_ptr + even_partner_idx, mask=even_partner_idx < D, other=1.0).to(tl.float32)
-    w_odd = tl.load(w_ptr + odd_partner_idx, mask=odd_partner_idx < D, other=1.0).to(tl.float32)
-
-    x_even_norm = x_even_partner * rrms * w_even
-    x_odd_norm = x_odd_partner * rrms * w_odd
-
-    # even position output: cos*x_even - sin*x_odd
-    out_even = cos_full * x_even_norm - sin_full * x_odd_norm
-    # odd  position output: sin*x_even + cos*x_odd
-    out_odd = sin_full * x_even_norm + cos_full * x_odd_norm
-
-    # Select based on whether position is even or odd
-    is_even = (d_idx % 2) == 0
-    out_vals = tl.where(is_even, out_even, out_odd)
-
-    # --- Step 6: Store (auto-cast fp32 → output dtype) ---
-    tl.store(out_ptr + x_offset + d_idx, out_vals, mask=mask_d)
+def reference_norm_rope(
+    x: torch.Tensor,       # [B, L, H, D]
+    weight: torch.Tensor,  # [D]
+    cos: torch.Tensor,     # [B, L, D//2]
+    sin: torch.Tensor,     # [B, L, D//2]
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Reference: RMSNorm then RoPE, pure PyTorch (no Triton)."""
+    orig_dtype = x.dtype
+    x = x.float()
+    # RMSNorm over last dim
+    rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    x = x * rrms * weight.float()
+    # RoPE: reshape to expose pairs
+    x = x.reshape(*x.shape[:-1], -1, 2)   # [B, L, H, D//2, 2]
+    x1, x2 = x[..., 0], x[..., 1]         # each [B, L, H, D//2]
+    # broadcast cos/sin over H dim: [B, L, 1, D//2]
+    c = cos.unsqueeze(2).float()
+    s = sin.unsqueeze(2).float()
+    o1 = c * x1 - s * x2
+    o2 = s * x1 + c * x2
+    out = torch.stack([o1, o2], dim=-1).reshape(*o1.shape[:-1], -1)  # [B,L,H,D]
+    return out.to(orig_dtype)
 
 
-# ---------------------------------------------------------------------------
-# Helper: extract cos/sin from freqs_cis
-# ---------------------------------------------------------------------------
+def reference_qkv_norm_rope(
+    qkv: torch.Tensor,      # [B, L, 3, H, D]
+    q_weight: torch.Tensor, # [D]
+    k_weight: torch.Tensor, # [D]
+    cos: torch.Tensor,      # [B, L, D//2]
+    sin: torch.Tensor,      # [B, L, D//2]
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Reference: packed QKV — RMSNorm+RoPE on Q and K, V copied unchanged."""
+    q = reference_norm_rope(qkv[:, :, 0], q_weight, cos, sin, eps)
+    k = reference_norm_rope(qkv[:, :, 1], k_weight, cos, sin, eps)
+    v = qkv[:, :, 2].to(q.dtype)
+    return torch.stack([q, k, v], dim=2)
 
 
 def extract_cos_sin(freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Extract cos and sin arrays from the freqs_cis rotation-matrix tensor.
+    """
+    Extract cos and sin arrays from the freqs_cis rotation-matrix tensor.
 
     Parameters
     ----------
     freqs_cis:
-        Shape ``[B, 1, L, D//2, 2, 2]`` (float32).  The last two dims are the
-        2×2 rotation matrix::
+        Shape ``[B, 1, L, D//2, 2, 2]`` (Flux2 format from pe_embedder).
+        The ``[2, 2]`` block is a rotation matrix::
 
             [[cos, -sin],
              [sin,  cos]]
@@ -181,34 +75,298 @@ def extract_cos_sin(freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor
     cos : torch.Tensor, shape ``[B, L, D//2]``, float32.
     sin : torch.Tensor, shape ``[B, L, D//2]``, float32.
     """
-    # freqs_cis[b, 0, l, d, 0, 0] = cos
-    # freqs_cis[b, 0, l, d, 1, 0] = sin
-    cos = freqs_cis[:, 0, :, :, 0, 0].contiguous()  # [B, L, D//2]
-    sin = freqs_cis[:, 0, :, :, 1, 0].contiguous()  # [B, L, D//2]
-    return cos, sin
+    fc = freqs_cis[:, 0]               # [B, L, D//2, 2, 2]
+    cos = fc[..., 0, 0].contiguous()   # [B, L, D//2]
+    sin = fc[..., 1, 0].contiguous()   # [B, L, D//2]
+    return cos.float(), sin.float()
 
 
 # ---------------------------------------------------------------------------
-# Python wrapper
+# Backward helpers (pure PyTorch, float32)
+# ---------------------------------------------------------------------------
+
+
+def _rope_backward(
+    dout: torch.Tensor,   # [B, L, H, D] float32
+    cos: torch.Tensor,    # [B, L, D//2] float32
+    sin: torch.Tensor,    # [B, L, D//2] float32
+) -> torch.Tensor:
+    """Backward through RoPE rotation: apply the transpose (inverse) rotation."""
+    B, L, H, D = dout.shape
+    D2 = D // 2
+    c = cos.unsqueeze(2)  # [B, L, 1, D//2]
+    s = sin.unsqueeze(2)
+    # dout pairs
+    dout_pairs = dout.reshape(B, L, H, D2, 2)
+    do1 = dout_pairs[..., 0]  # [B, L, H, D//2]
+    do2 = dout_pairs[..., 1]
+    # Inverse rotation: R^T @ [do1, do2]
+    dn1 = c * do1 + s * do2
+    dn2 = -s * do1 + c * do2
+    return torch.stack([dn1, dn2], dim=-1).reshape(B, L, H, D)
+
+
+def _rmsnorm_backward(
+    x: torch.Tensor,       # [B, L, H, D] float32 — original input to RMSNorm
+    weight: torch.Tensor,  # [D] float32
+    dnormed: torch.Tensor, # [B, L, H, D] float32 — grad w.r.t. RMSNorm output
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Backward through RMSNorm: y = x * rsqrt(mean(x²) + eps) * w.
+
+    Returns (dx, dw).
+    """
+    D = x.shape[-1]
+    rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)  # [B, L, H, 1]
+    # dw: sum over (B, L, H) of x * rrms * dnormed
+    dw = (dnormed * x * rrms).sum(dim=(0, 1, 2))  # [D]
+    # dx: standard RMSNorm gradient
+    dot = (dnormed * weight * x).sum(-1, keepdim=True)  # [B, L, H, 1]
+    dx = rrms * (dnormed * weight - (rrms**2 / D) * x * dot)
+    return dx, dw
+
+
+# ---------------------------------------------------------------------------
+# Triton kernels (only if HAS_TRITON)
+# ---------------------------------------------------------------------------
+
+if HAS_TRITON:
+    @triton.jit
+    def fused_norm_rope_kernel(
+        x_ptr, out_ptr, w_ptr, cos_ptr, sin_ptr,
+        H, L, D, D2,        # D2 = D // 2
+        eps,
+        BLOCK_D2: tl.constexpr,   # power of 2, >= D2
+    ):
+        pid = tl.program_id(0)
+        h = pid % H
+        l = (pid // H) % L  # noqa: E741
+        b = pid // (H * L)
+
+        x_base   = b * (L * H * D) + l * (H * D) + h * D
+        cos_base = b * (L * D2) + l * D2
+
+        cols = tl.arange(0, BLOCK_D2)
+        mask = cols < D2
+
+        # load pairs
+        x1 = tl.load(x_ptr + x_base + cols * 2,     mask=mask, other=0.0).to(tl.float32)
+        x2 = tl.load(x_ptr + x_base + cols * 2 + 1, mask=mask, other=0.0).to(tl.float32)
+
+        # RMSNorm reduction
+        ss = tl.sum(x1 * x1 + x2 * x2, axis=0)
+        rrms = tl.rsqrt(ss / D + eps)
+
+        # load weights for each element of the pair
+        w1 = tl.load(w_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
+        w2 = tl.load(w_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
+
+        n1 = x1 * rrms * w1
+        n2 = x2 * rrms * w2
+
+        # RoPE
+        c = tl.load(cos_ptr + cos_base + cols, mask=mask, other=1.0).to(tl.float32)
+        s = tl.load(sin_ptr + cos_base + cols, mask=mask, other=0.0).to(tl.float32)
+
+        o1 = c * n1 - s * n2
+        o2 = s * n1 + c * n2
+
+        # store interleaved pairs — cast back to float32; wrapper converts to original dtype
+        tl.store(out_ptr + x_base + cols * 2,     o1, mask=mask)
+        tl.store(out_ptr + x_base + cols * 2 + 1, o2, mask=mask)
+
+    @triton.jit
+    def fused_qkv_norm_rope_kernel(
+        qkv_ptr, out_ptr,
+        wq_ptr, wk_ptr,     # [D] norm weights for Q and K respectively
+        cos_ptr, sin_ptr,   # [B, L, D//2]
+        H, L, D, D2,        # D2 = D // 2
+        eps,
+        BLOCK_D2: tl.constexpr,   # power of 2, >= D2
+    ):
+        """One program per (b, l, h) row. Processes Q and K, copies V.
+
+        Input/output layout: [B, L, 3, H, D] contiguous.
+        Strides: (L*3*H*D, 3*H*D, H*D, D, 1).
+        """
+        pid = tl.program_id(0)
+        h = pid % H
+        l = (pid // H) % L  # noqa: E741
+        b = pid // (H * L)
+
+        # Base offsets into [B, L, 3, H, D]
+        row_base  = b * (L * 3 * H * D) + l * (3 * H * D) + h * D
+        q_base    = row_base + 0 * H * D   # K index 0
+        k_base    = row_base + 1 * H * D   # K index 1
+        v_base    = row_base + 2 * H * D   # K index 2
+        cos_base  = b * (L * D2) + l * D2
+
+        cols = tl.arange(0, BLOCK_D2)
+        mask = cols < D2
+
+        # Load cos/sin (shared by Q and K)
+        c = tl.load(cos_ptr + cos_base + cols, mask=mask, other=1.0).to(tl.float32)
+        s = tl.load(sin_ptr + cos_base + cols, mask=mask, other=0.0).to(tl.float32)
+
+        # --- Process Q ---
+        q1 = tl.load(qkv_ptr + q_base + cols * 2,     mask=mask, other=0.0).to(tl.float32)
+        q2 = tl.load(qkv_ptr + q_base + cols * 2 + 1, mask=mask, other=0.0).to(tl.float32)
+        ss_q  = tl.sum(q1 * q1 + q2 * q2, axis=0)
+        rrms_q = tl.rsqrt(ss_q / D + eps)
+        wq1 = tl.load(wq_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
+        wq2 = tl.load(wq_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
+        nq1 = q1 * rrms_q * wq1
+        nq2 = q2 * rrms_q * wq2
+        oq1 = c * nq1 - s * nq2
+        oq2 = s * nq1 + c * nq2
+        tl.store(out_ptr + q_base + cols * 2,     oq1, mask=mask)
+        tl.store(out_ptr + q_base + cols * 2 + 1, oq2, mask=mask)
+
+        # --- Process K ---
+        k1 = tl.load(qkv_ptr + k_base + cols * 2,     mask=mask, other=0.0).to(tl.float32)
+        k2 = tl.load(qkv_ptr + k_base + cols * 2 + 1, mask=mask, other=0.0).to(tl.float32)
+        ss_k  = tl.sum(k1 * k1 + k2 * k2, axis=0)
+        rrms_k = tl.rsqrt(ss_k / D + eps)
+        wk1 = tl.load(wk_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
+        wk2 = tl.load(wk_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
+        nk1 = k1 * rrms_k * wk1
+        nk2 = k2 * rrms_k * wk2
+        ok1 = c * nk1 - s * nk2
+        ok2 = s * nk1 + c * nk2
+        tl.store(out_ptr + k_base + cols * 2,     ok1, mask=mask)
+        tl.store(out_ptr + k_base + cols * 2 + 1, ok2, mask=mask)
+
+        # --- Copy V unchanged ---
+        v1 = tl.load(qkv_ptr + v_base + cols * 2,     mask=mask, other=0.0)
+        v2 = tl.load(qkv_ptr + v_base + cols * 2 + 1, mask=mask, other=0.0)
+        tl.store(out_ptr + v_base + cols * 2,     v1, mask=mask)
+        tl.store(out_ptr + v_base + cols * 2 + 1, v2, mask=mask)
+
+
+# ---------------------------------------------------------------------------
+# autograd.Function wrappers (Triton forward, PyTorch backward)
+# ---------------------------------------------------------------------------
+
+if HAS_TRITON:
+    class _FusedNormRopeFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, weight, cos, sin, eps):
+            # x: [B, L, H, D]
+            ctx.save_for_backward(x, weight, cos, sin)
+            ctx.eps = eps
+
+            B, L, H, D = x.shape
+            D2 = D // 2
+            BLOCK_D2 = triton.next_power_of_2(D2)
+            out_f32 = torch.empty(B, L, H, D, dtype=torch.float32, device=x.device)
+            fused_norm_rope_kernel[(B * L * H,)](
+                x, out_f32, weight.float(), cos, sin,
+                H, L, D, D2, eps,
+                BLOCK_D2=BLOCK_D2,
+            )
+            return out_f32.to(x.dtype)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x, weight, cos, sin = ctx.saved_tensors
+            eps = ctx.eps
+
+            x_f = x.float()
+            dout_f = grad_output.float()
+
+            # RoPE backward (transpose rotation)
+            dnormed = _rope_backward(dout_f, cos, sin)
+
+            # RMSNorm backward
+            dx_f, dw_f = _rmsnorm_backward(x_f, weight.float(), dnormed, eps)
+
+            grad_x = dx_f.to(x.dtype) if ctx.needs_input_grad[0] else None
+            grad_w = dw_f.to(weight.dtype) if ctx.needs_input_grad[1] else None
+            return grad_x, grad_w, None, None, None  # cos, sin, eps: no grad
+
+    class _FusedQKVNormRopeFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, qkv, q_weight, k_weight, cos, sin, eps):
+            # qkv: [B, L, 3, H, D]
+            ctx.save_for_backward(qkv, q_weight, k_weight, cos, sin)
+            ctx.eps = eps
+
+            B, L, _, H, D = qkv.shape
+            D2 = D // 2
+            BLOCK_D2 = triton.next_power_of_2(D2)
+            out_f32 = torch.empty(B, L, 3, H, D, dtype=torch.float32, device=qkv.device)
+            fused_qkv_norm_rope_kernel[(B * L * H,)](
+                qkv, out_f32, q_weight.float(), k_weight.float(), cos, sin,
+                H, L, D, D2, eps,
+                BLOCK_D2=BLOCK_D2,
+            )
+            return out_f32.to(qkv.dtype)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            qkv, q_weight, k_weight, cos, sin = ctx.saved_tensors
+            eps = ctx.eps
+
+            need_grad_qkv = ctx.needs_input_grad[0]
+            need_grad_wq  = ctx.needs_input_grad[1]
+            need_grad_wk  = ctx.needs_input_grad[2]
+
+            grad_qkv = None
+            grad_wq  = None
+            grad_wk  = None
+            dq_f     = None
+            dk_f     = None
+
+            if need_grad_qkv or need_grad_wq:
+                # Slice then cast: avoids a full [B, L, 3, H, D] fp32 copy
+                q_f    = qkv[:, :, 0].float()          # [B, L, H, D] fp32
+                dout_q = grad_output[:, :, 0].float()
+                dnormed_q = _rope_backward(dout_q, cos, sin)
+                dq_f, dw_q_f = _rmsnorm_backward(q_f, q_weight.float(), dnormed_q, eps)
+                if need_grad_wq:
+                    grad_wq = dw_q_f.to(q_weight.dtype)
+
+            if need_grad_qkv or need_grad_wk:
+                k_f    = qkv[:, :, 1].float()
+                dout_k = grad_output[:, :, 1].float()
+                dnormed_k = _rope_backward(dout_k, cos, sin)
+                dk_f, dw_k_f = _rmsnorm_backward(k_f, k_weight.float(), dnormed_k, eps)
+                if need_grad_wk:
+                    grad_wk = dw_k_f.to(k_weight.dtype)
+
+            if need_grad_qkv:
+                # V is identity passthrough — no fp32 intermediate needed
+                dv = grad_output[:, :, 2]
+                grad_qkv = torch.stack(
+                    [dq_f.to(qkv.dtype), dk_f.to(qkv.dtype), dv], dim=2
+                )
+
+            return grad_qkv, grad_wq, grad_wk, None, None, None  # cos, sin, eps
+
+
+# ---------------------------------------------------------------------------
+# Public API
 # ---------------------------------------------------------------------------
 
 
 def fused_norm_rope(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
+    x: torch.Tensor,        # [B, L, H, D] contiguous, any float dtype
+    weight: torch.Tensor,   # [D] RMSNorm scale
+    cos: torch.Tensor,      # [B, L, D//2] float32
+    sin: torch.Tensor,      # [B, L, D//2] float32
     eps: float = 1e-6,
 ) -> torch.Tensor:
-    """Apply fused RMSNorm + RoPE to a single Q or K tensor.
+    """Fused RMSNorm + RoPE for one of Q or K. Call twice with different weights.
 
     Parameters
     ----------
     x : torch.Tensor
-        Shape ``[B, L, H, D]``.  bfloat16, float16, or float32.
+        Shape ``[B, L, H, D]``.  bfloat16, float16, or float32.  Must be
+        contiguous.
     weight : torch.Tensor
         RMSNorm scale (``query_norm.scale`` or ``key_norm.scale``).
-        Shape ``[D]``.  Same dtype as *x*.
+        Shape ``[D]``.
     cos : torch.Tensor
         Shape ``[B, L, D//2]``, float32.  From :func:`extract_cos_sin`.
     sin : torch.Tensor
@@ -221,85 +379,61 @@ def fused_norm_rope(
     torch.Tensor
         Same shape and dtype as *x*.
     """
+    if not HAS_TRITON:
+        return reference_norm_rope(x, weight, cos, sin, eps)
+
+    assert x.is_contiguous(), "x must be contiguous"
     B, L, H, D = x.shape
     assert D % 2 == 0, f"Head dim D={D} must be even for RoPE"
-    D_HALF = D // 2
 
-    x = x.contiguous()
-    weight = weight.contiguous()
-    cos = cos.contiguous()
-    sin = sin.contiguous()
-
-    out = torch.empty_like(x)
-
-    BLOCK_D = triton.next_power_of_2(D)
-
-    grid = (B * L * H,)
-
-    fused_qk_norm_rope_kernel[grid](
-        x,
-        out,
-        weight,
-        cos,
-        sin,
-        x.stride(0),    # stride_x_b
-        x.stride(1),    # stride_x_l
-        x.stride(2),    # stride_x_h
-        cos.stride(0),  # stride_cos_b
-        cos.stride(1),  # stride_cos_l
-        H,
-        L,
-        D=D,
-        D_HALF=D_HALF,
-        eps=eps,
-        BLOCK_D=BLOCK_D,
-    )
-    return out
+    return _FusedNormRopeFunction.apply(x, weight, cos, sin, eps)
 
 
-# ---------------------------------------------------------------------------
-# Pure-PyTorch reference implementation (for testing / fallback)
-# ---------------------------------------------------------------------------
+def fused_qkv_norm_rope(
+    qkv: torch.Tensor,      # [B, L, 3, H, D] contiguous, any float dtype
+    q_weight: torch.Tensor, # [D] RMSNorm scale for Q
+    k_weight: torch.Tensor, # [D] RMSNorm scale for K
+    cos: torch.Tensor,      # [B, L, D//2] float32
+    sin: torch.Tensor,      # [B, L, D//2] float32
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Fused RMSNorm + RoPE on packed QKV in a single kernel launch.
 
+    Applies RMSNorm + RoPE to Q (index 0) and K (index 1) with separate norm
+    weights.  V (index 2) is copied unchanged.  One GPU kernel launch handles
+    all three components, avoiding any Q/K separation in Python.
 
-def _rms_norm_ref(x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-    """RMSNorm over last dim, with learned scale ``weight``."""
-    x_fp32 = x.float()
-    rrms = torch.rsqrt(x_fp32.pow(2).mean(dim=-1, keepdim=True) + eps)
-    return (x_fp32 * rrms).to(x.dtype) * weight
-
-
-def _apply_rope_ref(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
-    """Apply RoPE given pre-extracted cos/sin.
+    The backward pass is computed in pure PyTorch (float32), preserving full
+    gradient flow to qkv and to the norm scale weights.
 
     Parameters
     ----------
-    x   : ``[B, L, H, D]``
-    cos : ``[B, L, D//2]``
-    sin : ``[B, L, D//2]``
+    qkv : torch.Tensor
+        Shape ``[B, L, 3, H, D]``.  Must be contiguous.  Can be obtained from
+        a linear projection output via ``proj_out.reshape(B, L, 3, H, D)``.
+    q_weight : torch.Tensor
+        RMSNorm scale for Q (``query_norm.scale``).  Shape ``[D]``.
+    k_weight : torch.Tensor
+        RMSNorm scale for K (``key_norm.scale``).  Shape ``[D]``.
+    cos : torch.Tensor
+        Shape ``[B, L, D//2]``, float32.  From :func:`extract_cos_sin`.
+    sin : torch.Tensor
+        Shape ``[B, L, D//2]``, float32.  From :func:`extract_cos_sin`.
+    eps : float
+        RMSNorm epsilon (default ``1e-6``).
+
+    Returns
+    -------
+    torch.Tensor
+        Shape ``[B, L, 3, H, D]``, same dtype as *qkv*.  Q and K are
+        normalised and rotated; V is unchanged.
     """
-    B, L, H, D = x.shape
-    D_HALF = D // 2
-    cos = cos.unsqueeze(2).expand(B, L, H, D_HALF)  # [B, L, H, D//2]
-    sin = sin.unsqueeze(2).expand(B, L, H, D_HALF)
+    if not HAS_TRITON:
+        return reference_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin, eps)
 
-    x1 = x[..., 0::2].float()   # even positions → [B, L, H, D//2]
-    x2 = x[..., 1::2].float()   # odd  positions → [B, L, H, D//2]
+    assert qkv.is_contiguous(), "qkv must be contiguous"
+    assert qkv.shape[2] == 3, f"Expected packed QKV with dim-2 == 3, got {qkv.shape}"
+    B, L, _, H, D = qkv.shape
+    assert D % 2 == 0, f"Head dim D={D} must be even for RoPE"
 
-    out1 = cos * x1 - sin * x2
-    out2 = sin * x1 + cos * x2
-
-    out = torch.stack([out1, out2], dim=-1)  # [B, L, H, D//2, 2]
-    return out.reshape(B, L, H, D).to(x.dtype)
-
-
-def qk_norm_rope_reference(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
-    eps: float = 1e-6,
-) -> torch.Tensor:
-    """Reference: RMSNorm then RoPE, pure PyTorch (no Triton)."""
-    x_normed = _rms_norm_ref(x, weight, eps)
-    return _apply_rope_ref(x_normed, cos, sin)
+    return _FusedQKVNormRopeFunction.apply(qkv, q_weight, k_weight, cos, sin, eps)

--- a/src/musubi_tuner/kernels/fused_norm_rope.py
+++ b/src/musubi_tuner/kernels/fused_norm_rope.py
@@ -35,10 +35,7 @@ def reference_norm_rope(
     x = x.float()
     # RMSNorm over last dim
     rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
-    # Match original RMSNorm: (x * rrms).to(x_dtype) * weight
-    x = (x * rrms).to(orig_dtype) * weight.float()
-    # Match QKNorm .to(v) cast
-    x = x.to(orig_dtype).float()
+    x = x * rrms * weight.float()
     # RoPE: reshape to expose pairs
     x = x.reshape(*x.shape[:-1], -1, 2)   # [B, L, H, D//2, 2]
     x1, x2 = x[..., 0], x[..., 1]         # each [B, L, H, D//2]
@@ -120,27 +117,12 @@ def _rmsnorm_backward(
     weight: torch.Tensor,  # [D] float32
     dnormed: torch.Tensor, # [B, L, H, D] float32 — grad w.r.t. RMSNorm output
     eps: float,
-    input_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Backward through RMSNorm: y = x * rsqrt(mean(x²) + eps) * w.
-
-    When ``input_dtype`` is provided, the dw computation uses
-    ``(x * rrms).to(input_dtype)`` to match the original RMSNorm which
-    quantizes before the scale multiply: ``(x * rrms).to(x_dtype) * w``.
-
-    Returns (dx, dw).
-    """
+    """Backward through RMSNorm: y = x * rsqrt(mean(x²) + eps) * w. Returns (dx, dw)."""
     D = x.shape[-1]
     rrms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)  # [B, L, H, 1]
     normed = x * rrms
-    # dw: match original RMSNorm's intermediate cast for weight gradient
-    if input_dtype is not None:
-        normed_for_dw = normed.to(input_dtype).float()
-    else:
-        normed_for_dw = normed
-    dw = (dnormed * normed_for_dw).sum(dim=(0, 1, 2))  # [D]
-    # dx: standard RMSNorm gradient (STE through casts doesn't change dx)
+    dw = (dnormed * normed).sum(dim=(0, 1, 2))  # [D]
     dot = (dnormed * weight * x).sum(-1, keepdim=True)  # [B, L, H, 1]
     dx = rrms * (dnormed * weight - (rrms**2 / D) * x * dot)
     return dx, dw
@@ -156,8 +138,7 @@ if HAS_TRITON:
         x_ptr, out_ptr, w_ptr, cos_ptr, sin_ptr,
         H, L, D, D2,        # D2 = D // 2
         eps,
-        BLOCK_D2: tl.constexpr,   # power of 2, >= D2
-        INPUT_DTYPE: tl.constexpr,  # input dtype for intermediate casts
+        BLOCK_D2: tl.constexpr,
     ):
         pid = tl.program_id(0)
         h = pid % H
@@ -182,12 +163,8 @@ if HAS_TRITON:
         w1 = tl.load(w_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
         w2 = tl.load(w_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
 
-        # Match original RMSNorm: (x * rrms).to(x_dtype) * weight
-        n1 = (x1 * rrms).to(INPUT_DTYPE).to(tl.float32) * w1
-        n2 = (x2 * rrms).to(INPUT_DTYPE).to(tl.float32) * w2
-        # Match QKNorm .to(v) cast
-        n1 = n1.to(INPUT_DTYPE).to(tl.float32)
-        n2 = n2.to(INPUT_DTYPE).to(tl.float32)
+        n1 = x1 * rrms * w1
+        n2 = x2 * rrms * w2
 
         # RoPE
         c = tl.load(cos_ptr + cos_base + cols, mask=mask, other=1.0).to(tl.float32)
@@ -207,8 +184,7 @@ if HAS_TRITON:
         cos_ptr, sin_ptr,   # [B, L, D//2]
         H, L, D, D2,        # D2 = D // 2
         eps,
-        BLOCK_D2: tl.constexpr,   # power of 2, >= D2
-        INPUT_DTYPE: tl.constexpr,  # input dtype for intermediate casts
+        BLOCK_D2: tl.constexpr,
     ):
         """One program per (b, l, h) row. Processes Q and K, copies V.
 
@@ -241,11 +217,8 @@ if HAS_TRITON:
         rrms_q = tl.rsqrt(ss_q / D + eps)
         wq1 = tl.load(wq_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
         wq2 = tl.load(wq_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
-        # Match original RMSNorm: (x * rrms).to(x_dtype) * weight, then .to(v) cast
-        nq1 = (q1 * rrms_q).to(INPUT_DTYPE).to(tl.float32) * wq1
-        nq2 = (q2 * rrms_q).to(INPUT_DTYPE).to(tl.float32) * wq2
-        nq1 = nq1.to(INPUT_DTYPE).to(tl.float32)
-        nq2 = nq2.to(INPUT_DTYPE).to(tl.float32)
+        nq1 = q1 * rrms_q * wq1
+        nq2 = q2 * rrms_q * wq2
         oq1 = c * nq1 - s * nq2
         oq2 = s * nq1 + c * nq2
         tl.store(out_ptr + q_base + cols * 2,     oq1, mask=mask)
@@ -258,11 +231,8 @@ if HAS_TRITON:
         rrms_k = tl.rsqrt(ss_k / D + eps)
         wk1 = tl.load(wk_ptr + cols * 2,     mask=mask, other=1.0).to(tl.float32)
         wk2 = tl.load(wk_ptr + cols * 2 + 1, mask=mask, other=1.0).to(tl.float32)
-        # Match original RMSNorm: (x * rrms).to(x_dtype) * weight, then .to(v) cast
-        nk1 = (k1 * rrms_k).to(INPUT_DTYPE).to(tl.float32) * wk1
-        nk2 = (k2 * rrms_k).to(INPUT_DTYPE).to(tl.float32) * wk2
-        nk1 = nk1.to(INPUT_DTYPE).to(tl.float32)
-        nk2 = nk2.to(INPUT_DTYPE).to(tl.float32)
+        nk1 = k1 * rrms_k * wk1
+        nk2 = k2 * rrms_k * wk2
         ok1 = c * nk1 - s * nk2
         ok2 = s * nk1 + c * nk2
         tl.store(out_ptr + k_base + cols * 2,     ok1, mask=mask)
@@ -279,19 +249,7 @@ if HAS_TRITON:
 # autograd.Function wrappers (Triton forward, PyTorch backward)
 # ---------------------------------------------------------------------------
 
-_TORCH_TO_TRITON_DTYPE = {
-    torch.float32: "fp32",
-    torch.float16: "fp16",
-    torch.bfloat16: "bf16",
-}
-
 if HAS_TRITON:
-    _TRITON_DTYPE_MAP = {
-        "fp32": tl.float32,
-        "fp16": tl.float16,
-        "bf16": tl.bfloat16,
-    }
-
     class _FusedNormRopeFunction(torch.autograd.Function):
         @staticmethod
         def forward(ctx, x, weight, cos, sin, eps):
@@ -303,12 +261,10 @@ if HAS_TRITON:
             D2 = D // 2
             BLOCK_D2 = triton.next_power_of_2(D2)
             out_f32 = torch.empty(B, L, H, D, dtype=torch.float32, device=x.device)
-            triton_dtype = _TRITON_DTYPE_MAP[_TORCH_TO_TRITON_DTYPE[x.dtype]]
             fused_norm_rope_kernel[(B * L * H,)](
                 x, out_f32, weight.float(), cos, sin,
                 H, L, D, D2, eps,
                 BLOCK_D2=BLOCK_D2,
-                INPUT_DTYPE=triton_dtype,
             )
             return out_f32.to(x.dtype)
 
@@ -316,19 +272,11 @@ if HAS_TRITON:
         def backward(ctx, grad_output):
             x, weight, cos, sin = ctx.saved_tensors
             eps = ctx.eps
-            input_dtype = x.dtype
 
-            dout_f = grad_output.float()
+            dnormed = _rope_backward(grad_output.float(), cos, sin)
+            dx_f, dw_f = _rmsnorm_backward(x.float(), weight.float(), dnormed, eps)
 
-            # RoPE backward (transpose rotation)
-            dnormed = _rope_backward(dout_f, cos, sin)
-            # Match QKNorm .to(v) backward: gradient quantized through bf16 cast
-            dnormed = dnormed.to(input_dtype).float()
-
-            # RMSNorm backward (pass input_dtype for matching intermediate casts)
-            dx_f, dw_f = _rmsnorm_backward(x.float(), weight.float(), dnormed, eps, input_dtype=input_dtype)
-
-            grad_x = dx_f.to(input_dtype) if ctx.needs_input_grad[0] else None
+            grad_x = dx_f.to(x.dtype) if ctx.needs_input_grad[0] else None
             grad_w = dw_f.to(weight.dtype) if ctx.needs_input_grad[1] else None
             return grad_x, grad_w, None, None, None  # cos, sin, eps: no grad
 
@@ -343,12 +291,10 @@ if HAS_TRITON:
             D2 = D // 2
             BLOCK_D2 = triton.next_power_of_2(D2)
             out_f32 = torch.empty(B, L, 3, H, D, dtype=torch.float32, device=qkv.device)
-            triton_dtype = _TRITON_DTYPE_MAP[_TORCH_TO_TRITON_DTYPE[qkv.dtype]]
             fused_packed_qk_norm_rope_kernel[(B * L * H,)](
                 qkv, out_f32, q_weight.float(), k_weight.float(), cos, sin,
                 H, L, D, D2, eps,
                 BLOCK_D2=BLOCK_D2,
-                INPUT_DTYPE=triton_dtype,
             )
             return out_f32.to(qkv.dtype)
 
@@ -356,7 +302,6 @@ if HAS_TRITON:
         def backward(ctx, grad_output):
             qkv, q_weight, k_weight, cos, sin = ctx.saved_tensors
             eps = ctx.eps
-            input_dtype = qkv.dtype
 
             need_grad_qkv = ctx.needs_input_grad[0]
             need_grad_wq  = ctx.needs_input_grad[1]
@@ -369,31 +314,20 @@ if HAS_TRITON:
             dk_f     = None
 
             if need_grad_qkv or need_grad_wq:
-                # Slice then cast: avoids a full [B, L, 3, H, D] fp32 copy
-                q_f    = qkv[:, :, 0].float()          # [B, L, H, D] fp32
-                dout_q = grad_output[:, :, 0].float()
-                dnormed_q = _rope_backward(dout_q, cos, sin)
-                # Match QKNorm .to(v) backward: gradient quantized through input dtype cast
-                dnormed_q = dnormed_q.to(input_dtype).float()
-                dq_f, dw_q_f = _rmsnorm_backward(q_f, q_weight.float(), dnormed_q, eps, input_dtype=input_dtype)
+                dnormed_q = _rope_backward(grad_output[:, :, 0].float(), cos, sin)
+                dq_f, dw_q_f = _rmsnorm_backward(qkv[:, :, 0].float(), q_weight.float(), dnormed_q, eps)
                 if need_grad_wq:
                     grad_wq = dw_q_f.to(q_weight.dtype)
 
             if need_grad_qkv or need_grad_wk:
-                k_f    = qkv[:, :, 1].float()
-                dout_k = grad_output[:, :, 1].float()
-                dnormed_k = _rope_backward(dout_k, cos, sin)
-                # Match QKNorm .to(v) backward: gradient quantized through input dtype cast
-                dnormed_k = dnormed_k.to(input_dtype).float()
-                dk_f, dw_k_f = _rmsnorm_backward(k_f, k_weight.float(), dnormed_k, eps, input_dtype=input_dtype)
+                dnormed_k = _rope_backward(grad_output[:, :, 1].float(), cos, sin)
+                dk_f, dw_k_f = _rmsnorm_backward(qkv[:, :, 1].float(), k_weight.float(), dnormed_k, eps)
                 if need_grad_wk:
                     grad_wk = dw_k_f.to(k_weight.dtype)
 
             if need_grad_qkv:
-                # V is identity passthrough — no fp32 intermediate needed
-                dv = grad_output[:, :, 2]
                 grad_qkv = torch.stack(
-                    [dq_f.to(qkv.dtype), dk_f.to(qkv.dtype), dv], dim=2
+                    [dq_f.to(qkv.dtype), dk_f.to(qkv.dtype), grad_output[:, :, 2]], dim=2
                 )
 
             return grad_qkv, grad_wq, grad_wk, None, None, None  # cos, sin, eps

--- a/src/musubi_tuner/modules/attention.py
+++ b/src/musubi_tuner/modules/attention.py
@@ -9,11 +9,15 @@ try:
     from flash_attn.flash_attn_interface import _flash_attn_forward
     from flash_attn.flash_attn_interface import flash_attn_varlen_func
     from flash_attn.flash_attn_interface import flash_attn_func
+    from flash_attn.flash_attn_interface import flash_attn_qkvpacked_func
+    from flash_attn.flash_attn_interface import flash_attn_varlen_qkvpacked_func
 except ImportError:
     flash_attn = None
     flash_attn_varlen_func = None
     _flash_attn_forward = None
     flash_attn_func = None
+    flash_attn_qkvpacked_func = None
+    flash_attn_varlen_qkvpacked_func = None
 
 try:
     from sageattention import sageattn_varlen, sageattn
@@ -93,20 +97,33 @@ def attention(
     processing each sequence individually.
 
     Args:
-        qkv_or_q: Query tensor [B, L, H, D]. or list of such tensors.
-        k: Key tensor [B, L, H, D].
-        v: Value tensor [B, L, H, D].
-        attn_param: Attention parameters including mask and sequence lengths.
+        qkv_or_q: One of:
+            - Query tensor [B, L, H, D] (k and v must be provided separately)
+            - List [q, k, v] of tensors each [B, L, H, D]
+            - Packed QKV tensor [B, L, 3, H, D] (used directly by flash attention)
+        k: Key tensor [B, L, H, D]. Required when qkv_or_q is a plain query tensor.
+        v: Value tensor [B, L, H, D]. Required when qkv_or_q is a plain query tensor.
+        attn_params: Attention parameters including mask and sequence lengths.
         drop_rate: Attention dropout rate.
 
     Returns:
         Attention output tensor [B, L, H*D].
     """
+    # qkv_packed holds [B, L, 3, H, D] when the input was already packed.
+    # For flash attention this avoids a re-stack; other backends unpack via unbind views.
+    qkv_packed: Optional[torch.Tensor] = None
+
     if isinstance(qkv_or_q, list):
         q, k, v = qkv_or_q
         q: torch.Tensor = q
         qkv_or_q.clear()
         del qkv_or_q
+    elif isinstance(qkv_or_q, torch.Tensor) and qkv_or_q.ndim == 5:
+        # Packed QKV tensor [B, L, 3, H, D]
+        assert qkv_or_q.shape[2] == 3, f"5D input must be packed QKV [B, L, 3, H, D], got shape {tuple(qkv_or_q.shape)}"
+        qkv_packed = qkv_or_q
+        del qkv_or_q
+        q, k, v = qkv_packed.unbind(dim=2)  # views: each [B, L, H, D]
     else:
         q: torch.Tensor = qkv_or_q
         del qkv_or_q
@@ -227,32 +244,50 @@ def attention(
         if attn_params.split_attn:
             x = []
             for i in range(len(q)):
-                # HND seems to cause an error
-                x_i = flash_attn_func(q[i], k[i], v[i], drop_rate)  # B, L, H, D
-                q[i] = None
-                k[i] = None
-                v[i] = None
-                x.append(pad_fn(x_i, attn_params.max_seqlen))  # B, L, H, D
+                if qkv_packed is not None:
+                    # Packed input: slice directly, no unbind/re-stack needed
+                    qkv_i = qkv_packed[i : i + 1, : attn_params.seqlens[i]]  # [1, L_i, 3, H, D]
+                    x_i = flash_attn_qkvpacked_func(qkv_i, drop_rate)  # [1, L_i, H, D]
+                else:
+                    x_i = flash_attn_func(q[i], k[i], v[i], drop_rate)  # [1, L_i, H, D]
+                    q[i] = None
+                    k[i] = None
+                    v[i] = None
+                x.append(pad_fn(x_i, attn_params.max_seqlen))  # [1, max_seqlen, H, D]
             x = torch.cat(x, dim=0)
             q, k, v = None, None, None
+            qkv_packed = None
         elif attn_params.cu_seqlens is None:  # all tokens are valid
-            x = flash_attn_func(q, k, v, drop_rate)  # B, L, H, D
-            q, k, v = None, None, None
+            if qkv_packed is not None:
+                x = flash_attn_qkvpacked_func(qkv_packed, drop_rate)  # [B, L, H, D]
+                qkv_packed = None
+            else:
+                x = flash_attn_func(q, k, v, drop_rate)  # [B, L, H, D]
+                q, k, v = None, None, None
         else:
-            # Reshape to [(bxs), a, d]
+            # Varlen
             batch_size, seqlen = q.shape[0], q.shape[1]
-            q = q.view(q.shape[0] * q.shape[1], *q.shape[2:])  # [B*L, H, D]
-            k = k.view(k.shape[0] * k.shape[1], *k.shape[2:])  # [B*L, H, D]
-            v = v.view(v.shape[0] * v.shape[1], *v.shape[2:])  # [B*L, H, D]
+            if qkv_packed is not None:
+                # View to [B*L, 3, H, D] — zero-copy since qkv_packed is contiguous
+                qkv_flat = qkv_packed.view(batch_size * seqlen, 3, *qkv_packed.shape[3:])
+                qkv_packed = None
+                # Assume cu_seqlens_q == cu_seqlens_kv and max_seqlen_q == max_seqlen_kv
+                x = flash_attn_varlen_qkvpacked_func(
+                    qkv_flat, attn_params.cu_seqlens, attn_params.max_seqlen, drop_rate
+                )
+                qkv_flat = None
+            else:
+                q = q.view(batch_size * seqlen, *q.shape[2:])  # [B*L, H, D]
+                k = k.view(batch_size * seqlen, *k.shape[2:])
+                v = v.view(batch_size * seqlen, *v.shape[2:])
+                # Assume cu_seqlens_q == cu_seqlens_kv and max_seqlen_q == max_seqlen_kv
+                x = flash_attn_varlen_func(
+                    q, k, v, attn_params.cu_seqlens, attn_params.cu_seqlens, attn_params.max_seqlen, attn_params.max_seqlen, drop_rate
+                )
+                q, k, v = None, None, None
 
-            # Assume cu_seqlens_q == cu_seqlens_kv and max_seqlen_q == max_seqlen_kv
-            x = flash_attn_varlen_func(
-                q, k, v, attn_params.cu_seqlens, attn_params.cu_seqlens, attn_params.max_seqlen, attn_params.max_seqlen, drop_rate
-            )
-            q, k, v = None, None, None
-
-            # Reshape x with shape [(bxs), a, d] to [b, s, a, d]
-            x = x.view(batch_size, seqlen, x.shape[-2], x.shape[-1])  # B, L, H, D
+            # Reshape [B*L, H, D] → [B, L, H, D]
+            x = x.view(batch_size, seqlen, x.shape[-2], x.shape[-1])
 
     else:
         # Currently only PyTorch SDPA and xformers are implemented

--- a/tests/test_fused_norm_rope.py
+++ b/tests/test_fused_norm_rope.py
@@ -8,9 +8,9 @@ import pytest
 import torch
 from musubi_tuner.kernels.fused_norm_rope import (
     fused_norm_rope,
-    fused_qkv_norm_rope,
+    fused_packed_qk_norm_rope,
     reference_norm_rope,
-    reference_qkv_norm_rope,
+    reference_packed_qk_norm_rope,
     extract_cos_sin,
     HAS_TRITON,
 )
@@ -122,12 +122,12 @@ def test_fused_norm_rope_nontrivial_rope(B, L, H, D):
 
 
 # ---------------------------------------------------------------------------
-# Test 5: fused_qkv_norm_rope reference correctness (CPU)
+# Test 5: fused_packed_qk_norm_rope reference correctness (CPU)
 # ---------------------------------------------------------------------------
 
 
-def test_fused_qkv_norm_rope_reference_correctness():
-    """reference_qkv_norm_rope matches applying reference_norm_rope per Q and K."""
+def test_fused_packed_qk_norm_rope_reference_correctness():
+    """reference_packed_qk_norm_rope matches applying reference_norm_rope per Q and K."""
     B, L, H, D = 1, 4, 2, 8
     torch.manual_seed(7)
     D2 = D // 2
@@ -138,7 +138,7 @@ def test_fused_qkv_norm_rope_reference_correctness():
     cos = torch.cos(angles)
     sin = torch.sin(angles)
 
-    out = reference_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin)
+    out = reference_packed_qk_norm_rope(qkv, q_weight, k_weight, cos, sin)
 
     q_ref = reference_norm_rope(qkv[:, :, 0], q_weight, cos, sin)
     k_ref = reference_norm_rope(qkv[:, :, 1], k_weight, cos, sin)
@@ -151,7 +151,7 @@ def test_fused_qkv_norm_rope_reference_correctness():
 
 
 # ---------------------------------------------------------------------------
-# Test 6: fused_qkv_norm_rope Triton kernel matches reference (CUDA)
+# Test 6: fused_packed_qk_norm_rope Triton kernel matches reference (CUDA)
 # ---------------------------------------------------------------------------
 
 
@@ -168,7 +168,7 @@ def test_fused_qkv_norm_rope_reference_correctness():
         (2, 128, 24, 128),
     ],
 )
-def test_fused_qkv_norm_rope_matches_reference(dtype, B, L, H, D):
+def test_fused_packed_qk_norm_rope_matches_reference(dtype, B, L, H, D):
     """Packed QKV kernel matches reference for each Q/K/V slice."""
     torch.manual_seed(42)
     D2 = D // 2
@@ -179,8 +179,8 @@ def test_fused_qkv_norm_rope_matches_reference(dtype, B, L, H, D):
     cos = torch.cos(angles)
     sin = torch.sin(angles)
 
-    ref = reference_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin)
-    out = fused_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin)
+    ref = reference_packed_qk_norm_rope(qkv, q_weight, k_weight, cos, sin)
+    out = fused_packed_qk_norm_rope(qkv, q_weight, k_weight, cos, sin)
 
     assert out.shape == (B, L, 3, H, D)
     assert out.dtype == dtype

--- a/tests/test_fused_norm_rope.py
+++ b/tests/test_fused_norm_rope.py
@@ -11,6 +11,8 @@ from musubi_tuner.kernels.fused_norm_rope import (
     fused_packed_qk_norm_rope,
     reference_norm_rope,
     reference_packed_qk_norm_rope,
+    reference_norm_rope_fp32,
+    reference_packed_qk_norm_rope_fp32,
     extract_cos_sin,
     HAS_TRITON,
 )
@@ -36,7 +38,8 @@ def test_fused_norm_rope_matches_reference(dtype):
     cos = torch.ones(B, L, D2, device="cuda")
     sin = torch.zeros(B, L, D2, device="cuda")
 
-    ref = reference_norm_rope(x, weight, cos, sin)
+    # The kernel stays in float32, so compare against the float32 oracle.
+    ref = reference_norm_rope_fp32(x, weight, cos, sin)
     out = fused_norm_rope(x, weight, cos, sin)
 
     assert out.shape == ref.shape
@@ -113,7 +116,8 @@ def test_fused_norm_rope_nontrivial_rope(B, L, H, D):
     cos = torch.cos(angles)
     sin = torch.sin(angles)
 
-    ref = reference_norm_rope(x, weight, cos, sin)
+    # The kernel stays in float32, so compare against the float32 oracle.
+    ref = reference_norm_rope_fp32(x, weight, cos, sin)
     out = fused_norm_rope(x, weight, cos, sin)
 
     assert out.shape == ref.shape
@@ -179,7 +183,8 @@ def test_fused_packed_qk_norm_rope_matches_reference(dtype, B, L, H, D):
     cos = torch.cos(angles)
     sin = torch.sin(angles)
 
-    ref = reference_packed_qk_norm_rope(qkv, q_weight, k_weight, cos, sin)
+    # The kernel stays in float32, so compare against the float32 oracle.
+    ref = reference_packed_qk_norm_rope_fp32(qkv, q_weight, k_weight, cos, sin)
     out = fused_packed_qk_norm_rope(qkv, q_weight, k_weight, cos, sin)
 
     assert out.shape == (B, L, 3, H, D)

--- a/tests/test_fused_norm_rope.py
+++ b/tests/test_fused_norm_rope.py
@@ -1,0 +1,173 @@
+"""Tests for the fused QKNorm + RoPE Triton kernel.
+
+Compares the Triton fused kernel against a pure-PyTorch reference
+implementation using realistic Flux2-like tensor shapes.
+"""
+
+import pytest
+import torch
+
+# Skip the entire module if Triton is not available (CPU-only environments)
+triton = pytest.importorskip("triton", reason="triton not installed")
+
+from musubi_tuner.kernels.fused_norm_rope import (
+    extract_cos_sin,
+    fused_norm_rope,
+    qk_norm_rope_reference,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_freqs_cis(B: int, L: int, D_half: int, device: torch.device) -> torch.Tensor:
+    """Build a synthetic freqs_cis tensor with shape [B, 1, L, D_half, 2, 2]."""
+    # Use random angles so the rotation matrices are non-trivial
+    angles = torch.rand(B, L, D_half, device=device, dtype=torch.float32) * 2 * torch.pi
+    cos_a = torch.cos(angles)
+    sin_a = torch.sin(angles)
+    # Build rotation matrices [B, L, D_half, 2, 2]
+    rot = torch.stack(
+        [
+            torch.stack([cos_a, -sin_a], dim=-1),   # row 0: [cos, -sin]
+            torch.stack([sin_a,  cos_a], dim=-1),   # row 1: [sin,  cos]
+        ],
+        dim=-2,
+    )
+    # Add the head dimension (=1 in the actual model)
+    return rot.unsqueeze(1)  # [B, 1, L, D_half, 2, 2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")),
+    ]
+)
+def device(request):
+    return torch.device(request.param)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "B, L, H, D",
+    [
+        (2, 256, 24, 128),  # Flux2 Klein-4B-ish
+        (1, 64,  8,  64),   # smaller sanity check
+        (2, 128, 16, 128),  # another realistic shape
+    ],
+)
+def test_fused_norm_rope_matches_reference(B, L, H, D, device):
+    """Kernel output must match the PyTorch reference within bfloat16 tolerance."""
+    torch.manual_seed(42)
+    D_half = D // 2
+
+    # Input tensor in bfloat16 on the target device
+    x = torch.randn(B, L, H, D, dtype=torch.bfloat16, device=device)
+
+    # RMSNorm weight (learned scale), one per head-dimension element
+    weight = torch.rand(D, dtype=torch.bfloat16, device=device) + 0.5  # avoid zeros
+
+    # Build freqs_cis and extract cos/sin
+    freqs_cis = _make_freqs_cis(B, L, D_half, device=device)
+    cos, sin = extract_cos_sin(freqs_cis)
+
+    # Reference (pure PyTorch)
+    ref = qk_norm_rope_reference(x, weight, cos, sin, eps=1e-6)
+
+    # Fused Triton kernel
+    out = fused_norm_rope(x, weight, cos, sin, eps=1e-6)
+
+    assert out.shape == ref.shape, f"Shape mismatch: {out.shape} vs {ref.shape}"
+    assert out.dtype == ref.dtype, f"Dtype mismatch: {out.dtype} vs {ref.dtype}"
+
+    # bfloat16 has limited precision — use a generous but reasonable tolerance
+    torch.testing.assert_close(out.float(), ref.float(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_fused_norm_rope_dtypes(dtype, device):
+    """Kernel handles bf16, fp16, and fp32 inputs."""
+    torch.manual_seed(0)
+    B, L, H, D = 1, 32, 4, 64
+    D_half = D // 2
+
+    x = torch.randn(B, L, H, D, dtype=dtype, device=device)
+    weight = torch.ones(D, dtype=dtype, device=device)
+    freqs_cis = _make_freqs_cis(B, L, D_half, device=device)
+    cos, sin = extract_cos_sin(freqs_cis)
+
+    ref = qk_norm_rope_reference(x, weight, cos, sin)
+    out = fused_norm_rope(x, weight, cos, sin)
+
+    assert out.dtype == dtype
+    torch.testing.assert_close(out.float(), ref.float(), atol=1e-2, rtol=1e-2)
+
+
+def test_extract_cos_sin_shape(device):
+    """extract_cos_sin returns tensors of the expected shape."""
+    B, L, D_half = 2, 64, 32
+    freqs_cis = _make_freqs_cis(B, L, D_half, device=device)
+    cos, sin = extract_cos_sin(freqs_cis)
+    assert cos.shape == (B, L, D_half)
+    assert sin.shape == (B, L, D_half)
+
+
+def test_extract_cos_sin_values(device):
+    """cos and sin values extracted from freqs_cis are correct."""
+    B, L, D_half = 1, 4, 8
+    angles = torch.rand(B, L, D_half, device=device, dtype=torch.float32) * 2 * torch.pi
+    cos_expected = torch.cos(angles)
+    sin_expected = torch.sin(angles)
+
+    rot = torch.stack(
+        [
+            torch.stack([cos_expected, -sin_expected], dim=-1),
+            torch.stack([sin_expected,  cos_expected], dim=-1),
+        ],
+        dim=-2,
+    ).unsqueeze(1)  # [B, 1, L, D_half, 2, 2]
+
+    cos_got, sin_got = extract_cos_sin(rot)
+    torch.testing.assert_close(cos_got, cos_expected)
+    torch.testing.assert_close(sin_got, sin_expected)
+
+
+def test_identity_weight_no_rope(device):
+    """With unit weight and zero sin (no rotation), output == RMSNorm(x)."""
+    torch.manual_seed(1)
+    B, L, H, D = 1, 16, 2, 32
+    D_half = D // 2
+
+    x = torch.randn(B, L, H, D, dtype=torch.float32, device=device)
+    weight = torch.ones(D, device=device)
+
+    # Build freqs_cis with zero rotation (identity matrix)
+    cos_const = torch.ones(B, L, D_half, device=device)
+    sin_const = torch.zeros(B, L, D_half, device=device)
+
+    ref = qk_norm_rope_reference(x, weight, cos_const, sin_const)
+    out = fused_norm_rope(x, weight, cos_const, sin_const)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_output_dtype_preserved(device):
+    """Output dtype must match input dtype."""
+    for dtype in [torch.bfloat16, torch.float16, torch.float32]:
+        B, L, H, D = 1, 8, 2, 16
+        x = torch.randn(B, L, H, D, dtype=dtype, device=device)
+        weight = torch.ones(D, dtype=dtype, device=device)
+        cos = torch.ones(B, L, D // 2, device=device)
+        sin = torch.zeros(B, L, D // 2, device=device)
+        out = fused_norm_rope(x, weight, cos, sin)
+        assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"

--- a/tests/test_fused_norm_rope.py
+++ b/tests/test_fused_norm_rope.py
@@ -1,173 +1,187 @@
-"""Tests for the fused QKNorm + RoPE Triton kernel.
+"""Tests for the fused QKNorm + RoPE kernel.
 
 Compares the Triton fused kernel against a pure-PyTorch reference
-implementation using realistic Flux2-like tensor shapes.
+implementation, and validates helper utilities.
 """
 
 import pytest
 import torch
-
-# Skip the entire module if Triton is not available (CPU-only environments)
-triton = pytest.importorskip("triton", reason="triton not installed")
-
 from musubi_tuner.kernels.fused_norm_rope import (
-    extract_cos_sin,
     fused_norm_rope,
-    qk_norm_rope_reference,
+    fused_qkv_norm_rope,
+    reference_norm_rope,
+    reference_qkv_norm_rope,
+    extract_cos_sin,
+    HAS_TRITON,
 )
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Test 1: reference vs triton kernel (skip if no triton or no CUDA)
 # ---------------------------------------------------------------------------
 
 
-def _make_freqs_cis(B: int, L: int, D_half: int, device: torch.device) -> torch.Tensor:
-    """Build a synthetic freqs_cis tensor with shape [B, 1, L, D_half, 2, 2]."""
-    # Use random angles so the rotation matrices are non-trivial
-    angles = torch.rand(B, L, D_half, device=device, dtype=torch.float32) * 2 * torch.pi
-    cos_a = torch.cos(angles)
-    sin_a = torch.sin(angles)
-    # Build rotation matrices [B, L, D_half, 2, 2]
-    rot = torch.stack(
-        [
-            torch.stack([cos_a, -sin_a], dim=-1),   # row 0: [cos, -sin]
-            torch.stack([sin_a,  cos_a], dim=-1),   # row 1: [sin,  cos]
-        ],
-        dim=-2,
-    )
-    # Add the head dimension (=1 in the actual model)
-    return rot.unsqueeze(1)  # [B, 1, L, D_half, 2, 2]
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(
-    params=[
-        pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")),
-    ]
+@pytest.mark.skipif(
+    not HAS_TRITON or not torch.cuda.is_available(),
+    reason="requires triton + CUDA",
 )
-def device(request):
-    return torch.device(request.param)
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "B, L, H, D",
-    [
-        (2, 256, 24, 128),  # Flux2 Klein-4B-ish
-        (1, 64,  8,  64),   # smaller sanity check
-        (2, 128, 16, 128),  # another realistic shape
-    ],
-)
-def test_fused_norm_rope_matches_reference(B, L, H, D, device):
-    """Kernel output must match the PyTorch reference within bfloat16 tolerance."""
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_fused_norm_rope_matches_reference(dtype):
+    B, L, H, D = 2, 64, 16, 128
     torch.manual_seed(42)
-    D_half = D // 2
+    x = torch.randn(B, L, H, D, dtype=dtype, device="cuda")
+    weight = torch.randn(D, device="cuda")
+    # simple cos/sin for testing
+    D2 = D // 2
+    cos = torch.ones(B, L, D2, device="cuda")
+    sin = torch.zeros(B, L, D2, device="cuda")
 
-    # Input tensor in bfloat16 on the target device
-    x = torch.randn(B, L, H, D, dtype=torch.bfloat16, device=device)
-
-    # RMSNorm weight (learned scale), one per head-dimension element
-    weight = torch.rand(D, dtype=torch.bfloat16, device=device) + 0.5  # avoid zeros
-
-    # Build freqs_cis and extract cos/sin
-    freqs_cis = _make_freqs_cis(B, L, D_half, device=device)
-    cos, sin = extract_cos_sin(freqs_cis)
-
-    # Reference (pure PyTorch)
-    ref = qk_norm_rope_reference(x, weight, cos, sin, eps=1e-6)
-
-    # Fused Triton kernel
-    out = fused_norm_rope(x, weight, cos, sin, eps=1e-6)
-
-    assert out.shape == ref.shape, f"Shape mismatch: {out.shape} vs {ref.shape}"
-    assert out.dtype == ref.dtype, f"Dtype mismatch: {out.dtype} vs {ref.dtype}"
-
-    # bfloat16 has limited precision — use a generous but reasonable tolerance
-    torch.testing.assert_close(out.float(), ref.float(), atol=1e-2, rtol=1e-2)
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-def test_fused_norm_rope_dtypes(dtype, device):
-    """Kernel handles bf16, fp16, and fp32 inputs."""
-    torch.manual_seed(0)
-    B, L, H, D = 1, 32, 4, 64
-    D_half = D // 2
-
-    x = torch.randn(B, L, H, D, dtype=dtype, device=device)
-    weight = torch.ones(D, dtype=dtype, device=device)
-    freqs_cis = _make_freqs_cis(B, L, D_half, device=device)
-    cos, sin = extract_cos_sin(freqs_cis)
-
-    ref = qk_norm_rope_reference(x, weight, cos, sin)
+    ref = reference_norm_rope(x, weight, cos, sin)
     out = fused_norm_rope(x, weight, cos, sin)
 
+    assert out.shape == ref.shape
     assert out.dtype == dtype
     torch.testing.assert_close(out.float(), ref.float(), atol=1e-2, rtol=1e-2)
 
 
-def test_extract_cos_sin_shape(device):
-    """extract_cos_sin returns tensors of the expected shape."""
-    B, L, D_half = 2, 64, 32
-    freqs_cis = _make_freqs_cis(B, L, D_half, device=device)
-    cos, sin = extract_cos_sin(freqs_cis)
-    assert cos.shape == (B, L, D_half)
-    assert sin.shape == (B, L, D_half)
+# ---------------------------------------------------------------------------
+# Test 2: extract_cos_sin roundtrip (CPU, no triton needed)
+# ---------------------------------------------------------------------------
 
 
-def test_extract_cos_sin_values(device):
-    """cos and sin values extracted from freqs_cis are correct."""
-    B, L, D_half = 1, 4, 8
-    angles = torch.rand(B, L, D_half, device=device, dtype=torch.float32) * 2 * torch.pi
-    cos_expected = torch.cos(angles)
-    sin_expected = torch.sin(angles)
-
-    rot = torch.stack(
-        [
-            torch.stack([cos_expected, -sin_expected], dim=-1),
-            torch.stack([sin_expected,  cos_expected], dim=-1),
-        ],
-        dim=-2,
-    ).unsqueeze(1)  # [B, 1, L, D_half, 2, 2]
-
-    cos_got, sin_got = extract_cos_sin(rot)
-    torch.testing.assert_close(cos_got, cos_expected)
-    torch.testing.assert_close(sin_got, sin_expected)
+def test_extract_cos_sin():
+    B, L, D2 = 2, 64, 32
+    # Build a freqs_cis with known cos/sin values
+    cos_expected = torch.rand(B, L, D2)
+    sin_expected = torch.rand(B, L, D2)
+    # freqs_cis shape: [B, 1, L, D2, 2, 2]; the '1' is the num_heads broadcast dim.
+    # Assign via the squeezed view to avoid the singleton-dimension mismatch.
+    fc = torch.zeros(B, 1, L, D2, 2, 2)
+    fc[:, 0, :, :, 0, 0] = cos_expected
+    fc[:, 0, :, :, 0, 1] = -sin_expected
+    fc[:, 0, :, :, 1, 0] = sin_expected
+    fc[:, 0, :, :, 1, 1] = cos_expected
+    cos_out, sin_out = extract_cos_sin(fc)
+    torch.testing.assert_close(cos_out, cos_expected)
+    torch.testing.assert_close(sin_out, sin_expected)
 
 
-def test_identity_weight_no_rope(device):
-    """With unit weight and zero sin (no rotation), output == RMSNorm(x)."""
-    torch.manual_seed(1)
-    B, L, H, D = 1, 16, 2, 32
-    D_half = D // 2
-
-    x = torch.randn(B, L, H, D, dtype=torch.float32, device=device)
-    weight = torch.ones(D, device=device)
-
-    # Build freqs_cis with zero rotation (identity matrix)
-    cos_const = torch.ones(B, L, D_half, device=device)
-    sin_const = torch.zeros(B, L, D_half, device=device)
-
-    ref = qk_norm_rope_reference(x, weight, cos_const, sin_const)
-    out = fused_norm_rope(x, weight, cos_const, sin_const)
-    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+# ---------------------------------------------------------------------------
+# Test 3: reference is correct vs manual computation (CPU)
+# ---------------------------------------------------------------------------
 
 
-def test_output_dtype_preserved(device):
-    """Output dtype must match input dtype."""
-    for dtype in [torch.bfloat16, torch.float16, torch.float32]:
-        B, L, H, D = 1, 8, 2, 16
-        x = torch.randn(B, L, H, D, dtype=dtype, device=device)
-        weight = torch.ones(D, dtype=dtype, device=device)
-        cos = torch.ones(B, L, D // 2, device=device)
-        sin = torch.zeros(B, L, D // 2, device=device)
-        out = fused_norm_rope(x, weight, cos, sin)
-        assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
+def test_reference_correctness():
+    B, L, H, D = 1, 4, 2, 8
+    torch.manual_seed(0)
+    x = torch.randn(B, L, H, D)
+    weight = torch.ones(D)
+    D2 = D // 2
+    # identity RoPE (cos=1, sin=0) -> should just return normed x
+    cos = torch.ones(B, L, D2)
+    sin = torch.zeros(B, L, D2)
+    out = reference_norm_rope(x, weight, cos, sin)
+    # verify it's normalized per head
+    norms = out.pow(2).mean(-1)
+    torch.testing.assert_close(norms, torch.ones_like(norms), atol=1e-5, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: non-trivial RoPE rotations (CUDA, requires triton)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not HAS_TRITON or not torch.cuda.is_available(),
+    reason="requires triton + CUDA",
+)
+@pytest.mark.parametrize(
+    "B, L, H, D",
+    [
+        (2, 256, 24, 128),
+        (1, 64, 8, 64),
+        (2, 128, 16, 128),
+    ],
+)
+def test_fused_norm_rope_nontrivial_rope(B, L, H, D):
+    """Kernel matches reference for random (non-identity) cos/sin values."""
+    torch.manual_seed(99)
+    D2 = D // 2
+    x = torch.randn(B, L, H, D, dtype=torch.bfloat16, device="cuda")
+    weight = torch.rand(D, device="cuda") + 0.5  # avoid zeros
+    angles = torch.rand(B, L, D2, device="cuda") * 2 * torch.pi
+    cos = torch.cos(angles)
+    sin = torch.sin(angles)
+
+    ref = reference_norm_rope(x, weight, cos, sin)
+    out = fused_norm_rope(x, weight, cos, sin)
+
+    assert out.shape == ref.shape
+    assert out.dtype == torch.bfloat16
+    torch.testing.assert_close(out.float(), ref.float(), atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: fused_qkv_norm_rope reference correctness (CPU)
+# ---------------------------------------------------------------------------
+
+
+def test_fused_qkv_norm_rope_reference_correctness():
+    """reference_qkv_norm_rope matches applying reference_norm_rope per Q and K."""
+    B, L, H, D = 1, 4, 2, 8
+    torch.manual_seed(7)
+    D2 = D // 2
+    qkv = torch.randn(B, L, 3, H, D)
+    q_weight = torch.rand(D) + 0.5
+    k_weight = torch.rand(D) + 0.5
+    angles = torch.rand(B, L, D2) * 2 * torch.pi
+    cos = torch.cos(angles)
+    sin = torch.sin(angles)
+
+    out = reference_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin)
+
+    q_ref = reference_norm_rope(qkv[:, :, 0], q_weight, cos, sin)
+    k_ref = reference_norm_rope(qkv[:, :, 1], k_weight, cos, sin)
+    v_ref = qkv[:, :, 2].float()
+
+    assert out.shape == (B, L, 3, H, D)
+    torch.testing.assert_close(out[:, :, 0].float(), q_ref.float(), atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(out[:, :, 1].float(), k_ref.float(), atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(out[:, :, 2].float(), v_ref, atol=1e-5, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: fused_qkv_norm_rope Triton kernel matches reference (CUDA)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not HAS_TRITON or not torch.cuda.is_available(),
+    reason="requires triton + CUDA",
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "B, L, H, D",
+    [
+        (2, 64, 16, 128),
+        (1, 32, 8, 64),
+        (2, 128, 24, 128),
+    ],
+)
+def test_fused_qkv_norm_rope_matches_reference(dtype, B, L, H, D):
+    """Packed QKV kernel matches reference for each Q/K/V slice."""
+    torch.manual_seed(42)
+    D2 = D // 2
+    qkv = torch.randn(B, L, 3, H, D, dtype=dtype, device="cuda")
+    q_weight = (torch.rand(D, device="cuda") + 0.5).to(dtype)
+    k_weight = (torch.rand(D, device="cuda") + 0.5).to(dtype)
+    angles = torch.rand(B, L, D2, device="cuda") * 2 * torch.pi
+    cos = torch.cos(angles)
+    sin = torch.sin(angles)
+
+    ref = reference_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin)
+    out = fused_qkv_norm_rope(qkv, q_weight, k_weight, cos, sin)
+
+    assert out.shape == (B, L, 3, H, D)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out.float(), ref.float(), atol=1e-2, rtol=1e-2)

--- a/tests/test_fused_norm_rope_gradients.py
+++ b/tests/test_fused_norm_rope_gradients.py
@@ -1,0 +1,202 @@
+"""Gradient diagnostics for fused QKNorm + RoPE kernel.
+
+Confirms that:
+  1. reference_qkv_norm_rope produces correct non-zero gradients (baseline).
+  2. fused_qkv_norm_rope (with autograd.Function) matches reference gradients.
+  3. Gradient flow reaches both qkv (→ linear weights) and norm scale weights.
+
+Run with:
+  uv run --extra cu128 pytest tests/test_fused_norm_rope_gradients.py -v
+"""
+
+import pytest
+import torch
+from musubi_tuner.kernels.fused_norm_rope import (
+    HAS_TRITON,
+    fused_qkv_norm_rope,
+    reference_qkv_norm_rope,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_inputs(B, L, H, D, dtype, device, seed=42):
+    torch.manual_seed(seed)
+    D2 = D // 2
+    qkv = torch.randn(B, L, 3, H, D, dtype=dtype, device=device)
+    q_weight = (torch.rand(D, device=device) + 0.5).to(dtype)
+    k_weight = (torch.rand(D, device=device) + 0.5).to(dtype)
+    angles = torch.rand(B, L, D2, device=device) * 2 * torch.pi
+    cos = torch.cos(angles)
+    sin = torch.sin(angles)
+    return qkv, q_weight, k_weight, cos, sin
+
+
+def _clone_with_grad(*tensors):
+    """Return clones with requires_grad=True for each tensor."""
+    return [t.detach().clone().requires_grad_(True) for t in tensors]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: reference produces non-zero gradients (sanity check)
+# ---------------------------------------------------------------------------
+
+
+def test_reference_gradients_are_nonzero():
+    """Baseline: reference_qkv_norm_rope must produce valid grads."""
+    B, L, H, D = 1, 16, 8, 64
+    qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.float32, "cpu")
+    qkv_r, q_w_r, k_w_r = _clone_with_grad(qkv, q_w, k_w)
+
+    out = reference_qkv_norm_rope(qkv_r, q_w_r, k_w_r, cos, sin)
+    out.sum().backward()
+
+    assert qkv_r.grad is not None, "qkv grad should exist"
+    assert q_w_r.grad is not None, "q_weight grad should exist"
+    assert k_w_r.grad is not None, "k_weight grad should exist"
+
+    assert qkv_r.grad.norm() > 0, "qkv grad should be non-zero"
+    assert q_w_r.grad.norm() > 0, "q_weight grad should be non-zero"
+    assert k_w_r.grad.norm() > 0, "k_weight grad should be non-zero"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: diagnose whether fused produces gradients at all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not HAS_TRITON or not torch.cuda.is_available(),
+    reason="requires triton + CUDA",
+)
+def test_fused_gradients_exist():
+    """fused_qkv_norm_rope must produce non-None, non-zero gradients."""
+    B, L, H, D = 1, 16, 8, 64
+    qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
+    qkv_f, q_w_f, k_w_f = _clone_with_grad(qkv.cuda(), q_w.cuda(), k_w.cuda())
+
+    out = fused_qkv_norm_rope(qkv_f, q_w_f, k_w_f, cos, sin)
+    out.sum().backward()
+
+    assert qkv_f.grad is not None, (
+        "qkv.grad is None — Triton kernel is not wrapped in autograd.Function; "
+        "gradients cannot flow to linear1.weight / LoRA adapters"
+    )
+    assert q_w_f.grad is not None, (
+        "q_weight.grad is None — query_norm.scale will not be updated"
+    )
+    assert k_w_f.grad is not None, (
+        "k_weight.grad is None — key_norm.scale will not be updated"
+    )
+
+    assert qkv_f.grad.norm() > 0, "qkv grad is zero"
+    assert q_w_f.grad.norm() > 0, "q_weight grad is zero"
+    assert k_w_f.grad.norm() > 0, "k_weight grad is zero"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: fused gradients match reference gradients
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not HAS_TRITON or not torch.cuda.is_available(),
+    reason="requires triton + CUDA",
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "B, L, H, D",
+    [
+        (1, 16, 8, 64),
+        (2, 32, 16, 128),
+        (1, 64, 24, 128),
+    ],
+)
+def test_fused_gradients_match_reference(dtype, B, L, H, D):
+    """Fused kernel gradients must numerically match the reference PyTorch path."""
+    qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, dtype, "cuda")
+    cos_cuda = cos.cuda()
+    sin_cuda = sin.cuda()
+
+    # Reference
+    qkv_r, q_w_r, k_w_r = _clone_with_grad(qkv, q_w, k_w)
+    out_r = reference_qkv_norm_rope(qkv_r, q_w_r, k_w_r, cos_cuda, sin_cuda)
+    out_r.sum().backward()
+
+    # Fused
+    qkv_f, q_w_f, k_w_f = _clone_with_grad(qkv, q_w, k_w)
+    out_f = fused_qkv_norm_rope(qkv_f, q_w_f, k_w_f, cos_cuda, sin_cuda)
+    out_f.sum().backward()
+
+    # Compare gradients (float32 comparison, loose tolerance for bfloat16)
+    atol, rtol = (5e-2, 1e-2) if dtype == torch.bfloat16 else (1e-2, 1e-2)
+
+    torch.testing.assert_close(
+        qkv_f.grad.float(), qkv_r.grad.float(), atol=atol, rtol=rtol,
+        msg="qkv gradient mismatch between fused and reference"
+    )
+    torch.testing.assert_close(
+        q_w_f.grad.float(), q_w_r.grad.float(), atol=atol, rtol=rtol,
+        msg="q_weight gradient mismatch"
+    )
+    torch.testing.assert_close(
+        k_w_f.grad.float(), k_w_r.grad.float(), atol=atol, rtol=rtol,
+        msg="k_weight gradient mismatch"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: V gradient passthrough (V is unchanged, grad must be identity)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not HAS_TRITON or not torch.cuda.is_available(),
+    reason="requires triton + CUDA",
+)
+def test_v_gradient_passthrough():
+    """Gradient w.r.t. V slice must pass through unchanged (no norm/rope applied to V)."""
+    B, L, H, D = 1, 16, 8, 64
+    qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
+    qkv_f, q_w_f, k_w_f = _clone_with_grad(qkv, q_w, k_w)
+
+    out = fused_qkv_norm_rope(qkv_f, q_w_f, k_w_f, cos, sin)
+
+    # Backprop a gradient that only has signal in the V slice
+    grad = torch.zeros_like(out)
+    grad[:, :, 2] = 1.0  # only V
+    out.backward(grad)
+
+    # Q and K slices of qkv.grad should be zero (no gradient from V output)
+    assert qkv_f.grad[:, :, 0].norm() == 0, "Q slice got unexpected grad from V output"
+    assert qkv_f.grad[:, :, 1].norm() == 0, "K slice got unexpected grad from V output"
+    # V slice should get the identity gradient (cast to bf16)
+    torch.testing.assert_close(
+        qkv_f.grad[:, :, 2].float(),
+        grad[:, :, 2].float(),
+        atol=1e-3, rtol=0,
+        msg="V gradient should be identity passthrough"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: CPU / no-Triton fallback also has correct gradients
+# ---------------------------------------------------------------------------
+
+
+def test_reference_fallback_gradients_cpu():
+    """reference_qkv_norm_rope on CPU must have valid grads (fallback path)."""
+    B, L, H, D = 1, 8, 4, 32
+    qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.float32, "cpu")
+    qkv_r, q_w_r, k_w_r = _clone_with_grad(qkv, q_w, k_w)
+
+    # This exercises the PyTorch reference path (same as fused fallback when no Triton)
+    out = reference_qkv_norm_rope(qkv_r, q_w_r, k_w_r, cos, sin)
+    out.sum().backward()
+
+    assert qkv_r.grad is not None and qkv_r.grad.norm() > 0
+    assert q_w_r.grad is not None and q_w_r.grad.norm() > 0
+    assert k_w_r.grad is not None and k_w_r.grad.norm() > 0

--- a/tests/test_fused_norm_rope_gradients.py
+++ b/tests/test_fused_norm_rope_gradients.py
@@ -1,8 +1,8 @@
 """Gradient diagnostics for fused QKNorm + RoPE kernel.
 
 Confirms that:
-  1. reference_qkv_norm_rope produces correct non-zero gradients (baseline).
-  2. fused_qkv_norm_rope (with autograd.Function) matches reference gradients.
+  1. reference_packed_qk_norm_rope produces correct non-zero gradients (baseline).
+  2. fused_packed_qk_norm_rope (with autograd.Function) matches reference gradients.
   3. Gradient flow reaches both qkv (→ linear weights) and norm scale weights.
 
 Run with:
@@ -13,8 +13,8 @@ import pytest
 import torch
 from musubi_tuner.kernels.fused_norm_rope import (
     HAS_TRITON,
-    fused_qkv_norm_rope,
-    reference_qkv_norm_rope,
+    fused_packed_qk_norm_rope,
+    reference_packed_qk_norm_rope,
 )
 
 
@@ -46,12 +46,12 @@ def _clone_with_grad(*tensors):
 
 
 def test_reference_gradients_are_nonzero():
-    """Baseline: reference_qkv_norm_rope must produce valid grads."""
+    """Baseline: reference_packed_qk_norm_rope must produce valid grads."""
     B, L, H, D = 1, 16, 8, 64
     qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.float32, "cpu")
     qkv_r, q_w_r, k_w_r = _clone_with_grad(qkv, q_w, k_w)
 
-    out = reference_qkv_norm_rope(qkv_r, q_w_r, k_w_r, cos, sin)
+    out = reference_packed_qk_norm_rope(qkv_r, q_w_r, k_w_r, cos, sin)
     out.sum().backward()
 
     assert qkv_r.grad is not None, "qkv grad should exist"
@@ -73,12 +73,12 @@ def test_reference_gradients_are_nonzero():
     reason="requires triton + CUDA",
 )
 def test_fused_gradients_exist():
-    """fused_qkv_norm_rope must produce non-None, non-zero gradients."""
+    """fused_packed_qk_norm_rope must produce non-None, non-zero gradients."""
     B, L, H, D = 1, 16, 8, 64
     qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
     qkv_f, q_w_f, k_w_f = _clone_with_grad(qkv.cuda(), q_w.cuda(), k_w.cuda())
 
-    out = fused_qkv_norm_rope(qkv_f, q_w_f, k_w_f, cos, sin)
+    out = fused_packed_qk_norm_rope(qkv_f, q_w_f, k_w_f, cos, sin)
     out.sum().backward()
 
     assert qkv_f.grad is not None, (
@@ -123,12 +123,12 @@ def test_fused_gradients_match_reference(dtype, B, L, H, D):
 
     # Reference
     qkv_r, q_w_r, k_w_r = _clone_with_grad(qkv, q_w, k_w)
-    out_r = reference_qkv_norm_rope(qkv_r, q_w_r, k_w_r, cos_cuda, sin_cuda)
+    out_r = reference_packed_qk_norm_rope(qkv_r, q_w_r, k_w_r, cos_cuda, sin_cuda)
     out_r.sum().backward()
 
     # Fused
     qkv_f, q_w_f, k_w_f = _clone_with_grad(qkv, q_w, k_w)
-    out_f = fused_qkv_norm_rope(qkv_f, q_w_f, k_w_f, cos_cuda, sin_cuda)
+    out_f = fused_packed_qk_norm_rope(qkv_f, q_w_f, k_w_f, cos_cuda, sin_cuda)
     out_f.sum().backward()
 
     # Compare gradients (float32 comparison, loose tolerance for bfloat16)
@@ -163,7 +163,7 @@ def test_v_gradient_passthrough():
     qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
     qkv_f, q_w_f, k_w_f = _clone_with_grad(qkv, q_w, k_w)
 
-    out = fused_qkv_norm_rope(qkv_f, q_w_f, k_w_f, cos, sin)
+    out = fused_packed_qk_norm_rope(qkv_f, q_w_f, k_w_f, cos, sin)
 
     # Backprop a gradient that only has signal in the V slice
     grad = torch.zeros_like(out)
@@ -188,13 +188,13 @@ def test_v_gradient_passthrough():
 
 
 def test_reference_fallback_gradients_cpu():
-    """reference_qkv_norm_rope on CPU must have valid grads (fallback path)."""
+    """reference_packed_qk_norm_rope on CPU must have valid grads (fallback path)."""
     B, L, H, D = 1, 8, 4, 32
     qkv, q_w, k_w, cos, sin = _make_inputs(B, L, H, D, torch.float32, "cpu")
     qkv_r, q_w_r, k_w_r = _clone_with_grad(qkv, q_w, k_w)
 
     # This exercises the PyTorch reference path (same as fused fallback when no Triton)
-    out = reference_qkv_norm_rope(qkv_r, q_w_r, k_w_r, cos, sin)
+    out = reference_packed_qk_norm_rope(qkv_r, q_w_r, k_w_r, cos, sin)
     out.sum().backward()
 
     assert qkv_r.grad is not None and qkv_r.grad.norm() > 0

--- a/tests/test_fused_norm_rope_gradients.py
+++ b/tests/test_fused_norm_rope_gradients.py
@@ -15,6 +15,7 @@ from musubi_tuner.kernels.fused_norm_rope import (
     HAS_TRITON,
     fused_packed_qk_norm_rope,
     reference_packed_qk_norm_rope,
+    reference_packed_qk_norm_rope_fp32,
 )
 
 
@@ -121,9 +122,9 @@ def test_fused_gradients_match_reference(dtype, B, L, H, D):
     cos_cuda = cos.cuda()
     sin_cuda = sin.cuda()
 
-    # Reference
+    # Float32 reference (the kernel's oracle — kernel stays in float32)
     qkv_r, q_w_r, k_w_r = _clone_with_grad(qkv, q_w, k_w)
-    out_r = reference_packed_qk_norm_rope(qkv_r, q_w_r, k_w_r, cos_cuda, sin_cuda)
+    out_r = reference_packed_qk_norm_rope_fp32(qkv_r, q_w_r, k_w_r, cos_cuda, sin_cuda)
     out_r.sum().backward()
 
     # Fused

--- a/tests/test_packed_vs_original.py
+++ b/tests/test_packed_vs_original.py
@@ -12,9 +12,12 @@ The fused packed path:
   3. fused_packed_qk_norm_rope: RMSNorm + RoPE in float32, cast back
 
 These tests verify:
-  - Forward outputs are close (with expected bf16 intermediate precision gap)
-  - Backward gradients match (w.r.t. qkv input and norm scale weights)
-  - The fused path doesn't introduce training-breaking gradient divergence
+  - The PyTorch reference reproduces main's original numerics exactly (it is the
+    production fallback when Triton is unavailable), in both fp32 and bf16.
+  - The fused Triton kernel matches its own float32 oracle
+    (reference_packed_qk_norm_rope_fp32), since the kernel stays in float32.
+  - The fused path doesn't introduce training-breaking gradient divergence vs.
+    the original (loose tolerance, bf16 + cross-layout accumulation only).
 
 Run with:
   uv run --extra cu128 pytest tests/test_packed_vs_original.py -v
@@ -29,6 +32,7 @@ from musubi_tuner.kernels.fused_norm_rope import (
     HAS_TRITON,
     fused_packed_qk_norm_rope,
     reference_packed_qk_norm_rope,
+    reference_packed_qk_norm_rope_fp32,
     extract_cos_sin,
 )
 
@@ -72,12 +76,15 @@ def _original_path(
     qkv_5d = qkv_flat.reshape(B, L, 3, num_heads, D).permute(2, 0, 3, 1, 4)  # [3, B, H, L, D]
     q, k, v = qkv_5d.unbind(0)
 
-    # QKNorm: RMSNorm in float32, no intermediate casts
+    # QKNorm exactly as in main's flux2_models.py RMSNorm.forward:
+    #   (x.float() * rrms).to(x_dtype) * scale  — round to input dtype BEFORE scale
     def _rmsnorm(x: Tensor, scale: Tensor) -> Tensor:
-        x = x.float()
-        rrms = torch.rsqrt(torch.mean(x**2, dim=-1, keepdim=True) + 1e-6)
-        return x * rrms * scale.float()
+        x_dtype = x.dtype
+        xf = x.float()
+        rrms = torch.rsqrt(torch.mean(xf**2, dim=-1, keepdim=True) + 1e-6)
+        return (xf * rrms).to(x_dtype) * scale
 
+    # QKNorm.forward then casts q,k to v's dtype.
     q = _rmsnorm(q, q_scale).to(v.dtype)
     k = _rmsnorm(k, k_scale).to(v.dtype)
 
@@ -115,11 +122,33 @@ def _reference_path(
     pe: Tensor,
     num_heads: int,
 ) -> Tensor:
-    """Reference (PyTorch) packed path — always available, no Triton needed."""
+    """Reference (PyTorch) packed path — always available, no Triton needed.
+
+    Reproduces main's original numerics exactly (bf16 intermediate casts), so
+    it is the oracle for the production fallback.
+    """
     B, L = qkv_flat.shape[:2]
     qkv = qkv_flat.contiguous().reshape(B, L, 3, num_heads, -1)
     cos, sin = extract_cos_sin(pe)
     return reference_packed_qk_norm_rope(qkv, q_scale, k_scale, cos, sin)
+
+
+def _reference_fp32_path(
+    qkv_flat: Tensor,
+    q_scale: Tensor,
+    k_scale: Tensor,
+    pe: Tensor,
+    num_heads: int,
+) -> Tensor:
+    """Float32 reference packed path — the oracle for the fused Triton kernel.
+
+    The fused kernel keeps float32 throughout (no intermediate bf16 casts), so
+    it is verified against this, not against the original-matching reference.
+    """
+    B, L = qkv_flat.shape[:2]
+    qkv = qkv_flat.contiguous().reshape(B, L, 3, num_heads, -1)
+    cos, sin = extract_cos_sin(pe)
+    return reference_packed_qk_norm_rope_fp32(qkv, q_scale, k_scale, cos, sin)
 
 
 def _make_inputs(B, L, H, D, dtype, device, seed=42):
@@ -166,19 +195,19 @@ class TestForwardComparison:
         )
 
     def test_reference_vs_original_bf16(self, B, L, H, D):
-        """In bf16, intermediate quantization causes a small gap — quantify it."""
+        """In bf16 the reference must match the original exactly: both apply the
+        same intermediate bf16 cast in RMSNorm ((x*rrms).to(dtype)*scale) and the
+        same QKNorm .to(v) cast, so they are byte-for-byte identical."""
         device = "cpu"
         qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, device)
 
         out_orig = _original_path(qkv, q_s, k_s, pe, H)
         out_ref = _reference_path(qkv, q_s, k_s, pe, H)
 
-        # The fused path keeps float32 throughout; original has intermediate bf16.
-        # Expect small differences — this test documents the gap.
         torch.testing.assert_close(
             out_ref.float(), out_orig.float(),
-            atol=5e-2, rtol=1e-2,
-            msg="bf16 forward mismatch exceeds expected tolerance",
+            atol=1e-6, rtol=1e-6,
+            msg="bf16 reference must reproduce original exactly",
         )
 
     @pytest.mark.skipif(
@@ -203,16 +232,20 @@ class TestForwardComparison:
         reason="requires triton + CUDA",
     )
     def test_fused_matches_reference_cuda(self, B, L, H, D):
-        """Fused Triton kernel must match its own reference exactly."""
+        """Fused Triton kernel must match its own float32 reference.
+
+        The kernel stays in float32 throughout, so its oracle is the fp32
+        reference (not the original-matching reference, which adds bf16 casts).
+        """
         qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
 
-        out_ref = _reference_path(qkv, q_s, k_s, pe, H)
+        out_ref = _reference_fp32_path(qkv, q_s, k_s, pe, H)
         out_fused = _fused_path(qkv, q_s, k_s, pe, H)
 
         torch.testing.assert_close(
             out_fused.float(), out_ref.float(),
             atol=1e-2, rtol=1e-2,
-            msg="Fused kernel should match its own PyTorch reference",
+            msg="Fused kernel should match its own float32 reference",
         )
 
 
@@ -263,12 +296,9 @@ class TestBackwardComparison:
         )
 
     def test_gradients_reference_vs_original_bf16(self, B, L, H, D):
-        """In bf16, scale gradients diverge due to intermediate bf16 quantization
-        in the original RMSNorm: (x * rrms).to(x_dtype) * scale.
-
-        qkv gradients stay close, but q_scale/k_scale gradients can differ by ~0.2
-        because the original path quantizes to bf16 before the scale multiply,
-        which affects the gradient computation for scale.
+        """In bf16 the reference reproduces the original op-for-op (same
+        intermediate bf16 cast in RMSNorm and same QKNorm .to(v)), so autograd
+        builds the identical graph and all gradients match exactly.
         """
         qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cpu")
 
@@ -282,22 +312,20 @@ class TestBackwardComparison:
         out_r = _reference_path(qkv_r, q_s_r, k_s_r, pe, H)
         out_r.sum().backward()
 
-        # qkv gradients stay close
         torch.testing.assert_close(
             qkv_r.grad.float(), qkv_o.grad.float(),
-            atol=5e-2, rtol=1e-2,
+            atol=1e-5, rtol=1e-5,
             msg="qkv gradient mismatch (bf16, reference vs original)",
         )
-        # Scale gradients diverge — loose tolerance documents the expected gap
         torch.testing.assert_close(
             q_s_r.grad.float(), q_s_o.grad.float(),
-            atol=3e-1, rtol=5e-1,
-            msg="q_scale gradient mismatch (bf16) — expected gap from intermediate quantization",
+            atol=1e-5, rtol=1e-5,
+            msg="q_scale gradient mismatch (bf16, reference vs original)",
         )
         torch.testing.assert_close(
             k_s_r.grad.float(), k_s_o.grad.float(),
-            atol=3e-1, rtol=5e-1,
-            msg="k_scale gradient mismatch (bf16) — expected gap from intermediate quantization",
+            atol=1e-5, rtol=1e-5,
+            msg="k_scale gradient mismatch (bf16, reference vs original)",
         )
 
     @pytest.mark.skipif(
@@ -345,12 +373,12 @@ class TestBackwardComparison:
         reason="requires triton + CUDA",
     )
     def test_gradients_fused_matches_reference_cuda(self, B, L, H, D):
-        """Fused kernel gradients must match its own PyTorch reference."""
+        """Fused kernel gradients must match its own float32 reference."""
         qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
 
-        # Reference path
+        # Float32 reference path (the kernel's oracle)
         qkv_r, q_s_r, k_s_r = _clone_with_grad(qkv, q_s, k_s)
-        out_r = _reference_path(qkv_r, q_s_r, k_s_r, pe, H)
+        out_r = _reference_fp32_path(qkv_r, q_s_r, k_s_r, pe, H)
         out_r.sum().backward()
 
         # Fused path
@@ -404,11 +432,12 @@ def test_forward_gap_diagnostic(dtype):
     print(f"  V max diff:    {diff[:,:,2].max().item():.6e}")
     print(f"{'='*60}")
 
-    # In fp32, should be near-zero; in bf16, expect small gap
+    # Reference now reproduces the original op-for-op, so both fp32 and bf16
+    # should be near-zero (the reference is no longer fp32-simplified).
     if dtype == torch.float32:
         assert diff.max() < 1e-4, f"fp32 gap too large: {diff.max().item()}"
     else:
-        assert diff.max() < 0.1, f"bf16 gap too large: {diff.max().item()}"
+        assert diff.max() < 1e-4, f"bf16 gap too large: {diff.max().item()}"
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
@@ -444,4 +473,5 @@ def test_backward_gap_diagnostic(dtype):
         if dtype == torch.float32:
             assert diff.max() < 1e-4, f"fp32 {name} gradient gap too large: {diff.max().item()}"
         else:
-            assert diff.max() < 0.5, f"bf16 {name} gradient gap too large: {diff.max().item()}"
+            # Reference reproduces the original op-for-op → identical autograd graph.
+            assert diff.max() < 1e-3, f"bf16 {name} gradient gap too large: {diff.max().item()}"

--- a/tests/test_packed_vs_original.py
+++ b/tests/test_packed_vs_original.py
@@ -1,0 +1,447 @@
+"""Compare original (separate Q/K/V) norm+rope path against fused packed path.
+
+The original Flux2 path:
+  1. rearrange qkv to [K, B, H, L, D]
+  2. QKNorm: RMSNorm(q), RMSNorm(k), then cast to v's dtype (bf16)
+  3. apply_rope in float32, cast back to input dtype
+  4. transpose to [B, L, H, D]
+
+The fused packed path:
+  1. reshape qkv to [B, L, 3, H, D]
+  2. extract_cos_sin from rotation-matrix pe
+  3. fused_packed_qk_norm_rope: RMSNorm + RoPE in float32, cast back
+
+These tests verify:
+  - Forward outputs are close (with expected bf16 intermediate precision gap)
+  - Backward gradients match (w.r.t. qkv input and norm scale weights)
+  - The fused path doesn't introduce training-breaking gradient divergence
+
+Run with:
+  uv run --extra cu128 pytest tests/test_packed_vs_original.py -v
+"""
+
+import pytest
+import torch
+from torch import Tensor
+
+from musubi_tuner.flux_2.flux2_models import apply_rope, rope
+from musubi_tuner.kernels.fused_norm_rope import (
+    HAS_TRITON,
+    fused_packed_qk_norm_rope,
+    reference_packed_qk_norm_rope,
+    extract_cos_sin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pe(B: int, L: int, D: int, device: torch.device, theta: int = 256):
+    """Build rotation-matrix pe identical to Flux2's rope() output.
+
+    Returns shape [B, 1, L, D//2, 2, 2].
+    """
+    pos = torch.arange(L, device=device).unsqueeze(0).expand(B, -1).float()
+    pe = rope(pos, D, theta)  # [B, L, D//2, 2, 2]
+    return pe.unsqueeze(1)  # [B, 1, L, D//2, 2, 2]
+
+
+def _original_path(
+    qkv_flat: Tensor,
+    q_scale: Tensor,
+    k_scale: Tensor,
+    pe: Tensor,
+    num_heads: int,
+) -> Tensor:
+    """Original Flux2 path: separate Q/K/V → QKNorm → apply_rope → transpose.
+
+    Args:
+        qkv_flat: [B, L, 3*H*D] — contiguous projection output.
+        q_scale, k_scale: [D] — RMSNorm scale parameters.
+        pe: [B, 1, L, D//2, 2, 2] — rotation matrix.
+        num_heads: number of attention heads.
+
+    Returns:
+        Packed [B, L, 3, H, D] with Q normed+rotated, K normed+rotated, V unchanged.
+    """
+    B, L, _ = qkv_flat.shape
+    D = qkv_flat.shape[-1] // (3 * num_heads)
+    # rearrange "B L (K H D) -> K B H L D"
+    qkv_5d = qkv_flat.reshape(B, L, 3, num_heads, D).permute(2, 0, 3, 1, 4)  # [3, B, H, L, D]
+    q, k, v = qkv_5d.unbind(0)
+
+    # QKNorm: RMSNorm in float32, no intermediate casts
+    def _rmsnorm(x: Tensor, scale: Tensor) -> Tensor:
+        x = x.float()
+        rrms = torch.rsqrt(torch.mean(x**2, dim=-1, keepdim=True) + 1e-6)
+        return x * rrms * scale.float()
+
+    q = _rmsnorm(q, q_scale).to(v.dtype)
+    k = _rmsnorm(k, k_scale).to(v.dtype)
+
+    # apply_rope in float32, cast back to input dtype
+    q, k = apply_rope(q, k, pe)
+
+    # Transpose to [B, L, H, D] and stack
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    return torch.stack([q, k, v], dim=2)  # [B, L, 3, H, D]
+
+
+def _fused_path(
+    qkv_flat: Tensor,
+    q_scale: Tensor,
+    k_scale: Tensor,
+    pe: Tensor,
+    num_heads: int,
+) -> Tensor:
+    """New fused packed path: reshape → extract_cos_sin → fused_packed_qk_norm_rope.
+
+    Same inputs/outputs as _original_path.
+    """
+    B, L = qkv_flat.shape[:2]
+    qkv = qkv_flat.contiguous().reshape(B, L, 3, num_heads, -1)
+    cos, sin = extract_cos_sin(pe)
+    return fused_packed_qk_norm_rope(qkv, q_scale, k_scale, cos, sin)
+
+
+def _reference_path(
+    qkv_flat: Tensor,
+    q_scale: Tensor,
+    k_scale: Tensor,
+    pe: Tensor,
+    num_heads: int,
+) -> Tensor:
+    """Reference (PyTorch) packed path — always available, no Triton needed."""
+    B, L = qkv_flat.shape[:2]
+    qkv = qkv_flat.contiguous().reshape(B, L, 3, num_heads, -1)
+    cos, sin = extract_cos_sin(pe)
+    return reference_packed_qk_norm_rope(qkv, q_scale, k_scale, cos, sin)
+
+
+def _make_inputs(B, L, H, D, dtype, device, seed=42):
+    """Create shared inputs for both paths."""
+    torch.manual_seed(seed)
+    qkv_flat = torch.randn(B, L, 3 * H * D, dtype=dtype, device=device)
+    q_scale = (torch.rand(D, device=device) + 0.5).to(torch.float32)
+    k_scale = (torch.rand(D, device=device) + 0.5).to(torch.float32)
+    pe = _make_pe(B, L, D, device)
+    return qkv_flat, q_scale, k_scale, pe
+
+
+def _clone_with_grad(*tensors):
+    return [t.detach().clone().requires_grad_(True) for t in tensors]
+
+
+# ---------------------------------------------------------------------------
+# Forward tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "B, L, H, D",
+    [
+        (1, 16, 8, 64),
+        (2, 32, 16, 128),
+        (1, 64, 24, 128),
+    ],
+)
+class TestForwardComparison:
+    """Forward output comparison between original and fused paths."""
+
+    def test_reference_matches_original_fp32(self, B, L, H, D):
+        """In float32 both paths should be nearly identical (no bf16 intermediate cast)."""
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.float32, "cpu")
+
+        out_orig = _original_path(qkv, q_s, k_s, pe, H)
+        out_ref = _reference_path(qkv, q_s, k_s, pe, H)
+
+        torch.testing.assert_close(
+            out_ref.float(), out_orig.float(),
+            atol=1e-5, rtol=1e-5,
+            msg="In float32, reference and original should match exactly",
+        )
+
+    def test_reference_vs_original_bf16(self, B, L, H, D):
+        """In bf16, intermediate quantization causes a small gap — quantify it."""
+        device = "cpu"
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, device)
+
+        out_orig = _original_path(qkv, q_s, k_s, pe, H)
+        out_ref = _reference_path(qkv, q_s, k_s, pe, H)
+
+        # The fused path keeps float32 throughout; original has intermediate bf16.
+        # Expect small differences — this test documents the gap.
+        torch.testing.assert_close(
+            out_ref.float(), out_orig.float(),
+            atol=5e-2, rtol=1e-2,
+            msg="bf16 forward mismatch exceeds expected tolerance",
+        )
+
+    @pytest.mark.skipif(
+        not HAS_TRITON or not torch.cuda.is_available(),
+        reason="requires triton + CUDA",
+    )
+    def test_fused_vs_original_cuda(self, B, L, H, D):
+        """Fused Triton kernel vs original path on CUDA."""
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
+
+        out_orig = _original_path(qkv, q_s, k_s, pe, H)
+        out_fused = _fused_path(qkv, q_s, k_s, pe, H)
+
+        torch.testing.assert_close(
+            out_fused.float(), out_orig.float(),
+            atol=5e-2, rtol=1e-2,
+            msg="Fused CUDA forward vs original exceeds tolerance",
+        )
+
+    @pytest.mark.skipif(
+        not HAS_TRITON or not torch.cuda.is_available(),
+        reason="requires triton + CUDA",
+    )
+    def test_fused_matches_reference_cuda(self, B, L, H, D):
+        """Fused Triton kernel must match its own reference exactly."""
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
+
+        out_ref = _reference_path(qkv, q_s, k_s, pe, H)
+        out_fused = _fused_path(qkv, q_s, k_s, pe, H)
+
+        torch.testing.assert_close(
+            out_fused.float(), out_ref.float(),
+            atol=1e-2, rtol=1e-2,
+            msg="Fused kernel should match its own PyTorch reference",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Backward tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "B, L, H, D",
+    [
+        (1, 16, 8, 64),
+        (2, 32, 16, 128),
+        (1, 64, 24, 128),
+    ],
+)
+class TestBackwardComparison:
+    """Backward gradient comparison between original and reference/fused paths."""
+
+    def test_gradients_reference_vs_original_fp32(self, B, L, H, D):
+        """In float32, gradients should match tightly."""
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.float32, "cpu")
+
+        # Original path
+        qkv_o, q_s_o, k_s_o = _clone_with_grad(qkv, q_s, k_s)
+        out_o = _original_path(qkv_o, q_s_o, k_s_o, pe, H)
+        out_o.sum().backward()
+
+        # Reference path
+        qkv_r, q_s_r, k_s_r = _clone_with_grad(qkv, q_s, k_s)
+        out_r = _reference_path(qkv_r, q_s_r, k_s_r, pe, H)
+        out_r.sum().backward()
+
+        torch.testing.assert_close(
+            qkv_r.grad.float(), qkv_o.grad.float(),
+            atol=1e-5, rtol=1e-5,
+            msg="qkv gradient mismatch (fp32, reference vs original)",
+        )
+        torch.testing.assert_close(
+            q_s_r.grad.float(), q_s_o.grad.float(),
+            atol=1e-5, rtol=1e-5,
+            msg="q_scale gradient mismatch (fp32)",
+        )
+        torch.testing.assert_close(
+            k_s_r.grad.float(), k_s_o.grad.float(),
+            atol=1e-5, rtol=1e-5,
+            msg="k_scale gradient mismatch (fp32)",
+        )
+
+    def test_gradients_reference_vs_original_bf16(self, B, L, H, D):
+        """In bf16, scale gradients diverge due to intermediate bf16 quantization
+        in the original RMSNorm: (x * rrms).to(x_dtype) * scale.
+
+        qkv gradients stay close, but q_scale/k_scale gradients can differ by ~0.2
+        because the original path quantizes to bf16 before the scale multiply,
+        which affects the gradient computation for scale.
+        """
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cpu")
+
+        # Original path
+        qkv_o, q_s_o, k_s_o = _clone_with_grad(qkv, q_s, k_s)
+        out_o = _original_path(qkv_o, q_s_o, k_s_o, pe, H)
+        out_o.sum().backward()
+
+        # Reference path
+        qkv_r, q_s_r, k_s_r = _clone_with_grad(qkv, q_s, k_s)
+        out_r = _reference_path(qkv_r, q_s_r, k_s_r, pe, H)
+        out_r.sum().backward()
+
+        # qkv gradients stay close
+        torch.testing.assert_close(
+            qkv_r.grad.float(), qkv_o.grad.float(),
+            atol=5e-2, rtol=1e-2,
+            msg="qkv gradient mismatch (bf16, reference vs original)",
+        )
+        # Scale gradients diverge — loose tolerance documents the expected gap
+        torch.testing.assert_close(
+            q_s_r.grad.float(), q_s_o.grad.float(),
+            atol=3e-1, rtol=5e-1,
+            msg="q_scale gradient mismatch (bf16) — expected gap from intermediate quantization",
+        )
+        torch.testing.assert_close(
+            k_s_r.grad.float(), k_s_o.grad.float(),
+            atol=3e-1, rtol=5e-1,
+            msg="k_scale gradient mismatch (bf16) — expected gap from intermediate quantization",
+        )
+
+    @pytest.mark.skipif(
+        not HAS_TRITON or not torch.cuda.is_available(),
+        reason="requires triton + CUDA",
+    )
+    def test_gradients_fused_vs_original_cuda(self, B, L, H, D):
+        """Fused Triton kernel gradients vs original path."""
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
+
+        # Original path
+        qkv_o, q_s_o, k_s_o = _clone_with_grad(qkv, q_s, k_s)
+        out_o = _original_path(qkv_o, q_s_o, k_s_o, pe, H)
+        out_o.sum().backward()
+
+        # Fused path
+        qkv_f, q_s_f, k_s_f = _clone_with_grad(qkv, q_s, k_s)
+        out_f = _fused_path(qkv_f, q_s_f, k_s_f, pe, H)
+        out_f.sum().backward()
+
+        torch.testing.assert_close(
+            qkv_f.grad.float(), qkv_o.grad.float(),
+            atol=5e-2, rtol=1e-2,
+            msg="qkv gradient mismatch (fused vs original, CUDA)",
+        )
+        # Weight scale gradients are reductions over all (B, L, H) positions.
+        # The original path operates on a [B, H, L, D] layout while the fused
+        # path uses [B, L, H, D], so float32 accumulation order differs and
+        # produces noise proportional to sqrt(B*L*H). Fused matches its own
+        # reference exactly (same layout); this looser tolerance only covers the
+        # cross-layout accumulation difference.
+        torch.testing.assert_close(
+            q_s_f.grad.float(), q_s_o.grad.float(),
+            atol=0.3, rtol=1e-2,
+            msg="q_scale gradient mismatch (fused vs original, CUDA)",
+        )
+        torch.testing.assert_close(
+            k_s_f.grad.float(), k_s_o.grad.float(),
+            atol=0.3, rtol=1e-2,
+            msg="k_scale gradient mismatch (fused vs original, CUDA)",
+        )
+
+    @pytest.mark.skipif(
+        not HAS_TRITON or not torch.cuda.is_available(),
+        reason="requires triton + CUDA",
+    )
+    def test_gradients_fused_matches_reference_cuda(self, B, L, H, D):
+        """Fused kernel gradients must match its own PyTorch reference."""
+        qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, torch.bfloat16, "cuda")
+
+        # Reference path
+        qkv_r, q_s_r, k_s_r = _clone_with_grad(qkv, q_s, k_s)
+        out_r = _reference_path(qkv_r, q_s_r, k_s_r, pe, H)
+        out_r.sum().backward()
+
+        # Fused path
+        qkv_f, q_s_f, k_s_f = _clone_with_grad(qkv, q_s, k_s)
+        out_f = _fused_path(qkv_f, q_s_f, k_s_f, pe, H)
+        out_f.sum().backward()
+
+        torch.testing.assert_close(
+            qkv_f.grad.float(), qkv_r.grad.float(),
+            atol=5e-2, rtol=1e-2,
+            msg="qkv gradient: fused kernel vs reference",
+        )
+        torch.testing.assert_close(
+            q_s_f.grad.float(), q_s_r.grad.float(),
+            atol=5e-2, rtol=1e-2,
+            msg="q_scale gradient: fused kernel vs reference",
+        )
+        torch.testing.assert_close(
+            k_s_f.grad.float(), k_s_r.grad.float(),
+            atol=5e-2, rtol=1e-2,
+            msg="k_scale gradient: fused kernel vs reference",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic: measure and report the actual gap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_forward_gap_diagnostic(dtype):
+    """Measure the actual forward gap between paths — prints stats for debugging."""
+    B, L, H, D = 2, 64, 16, 128
+    device = "cpu"
+    qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, dtype, device)
+
+    out_orig = _original_path(qkv, q_s, k_s, pe, H)
+    out_ref = _reference_path(qkv, q_s, k_s, pe, H)
+
+    diff = (out_ref.float() - out_orig.float()).abs()
+    rel_diff = diff / (out_orig.float().abs() + 1e-8)
+
+    print(f"\n{'='*60}")
+    print(f"Forward gap diagnostic — dtype={dtype}")
+    print(f"  Max abs diff:  {diff.max().item():.6e}")
+    print(f"  Mean abs diff: {diff.mean().item():.6e}")
+    print(f"  Max rel diff:  {rel_diff.max().item():.6e}")
+    print(f"  Mean rel diff: {rel_diff.mean().item():.6e}")
+    print(f"  Q max diff:    {diff[:,:,0].max().item():.6e}")
+    print(f"  K max diff:    {diff[:,:,1].max().item():.6e}")
+    print(f"  V max diff:    {diff[:,:,2].max().item():.6e}")
+    print(f"{'='*60}")
+
+    # In fp32, should be near-zero; in bf16, expect small gap
+    if dtype == torch.float32:
+        assert diff.max() < 1e-4, f"fp32 gap too large: {diff.max().item()}"
+    else:
+        assert diff.max() < 0.1, f"bf16 gap too large: {diff.max().item()}"
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_backward_gap_diagnostic(dtype):
+    """Measure actual backward gradient gap — prints stats for debugging."""
+    B, L, H, D = 2, 32, 16, 128
+    device = "cpu"
+    qkv, q_s, k_s, pe = _make_inputs(B, L, H, D, dtype, device)
+
+    # Original
+    qkv_o, q_s_o, k_s_o = _clone_with_grad(qkv, q_s, k_s)
+    out_o = _original_path(qkv_o, q_s_o, k_s_o, pe, H)
+    out_o.sum().backward()
+
+    # Reference
+    qkv_r, q_s_r, k_s_r = _clone_with_grad(qkv, q_s, k_s)
+    out_r = _reference_path(qkv_r, q_s_r, k_s_r, pe, H)
+    out_r.sum().backward()
+
+    for name, g_ref, g_orig in [
+        ("qkv", qkv_r.grad, qkv_o.grad),
+        ("q_scale", q_s_r.grad, q_s_o.grad),
+        ("k_scale", k_s_r.grad, k_s_o.grad),
+    ]:
+        diff = (g_ref.float() - g_orig.float()).abs()
+        rel_diff = diff / (g_orig.float().abs() + 1e-8)
+        print(f"\n--- Backward gap: {name} (dtype={dtype}) ---")
+        print(f"  Max abs diff:  {diff.max().item():.6e}")
+        print(f"  Mean abs diff: {diff.mean().item():.6e}")
+        print(f"  Max rel diff:  {rel_diff.max().item():.6e}")
+        print(f"  Mean rel diff: {rel_diff.mean().item():.6e}")
+
+        if dtype == torch.float32:
+            assert diff.max() < 1e-4, f"fp32 {name} gradient gap too large: {diff.max().item()}"
+        else:
+            assert diff.max() < 0.5, f"bf16 {name} gradient gap too large: {diff.max().item()}"


### PR DESCRIPTION
For Flux2 we have QKNorm which requires QK "separated" and the rest doesn't need QKV separated. 

This PR works to keep QKV together all the way through attention (specifically flash attention) using a fused QKNorm + RoPE triton kernel. 

Getting ~7.8% improved performance and increased tensor usage. Doesn't need to allocate new tensors on the CPU and then transfer them to the GPU. We do the QKNorm in place. 

There is a benchmark  in here which showing around 2.4x to 5.8x (Edit: now 3.8x to 10x) as fast as the reference implementation. 

This is my first attempt at a kernel so will probably need edge cases to be covered, and maybe it should be opt-in instead of always on. Also has a reference implementation that works without the fusion. 

Specifically posting this to get feedback if this is desired, and any concerns about this implementation.

References:

https://www.kapilsharma.dev/posts/triton-kernels-rms-norm/
https://github.com/nvxuanyuc/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu