### PR TITLE
Fix multi control bucketing

### DIFF
--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -16,6 +16,7 @@ import torch
 from PIL import Image
 
 from musubi_tuner.utils import safetensors_utils
+from musubi_tuner.utils.model_utils import remove_dtype_suffix
 
 import logging
 
@@ -405,12 +406,15 @@ class ImageDataset(BaseDataset):
 
                     if controls is not None:
                         item_info.control_content = controls
-                        if self.no_resize_control or self.control_resolution is not None:
-                            # Add control size to bucket_reso to make different control resolutions to different batch
-                            bucket_reso = list(bucket_reso)
-                            for control in controls:
-                                bucket_reso = bucket_reso + list(control.shape[0:2])
-                            bucket_reso = tuple(bucket_reso)
+                        # Add every control size to bucket_reso so that different control resolutions AND a
+                        # different number of control images go to different batches. Run this whenever control
+                        # data is present (not only for no_resize_control / control_resolution): otherwise items
+                        # with a different control count share a batch and the collator stacks a ragged batch.
+                        # controls is already in index order, so the appended shapes stay index-aligned.
+                        bucket_reso = list(bucket_reso)
+                        for control in controls:
+                            bucket_reso = bucket_reso + list(control.shape[0:2])
+                        bucket_reso = tuple(bucket_reso)
 
                     if bucket_reso not in batches:
                         batches[bucket_reso] = []
@@ -528,12 +532,19 @@ class ImageDataset(BaseDataset):
                     bucket_reso.append(len(self.fp_1f_clean_indices))
                     bucket_reso.append(self.fp_1f_no_post)
                 bucket_reso = tuple(bucket_reso)
-            if self.no_resize_control or self.control_resolution is not None:
-                # we also need to split the bucket with control resolutions
-                control_key = safetensors_utils.find_key(cache_file, starts_with="latents_control_")  # latents_control_FxHxW_dtype
-                if control_key is not None:
-                    control_shape = control_key.rsplit("_", 3)[-2]  # FxHxW
-                    bucket_reso = tuple(list(bucket_reso) + [control_shape])  # (int, int, str)
+            # Split the bucket by control latents so that every item in a batch has the same number of
+            # control images AND matching per-control shapes. The collator stacks latents_control_{i}
+            # across the batch (see BucketBatchManager.__getitem__), so a count or shape mismatch produces
+            # a ragged stack (crash) or silently misaligns controls between samples. This must run whenever
+            # control data is present, not only for no_resize_control / control_resolution: even controls
+            # resized to the bucket resolution share that resolution but can still differ in *count*.
+            # find_keys returns the keys sorted, so the per-control order (and the index<->shape pairing,
+            # which remove_dtype_suffix keeps in each element) is deterministic across cache files.
+            control_keys = safetensors_utils.find_keys(cache_file, starts_with="latents_control_")
+            if control_keys:
+                # key: latents_control_{i}_FxHxW_dtype -> "latents_control_{i}_FxHxW" (index + shape)
+                control_shapes = [remove_dtype_suffix(key) for key in control_keys]
+                bucket_reso = tuple(list(bucket_reso) + control_shapes)
 
             item_info = ItemInfo(item_key, "", image_size, bucket_reso, latent_cache_path=cache_file)
             item_info.text_encoder_output_cache_path = text_encoder_output_cache_file

--- a/src/musubi_tuner/hidream_o1_cache_pixel.py
+++ b/src/musubi_tuner/hidream_o1_cache_pixel.py
@@ -22,9 +22,14 @@ def encode_and_save_batch(batch: List[ItemInfo]):
         control_tokens = None
         if item.control_content is not None:
             controls = item.control_content if isinstance(item.control_content, list) else [item.control_content]
-            control_contents = torch.stack([torch.from_numpy(control) for control in controls], dim=0)
-            control_pixels = hidream_o1_utils.preprocess_image_tensor(control_contents)
-            control_tokens = hidream_o1_utils.patchify_pixels_grid(control_pixels).to(torch.bfloat16)
+            # Each control image for one sample can have a different shape (e.g. reference images of
+            # different aspect ratios). The cache format stores controls individually and the model
+            # reads them per-control with their own patch shape, so preprocess each one separately
+            # instead of stacking (torch.stack would require a uniform shape across controls).
+            control_tokens = []
+            for control in controls:
+                control_pixels = hidream_o1_utils.preprocess_image_tensor(torch.from_numpy(control).unsqueeze(0))
+                control_tokens.append(hidream_o1_utils.patchify_pixels_grid(control_pixels)[0].to(torch.bfloat16))  # H,W,D
         logger.debug(f"Saving HiDream-O1 pixel-token cache for item {item.item_key}: {tuple(tokens.shape)}")
         save_pixel_cache_hidream_o1(item, tokens.to(torch.bfloat16), control_tokens)
 

--- a/src/musubi_tuner/utils/safetensors_utils.py
+++ b/src/musubi_tuner/utils/safetensors_utils.py
@@ -375,6 +375,26 @@ def find_key(safetensors_file: str, starts_with: Optional[str] = None, ends_with
     return None
 
 
+def find_keys(safetensors_file: str, starts_with: Optional[str] = None, ends_with: Optional[str] = None) -> list[str]:
+    """
+    Find all keys in a safetensors file that start with `starts_with` and end with `ends_with`.
+    If `starts_with` is None, it will match any key. If `ends_with` is None, it will match any key.
+
+    The matching keys are returned sorted, so callers get a deterministic order regardless of the
+    order the keys happen to be stored in the file header. This matters when the keys are folded into
+    a bucket key (e.g. ``latents_control_{i}``): otherwise two files holding the same tensors in a
+    different header order, or with the index<->shape association swapped, could end up in different
+    buckets or be wrongly batched together.
+    """
+    with MemoryEfficientSafeOpen(safetensors_file) as f:
+        keys = [
+            key
+            for key in f.keys()
+            if (starts_with is None or key.startswith(starts_with)) and (ends_with is None or key.endswith(ends_with))
+        ]
+    return sorted(keys)
+
+
 @dataclass
 class WeightTransformHooks:
     split_hook: Optional[callable] = None


### PR DESCRIPTION
- When some images contains multiple control images with different resolutions, they may be mistakenly included in the same batch. This is because the bucket reso doesn't handle the number of control images.
- HiDream-O1 pixel cache cannot cache images with multiple control images of different resolutions.