### PR TITLE
Add step_func optimizer support for ScheduleFree+

### DIFF
--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -2043,7 +2043,13 @@ class NetworkTrainer:
                             params_to_clip = accelerator.unwrap_model(network).get_trainable_params()
                             accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
-                    optimizer.step()
+                    # Check if step_func exists, ScheduleFree+
+                    # We need to check the underlining optimizer from the Accelerate version
+                    if hasattr(optimizer.optimizer, "step_func"):
+                        optimizer.step_func(lambda: loss.item())
+                    else:
+                        optimizer.step()
+
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 


### PR DESCRIPTION
[ScheduleFree+: Scaling Learning-Rate-Free & Schedule-Free Learning to Large Language Models](https://arxiv.org/abs/2605.19095)

`uv pip install git+https://github.com/facebookresearch/schedule_free`
Not on released on pypi so using the git version. 

```toml
optimizer_type = "schedule_free.AdamCScheduleFreePlusPaper"
optimizer_args = [
  "weight_decay=30.0", # AdamC: should be 20-50
  "c_warmup=200", # ~1-2x your LR warmup steps
  "polyak_beta=0.9", # reference default; use 0.9 if training is unstable
  "sf_beta1=0.925",
  "sf_beta1_max=0.965",
  "sf_beta1_anneal_steps=1000",
  "betas=[0.9,0.95]", 
  "eps=1e-8",     
]
```

This optimizer also has a few extra parameters to log which would be helpful at understanding how it is working. 

The key difference in ScheduleFree+ is that it also has an adaptive LR component (optional) but requires the loss value to be shared with the optimizer. That is what the `step_func` is doing here. 

There are other differences to consider, from the paper/code about what are the right values to set.