### PR TITLE
Add --save_precision option for network weights (default: fp32)

### DIFF
--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -201,6 +201,14 @@ def _add_training_args(parser: argparse.ArgumentParser) -> None:
         choices=["no", "fp16", "bf16"],
         help="use mixed precision / 混合精度を使う場合、その精度",
     )
+    parser.add_argument(
+        "--save_precision",
+        type=str,
+        default=None,
+        choices=["float", "fp32", "fp16", "bf16"],
+        help="precision for saving network weights, default: fp32 (the precision network weights are trained in)"
+        " / ネットワークの重みを保存する際の精度、省略時はfp32（ネットワークの重みはfp32で学習されるため）",
+    )
 
 
 def _add_logging_args(parser: argparse.ArgumentParser) -> None:

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1301,11 +1301,6 @@ class NetworkTrainer:
         if not self._validate_args_and_init(args):
             return
 
-        # resolve before full_fp16/full_bf16 may be modified during preparation
-        save_dtype = train_utils.resolve_save_dtype(
-            args.save_precision, getattr(args, "full_fp16", False), getattr(args, "full_bf16", False)
-        )
-
         session_id, training_started_at = self._init_session(args)
         train_dataset_group, collator, current_epoch = self._build_dataset(args)
         accelerator, weight_dtype, dit_dtype, dit_weight_dtype, vae_dtype = self._prepare_accelerator_and_dtypes(args)
@@ -1920,6 +1915,14 @@ class NetworkTrainer:
         del train_dataset_group
 
         # function for saving/removing
+        save_dtype = train_utils.resolve_save_dtype(
+            args.save_precision, getattr(args, "full_fp16", False), getattr(args, "full_bf16", False)
+        )
+        logger.info(
+            f"network weights will be saved as {save_dtype}"
+            + (f" (--save_precision {args.save_precision})" if args.save_precision is not None else " (default)")
+        )
+
         def save_model(ckpt_name: str, unwrapped_nw, steps, epoch_no, force_sync_upload=False):
             os.makedirs(args.output_dir, exist_ok=True)
             ckpt_file = os.path.join(args.output_dir, ckpt_name)

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1301,6 +1301,11 @@ class NetworkTrainer:
         if not self._validate_args_and_init(args):
             return
 
+        # resolve before full_fp16/full_bf16 may be modified during preparation
+        save_dtype = train_utils.resolve_save_dtype(
+            args.save_precision, getattr(args, "full_fp16", False), getattr(args, "full_bf16", False)
+        )
+
         session_id, training_started_at = self._init_session(args)
         train_dataset_group, collator, current_epoch = self._build_dataset(args)
         accelerator, weight_dtype, dit_dtype, dit_weight_dtype, vae_dtype = self._prepare_accelerator_and_dtypes(args)
@@ -1915,8 +1920,6 @@ class NetworkTrainer:
         del train_dataset_group
 
         # function for saving/removing
-        save_dtype = dit_dtype
-
         def save_model(ckpt_name: str, unwrapped_nw, steps, epoch_no, force_sync_upload=False):
             os.makedirs(args.output_dir, exist_ok=True)
             ckpt_file = os.path.join(args.output_dir, ckpt_name)

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -2,14 +2,32 @@ import argparse
 import logging
 import os
 import shutil
-from typing import Callable
+from typing import Callable, Optional
 
 import accelerate
+import torch
 
 from musubi_tuner.utils import huggingface_utils
+from musubi_tuner.utils.model_utils import str_to_dtype
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
+
+def resolve_save_dtype(save_precision: Optional[str], full_fp16: bool = False, full_bf16: bool = False) -> torch.dtype:
+    """Resolve the dtype for saving network weights.
+
+    Explicit --save_precision wins; otherwise follow full_fp16/full_bf16 so the
+    saved weights match the training precision; otherwise fp32, the precision
+    the network weights are actually trained in.
+    """
+    if save_precision is not None:
+        return str_to_dtype(save_precision)
+    if full_fp16:
+        return torch.float16
+    if full_bf16:
+        return torch.bfloat16
+    return torch.float32
 
 
 # checkpointファイル名

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import os
 import shutil
-from typing import Callable, Optional
+from typing import Callable
 
 import accelerate
 import torch
@@ -12,22 +12,6 @@ from musubi_tuner.utils.model_utils import str_to_dtype
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-
-def resolve_save_dtype(save_precision: Optional[str], full_fp16: bool = False, full_bf16: bool = False) -> torch.dtype:
-    """Resolve the dtype for saving network weights.
-
-    Explicit --save_precision wins; otherwise follow full_fp16/full_bf16 so the
-    saved weights match the training precision; otherwise fp32, the precision
-    the network weights are actually trained in.
-    """
-    if save_precision is not None:
-        return str_to_dtype(save_precision)
-    if full_fp16:
-        return torch.float16
-    if full_bf16:
-        return torch.bfloat16
-    return torch.float32
 
 
 # checkpointファイル名
@@ -199,3 +183,19 @@ def get_lin_function(x1: float = 256, y1: float = 0.5, x2: float = 4096, y2: flo
     m = (y2 - y1) / (x2 - x1)
     b = y1 - m * x1
     return lambda x: m * x + b
+
+
+def resolve_save_dtype(save_precision: str | None, full_fp16: bool = False, full_bf16: bool = False) -> torch.dtype:
+    """Resolve the dtype for saving network weights.
+
+    Explicit --save_precision wins; otherwise follow full_fp16/full_bf16 so the
+    saved weights match the training precision; otherwise fp32, the precision
+    the network weights are actually trained in.
+    """
+    if save_precision is not None:
+        return str_to_dtype(save_precision)
+    if full_fp16:
+        return torch.float16
+    if full_bf16:
+        return torch.bfloat16
+    return torch.float32

--- a/tests/test_save_precision.py
+++ b/tests/test_save_precision.py
@@ -1,0 +1,31 @@
+import torch
+
+from musubi_tuner.training.parser_common import setup_parser_common
+from musubi_tuner.utils.train_utils import resolve_save_dtype
+
+
+def test_default_is_fp32():
+    assert resolve_save_dtype(None, full_fp16=False, full_bf16=False) == torch.float32
+
+
+def test_explicit_precision():
+    assert resolve_save_dtype("fp32", full_fp16=False, full_bf16=False) == torch.float32
+    assert resolve_save_dtype("float", full_fp16=False, full_bf16=False) == torch.float32
+    assert resolve_save_dtype("fp16", full_fp16=False, full_bf16=False) == torch.float16
+    assert resolve_save_dtype("bf16", full_fp16=False, full_bf16=False) == torch.bfloat16
+
+
+def test_full_precision_flags_used_when_unset():
+    assert resolve_save_dtype(None, full_fp16=True, full_bf16=False) == torch.float16
+    assert resolve_save_dtype(None, full_fp16=False, full_bf16=True) == torch.bfloat16
+
+
+def test_explicit_precision_overrides_full_flags():
+    assert resolve_save_dtype("fp32", full_fp16=True, full_bf16=False) == torch.float32
+    assert resolve_save_dtype("fp16", full_fp16=False, full_bf16=True) == torch.float16
+
+
+def test_parser_has_save_precision_defaulting_to_none():
+    parser = setup_parser_common()
+    args = parser.parse_args(["--dataset_config", "x.toml", "--dit", "x.safetensors"])
+    assert args.save_precision is None


### PR DESCRIPTION
## Summary

Network (LoRA) weights are trained in fp32 (`full_fp16`/`full_bf16` are currently force-disabled in `trainer_base.py`), but checkpoints were unconditionally saved in the DiT compute dtype — e.g. bf16 with `--mixed_precision bf16`. The bf16 cast silently discards all precision below ~`weight × 2⁻⁹`, which affects post-hoc tools that re-process saved LoRAs (post-hoc EMA, merging, extraction) and any weight-level analysis of saved files.

ネットワーク（LoRA）の重みはfp32で学習されますが（`full_fp16`/`full_bf16`は現在`trainer_base.py`で無効化されています）、保存時には無条件にDiTの計算精度（例：`--mixed_precision bf16`の場合はbf16）にキャストされていました。このbf16キャストにより `weight × 2⁻⁹` 未満の精度が失われ、保存済みLoRAを再処理するツール（post-hoc EMA、マージ、抽出）や重みレベルの分析に影響します。

## Changes / 変更点

- Add `--save_precision` (`float` / `fp32` / `fp16` / `bf16`) to the common network trainer parser, available to all architectures / 共通パーサーに `--save_precision` を追加（全アーキテクチャで利用可能）
- Resolution order / 優先順位:
  1. explicit `--save_precision` / 明示的な指定
  2. `full_fp16` / `full_bf16` if (re-)enabled, so saved weights match training precision / 有効な場合は学習精度に合わせる
  3. default: **fp32**, the precision the weights are actually trained in / デフォルト: 実際に学習されている精度である**fp32**
- The resolved dtype flows through `on_post_save` as before, so companion files (EMA etc.) stay consistent / 解決されたdtypeは従来どおり`on_post_save`に渡されるため、EMAなどの付随ファイルも一貫します
- Tests in `tests/test_save_precision.py` / テストを追加

## Note on the default / デフォルト値について

This changes the default saved dtype from bf16 to fp32 (≈2× file size for LoRA-scale files), on the grounds that the artifact should faithfully represent the trained weights, with bf16 as an explicit opt-in. If you prefer to keep the current behavior as default (`save_dtype = dit_dtype`) for compatibility, I'm happy to change it — the option is the main point.

このPRはデフォルトの保存dtypeをbf16からfp32に変更します（LoRA規模のファイルでは約2倍のサイズ）。学習された重みを忠実に保存すべきという理由ですが、互換性のため現行動作（`save_dtype = dit_dtype`）をデフォルトのまま維持したい場合は変更します。オプションの追加が主目的です。

The full fine-tuning scripts (`qwen_image_train.py`, `zimage_train.py`) are unchanged — saving a full DiT in its compute dtype is a separate decision. / フルファインチューニング用スクリプトは変更していません。