### PR TITLE
Add fused Triton QKNorm+RoPE kernel for FLUX.2 (--fused_qknorm_rope)

### DIFF
--- a/benchmarking/bench_fused_qknorm_rope.py
+++ b/benchmarking/bench_fused_qknorm_rope.py
@@ -1,0 +1,85 @@
+"""Benchmark fused QKNorm+RoPE (packed) vs eager path at FLUX.2 shapes.
+
+Run with:
+  uv run --extra cu132 python benchmarking/bench_fused_qknorm_rope.py
+"""
+
+import torch
+from einops import rearrange
+
+from musubi_tuner.flux_2.flux2_models import apply_rope, rope
+from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+
+def eager_rms(x, scale, eps=1e-6):
+    x_dtype = x.dtype
+    x = x.float()
+    rrms = torch.rsqrt(torch.mean(x**2, dim=-1, keepdim=True) + eps)
+    return (x * rrms).to(dtype=x_dtype) * scale
+
+
+def eager_path(qkv, q_scale, k_scale, pe):
+    q, k, v = rearrange(qkv, "B L K H D -> K B H L D")
+    q = eager_rms(q, q_scale).to(v.dtype)
+    k = eager_rms(k, k_scale).to(v.dtype)
+    q, k = apply_rope(q, k, pe)
+    return q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+
+
+def bench(fn, n_warmup=10, n_iter=50):
+    for _ in range(n_warmup):
+        fn()
+    torch.cuda.synchronize()
+    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(n_iter):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / n_iter
+
+
+def peak_mem(fn):
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    fn()
+    torch.cuda.synchronize()
+    return torch.cuda.max_memory_allocated() / 1024**2
+
+
+def main():
+    for B, L, H, D in [(1, 4096, 48, 128), (1, 8192, 48, 128), (4, 4096, 24, 128)]:
+        pos = torch.arange(L, device=DEVICE).unsqueeze(0).float()
+        pe = rope(pos, D, 2000).unsqueeze(1)
+        qkv = torch.randn(B, L, 3, H, D, device=DEVICE, dtype=DTYPE, requires_grad=True)
+        q_scale = torch.ones(D, device=DEVICE, dtype=DTYPE, requires_grad=True)
+        k_scale = torch.ones(D, device=DEVICE, dtype=DTYPE, requires_grad=True)
+        go = torch.randn(B, L, 3, H, D, device=DEVICE, dtype=DTYPE)
+
+        def fwd_fused():
+            return fused_qknorm_rope(qkv, q_scale, k_scale, pe)
+
+        def fwd_eager():
+            return eager_path(qkv, q_scale, k_scale, pe)
+
+        def fwdbwd_fused():
+            out = fused_qknorm_rope(qkv, q_scale, k_scale, pe)
+            out.backward(go)
+            qkv.grad = q_scale.grad = k_scale.grad = None
+
+        def fwdbwd_eager():
+            q, k, v = eager_path(qkv, q_scale, k_scale, pe)
+            torch.autograd.backward([q, k, v], [go[:, :, 0], go[:, :, 1], go[:, :, 2]])
+            qkv.grad = q_scale.grad = k_scale.grad = None
+
+        print(f"\nB={B} L={L} H={H} D={D} ({DTYPE})")
+        print(f"  fwd      eager {bench(fwd_eager):8.3f} ms   fused {bench(fwd_fused):8.3f} ms")
+        print(f"  fwd+bwd  eager {bench(fwdbwd_eager):8.3f} ms   fused {bench(fwdbwd_fused):8.3f} ms")
+        print(f"  peak mem fwd  eager {peak_mem(fwd_eager):8.1f} MB  fused {peak_mem(fwd_fused):8.1f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/profile_fused_qknorm_rope.py
+++ b/benchmarking/profile_fused_qknorm_rope.py
@@ -1,0 +1,163 @@
+"""torch.profiler: fused vs eager QKNorm + RoPE (forward and forward+backward).
+
+Follows the repo's profiling conventions (see profile_fused_norm_rope.py):
+  - schedule(wait=1, warmup=1, active=3) to skip cold-start noise
+  - record_function annotations for readable traces
+  - CPU + CUDA activities, memory profiling enabled
+  - Table (txt) + Chrome trace (json) exported per variant
+
+Usage:
+  uv run --no-sync python benchmarking/profile_fused_qknorm_rope.py
+  uv run --no-sync python benchmarking/profile_fused_qknorm_rope.py --shape 1 8192 48 128
+  uv run --no-sync python benchmarking/profile_fused_qknorm_rope.py --dtype fp16
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+import torch.profiler
+from einops import rearrange
+
+from musubi_tuner.flux_2.flux2_models import apply_rope, rope
+from musubi_tuner.modules.fused_qknorm_rope import HAS_TRITON, fused_qknorm_rope
+
+SCHEDULE = torch.profiler.schedule(wait=1, warmup=1, active=3, repeat=1)
+WARMUP_ITERS = 30  # runs outside the profiler to eliminate cold-start
+
+
+# ---------------------------------------------------------------------------
+# Eager path (mirrors flux2_models: rearrange -> RMSNorm -> apply_rope)
+# ---------------------------------------------------------------------------
+
+
+def eager_rms(x, scale, eps=1e-6):
+    x_dtype = x.dtype
+    x = x.float()
+    rrms = torch.rsqrt(torch.mean(x**2, dim=-1, keepdim=True) + eps)
+    return (x * rrms).to(dtype=x_dtype) * scale
+
+
+def eager_path(qkv, q_scale, k_scale, pe):
+    q, k, v = rearrange(qkv, "B L K H D -> K B H L D")
+    q = eager_rms(q, q_scale).to(v.dtype)
+    k = eager_rms(k, k_scale).to(v.dtype)
+    q, k = apply_rope(q, k, pe)
+    return q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Profiling helpers
+# ---------------------------------------------------------------------------
+
+
+def profile_variant(label: str, fn, trace_dir: Path, *, warmup: int = WARMUP_ITERS) -> None:
+    """Run torch.profiler on *fn*, save table + chrome trace, print table."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    def step():
+        with torch.profiler.record_function(label):
+            fn()
+
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+        schedule=SCHEDULE,
+        record_shapes=True,
+        profile_memory=True,
+        with_stack=False,
+    ) as prof:
+        for _ in range(5):  # wait=1 + warmup=1 + active=3
+            step()
+            prof.step()
+
+    table = prof.key_averages().table(sort_by="cuda_time_total", row_limit=25)
+
+    safe_label = label.replace(" ", "_").replace("(", "").replace(")", "").replace("/", "_").replace("+", "_")
+    table_path = trace_dir / f"{safe_label}.txt"
+    trace_path = trace_dir / f"{safe_label}.json"
+    table_path.write_text(table)
+    prof.export_chrome_trace(str(trace_path))
+
+    print(f"\n{'=' * 70}")
+    print(f"  {label}")
+    print(f"{'=' * 70}")
+    print(table)
+    print(f"  Table  -> {table_path}")
+    print(f"  Trace  -> {trace_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Profile fused QKNorm+RoPE with torch.profiler")
+    parser.add_argument(
+        "--shape", nargs=4, type=int, metavar=("B", "L", "H", "D"),
+        default=[1, 4096, 48, 128],
+        help="Input shape B L H D (default: 1 4096 48 128)",
+    )
+    parser.add_argument("--dtype", choices=["bf16", "fp16", "fp32"], default="bf16")
+    parser.add_argument("--warmup", type=int, default=WARMUP_ITERS, help="Pre-profiler warmup iterations")
+    parser.add_argument("--out", default="traces/profile_fused_qknorm_rope", help="Output directory for traces")
+    args = parser.parse_args()
+
+    assert torch.cuda.is_available() and HAS_TRITON, "CUDA + Triton required"
+
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[args.dtype]
+    B, L, H, D = args.shape
+    device = "cuda"
+
+    tag = f"B{B}_L{L}_H{H}_D{D}_{args.dtype}"
+    trace_dir = Path(args.out) / tag
+    trace_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"dtype  : {dtype}")
+    print(f"Shape  : B={B} L={L} H={H} D={D}")
+    print(f"Traces : {trace_dir.resolve()}")
+
+    torch.manual_seed(42)
+    pos = torch.arange(L, device=device).unsqueeze(0).float()
+    pe = rope(pos, D, 2000).unsqueeze(1)
+    qkv = torch.randn(B, L, 3, H, D, device=device, dtype=dtype, requires_grad=True)
+    q_scale = torch.ones(D, device=device, dtype=dtype, requires_grad=True)
+    k_scale = torch.ones(D, device=device, dtype=dtype, requires_grad=True)
+    go = torch.randn(B, L, 3, H, D, device=device, dtype=dtype)
+
+    def clear_grads():
+        qkv.grad = q_scale.grad = k_scale.grad = None
+
+    def fwd_eager():
+        with torch.no_grad():
+            eager_path(qkv, q_scale, k_scale, pe)
+
+    def fwd_fused():
+        with torch.no_grad():
+            fused_qknorm_rope(qkv, q_scale, k_scale, pe)
+
+    def fwdbwd_eager():
+        q, k, v = eager_path(qkv, q_scale, k_scale, pe)
+        torch.autograd.backward([q, k, v], [go[:, :, 0], go[:, :, 1], go[:, :, 2]])
+        clear_grads()
+
+    def fwdbwd_fused():
+        out = fused_qknorm_rope(qkv, q_scale, k_scale, pe)
+        out.backward(go)
+        clear_grads()
+
+    profile_variant("eager fwd", fwd_eager, trace_dir, warmup=args.warmup)
+    profile_variant("fused fwd", fwd_fused, trace_dir, warmup=args.warmup)
+    profile_variant("eager fwd+bwd", fwdbwd_eager, trace_dir, warmup=args.warmup)
+    profile_variant("fused fwd+bwd", fwdbwd_fused, trace_dir, warmup=args.warmup)
+
+    print(f"\nAll traces written to: {trace_dir.resolve()}")
+    print("Open .json files in https://ui.perfetto.dev/ to view traces.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/profile_fused_qknorm_rope.py
+++ b/benchmarking/profile_fused_qknorm_rope.py
@@ -98,7 +98,10 @@ def profile_variant(label: str, fn, trace_dir: Path, *, warmup: int = WARMUP_ITE
 def main():
     parser = argparse.ArgumentParser(description="Profile fused QKNorm+RoPE with torch.profiler")
     parser.add_argument(
-        "--shape", nargs=4, type=int, metavar=("B", "L", "H", "D"),
+        "--shape",
+        nargs=4,
+        type=int,
+        metavar=("B", "L", "H", "D"),
         default=[1, 4096, 48, 128],
         help="Input shape B L H D (default: 1 4096 48 128)",
     )

--- a/benchmarking/profile_fused_qknorm_rope.py
+++ b/benchmarking/profile_fused_qknorm_rope.py
@@ -105,6 +105,11 @@ def main():
     parser.add_argument("--dtype", choices=["bf16", "fp16", "fp32"], default="bf16")
     parser.add_argument("--warmup", type=int, default=WARMUP_ITERS, help="Pre-profiler warmup iterations")
     parser.add_argument("--out", default="traces/profile_fused_qknorm_rope", help="Output directory for traces")
+    parser.add_argument(
+        "--frozen-scales",
+        action="store_true",
+        help="freeze the RMSNorm scales (the LoRA training case; skips dscale atomics via NEEDS_DSCALE)",
+    )
     args = parser.parse_args()
 
     assert torch.cuda.is_available() and HAS_TRITON, "CUDA + Triton required"
@@ -113,20 +118,22 @@ def main():
     B, L, H, D = args.shape
     device = "cuda"
 
-    tag = f"B{B}_L{L}_H{H}_D{D}_{args.dtype}"
+    tag = f"B{B}_L{L}_H{H}_D{D}_{args.dtype}" + ("_frozen" if args.frozen_scales else "")
     trace_dir = Path(args.out) / tag
     trace_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"dtype  : {dtype}")
     print(f"Shape  : B={B} L={L} H={H} D={D}")
+    print(f"Scales : {'frozen (LoRA case)' if args.frozen_scales else 'trainable'}")
     print(f"Traces : {trace_dir.resolve()}")
 
     torch.manual_seed(42)
     pos = torch.arange(L, device=device).unsqueeze(0).float()
     pe = rope(pos, D, 2000).unsqueeze(1)
     qkv = torch.randn(B, L, 3, H, D, device=device, dtype=dtype, requires_grad=True)
-    q_scale = torch.ones(D, device=device, dtype=dtype, requires_grad=True)
-    k_scale = torch.ones(D, device=device, dtype=dtype, requires_grad=True)
+    train_scales = not args.frozen_scales
+    q_scale = torch.ones(D, device=device, dtype=dtype, requires_grad=train_scales)
+    k_scale = torch.ones(D, device=device, dtype=dtype, requires_grad=train_scales)
     go = torch.randn(B, L, 3, H, D, device=device, dtype=dtype)
 
     def clear_grads():

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -11,6 +11,7 @@ from torch.utils.checkpoint import checkpoint
 from musubi_tuner.modules.attention import AttentionParams, flash_attn_qkvpacked_func
 from musubi_tuner.modules.custom_offloading_utils import ModelOffloader
 from musubi_tuner.modules.attention import attention as unified_attention
+from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
 
 from musubi_tuner.utils.model_utils import create_cpu_offloading_wrapper
 
@@ -715,7 +716,7 @@ class LastLayer(nn.Module):
 
 
 class SingleStreamBlock(nn.Module):
-    def __init__(self, hidden_size: int, num_heads: int, mlp_ratio: float = 4.0):
+    def __init__(self, hidden_size: int, num_heads: int, mlp_ratio: float = 4.0, fused_qknorm_rope: bool = False):
         super().__init__()
 
         self.hidden_dim = hidden_size
@@ -735,6 +736,7 @@ class SingleStreamBlock(nn.Module):
 
         self.gradient_checkpointing = False
         self.activation_cpu_offloading = False
+        self.fused_qknorm_rope = fused_qknorm_rope
 
     def enable_gradient_checkpointing(self, activation_cpu_offloading: bool = False):
         self.gradient_checkpointing = True
@@ -752,14 +754,21 @@ class SingleStreamBlock(nn.Module):
 
         qkv, mlp = torch.split(self.linear1(x_mod), [3 * self.hidden_size, self.mlp_hidden_dim * self.mlp_mult_factor], dim=-1)
 
-        q, k, v = rearrange(qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
-        del qkv
-        q, k = self.norm(q, k, v)
+        if self.fused_qknorm_rope:
+            head_dim = self.hidden_size // self.num_heads
+            qkv = qkv.view(qkv.shape[0], qkv.shape[1], 3, self.num_heads, head_dim)
+            qkv = fused_qknorm_rope(qkv, self.norm.query_norm.scale, self.norm.key_norm.scale, pe)
+            attn = packed_attention(qkv, attn_params)
+            del qkv, pe
+        else:
+            q, k, v = rearrange(qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
+            del qkv
+            q, k = self.norm(q, k, v)
 
-        qkv_list = [q, k, v]
-        del q, k, v
-        attn = attention(qkv_list, pe, attn_params)
-        del qkv_list, pe
+            qkv_list = [q, k, v]
+            del q, k, v
+            attn = attention(qkv_list, pe, attn_params)
+            del qkv_list, pe
 
         # compute activation in mlp stream, cat again and run second linear layer
         output = self.linear2(torch.cat((attn, self.mlp_act(mlp)), 2))

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -785,7 +785,7 @@ class SingleStreamBlock(nn.Module):
 
 
 class DoubleStreamBlock(nn.Module):
-    def __init__(self, hidden_size: int, num_heads: int, mlp_ratio: float):
+    def __init__(self, hidden_size: int, num_heads: int, mlp_ratio: float, fused_qknorm_rope: bool = False):
         super().__init__()
         mlp_hidden_dim = int(hidden_size * mlp_ratio)
         self.num_heads = num_heads
@@ -813,6 +813,7 @@ class DoubleStreamBlock(nn.Module):
         )
         self.gradient_checkpointing = False
         self.activation_cpu_offloading = False
+        self.fused_qknorm_rope = fused_qknorm_rope
 
     def enable_gradient_checkpointing(self, activation_cpu_offloading: bool = False):
         self.gradient_checkpointing = True
@@ -849,9 +850,6 @@ class DoubleStreamBlock(nn.Module):
 
         img_qkv = self.img_attn.qkv(img_modulated)
         del img_modulated
-        img_q, img_k, img_v = rearrange(img_qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
-        del img_qkv
-        img_q, img_k = self.img_attn.norm(img_q, img_k, img_v)
 
         # prepare txt for attention
         txt_modulated = self.txt_norm1(txt)
@@ -859,24 +857,46 @@ class DoubleStreamBlock(nn.Module):
         del txt_mod1_scale, txt_mod1_shift
         txt_qkv = self.txt_attn.qkv(txt_modulated)
         del txt_modulated
-        txt_q, txt_k, txt_v = rearrange(txt_qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
-        del txt_qkv
-        txt_q, txt_k = self.txt_attn.norm(txt_q, txt_k, txt_v)
 
-        txt_len = txt_q.shape[2]
-        q = torch.cat((txt_q, img_q), dim=2)
-        del txt_q, img_q
-        k = torch.cat((txt_k, img_k), dim=2)
-        del txt_k, img_k
-        v = torch.cat((txt_v, img_v), dim=2)
-        del txt_v, img_v
+        txt_len = txt_qkv.shape[1]
 
-        pe = torch.cat((pe_ctx, pe), dim=2)
-        del pe_ctx
-        qkv_list = [q, k, v]
-        del q, k, v
-        attn = attention(qkv_list, pe, attn_params)
-        del qkv_list, pe
+        if self.fused_qknorm_rope:
+            head_dim = self.hidden_size // self.num_heads
+            img_qkv = img_qkv.view(img_qkv.shape[0], img_qkv.shape[1], 3, self.num_heads, head_dim)
+            img_qkv = fused_qknorm_rope(
+                img_qkv, self.img_attn.norm.query_norm.scale, self.img_attn.norm.key_norm.scale, pe
+            )
+            txt_qkv = txt_qkv.view(txt_qkv.shape[0], txt_qkv.shape[1], 3, self.num_heads, head_dim)
+            txt_qkv = fused_qknorm_rope(
+                txt_qkv, self.txt_attn.norm.query_norm.scale, self.txt_attn.norm.key_norm.scale, pe_ctx
+            )
+            qkv = torch.cat((txt_qkv, img_qkv), dim=1)
+            del txt_qkv, img_qkv, pe, pe_ctx
+            attn = packed_attention(qkv, attn_params)
+            del qkv
+        else:
+            img_q, img_k, img_v = rearrange(img_qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
+            del img_qkv
+            img_q, img_k = self.img_attn.norm(img_q, img_k, img_v)
+
+            txt_q, txt_k, txt_v = rearrange(txt_qkv, "B L (K H D) -> K B H L D", K=3, H=self.num_heads)
+            del txt_qkv
+            txt_q, txt_k = self.txt_attn.norm(txt_q, txt_k, txt_v)
+
+            q = torch.cat((txt_q, img_q), dim=2)
+            del txt_q, img_q
+            k = torch.cat((txt_k, img_k), dim=2)
+            del txt_k, img_k
+            v = torch.cat((txt_v, img_v), dim=2)
+            del txt_v, img_v
+
+            pe = torch.cat((pe_ctx, pe), dim=2)
+            del pe_ctx
+            qkv_list = [q, k, v]
+            del q, k, v
+            attn = attention(qkv_list, pe, attn_params)
+            del qkv_list, pe
+
         txt_attn, img_attn = attn[:, :txt_len], attn[:, txt_len:]
         del attn
 

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -8,7 +8,7 @@ from einops import rearrange
 from torch import Tensor, nn
 from torch.utils.checkpoint import checkpoint
 
-from musubi_tuner.modules.attention import AttentionParams
+from musubi_tuner.modules.attention import AttentionParams, flash_attn_qkvpacked_func
 from musubi_tuner.modules.custom_offloading_utils import ModelOffloader
 from musubi_tuner.modules.attention import attention as unified_attention
 
@@ -997,6 +997,20 @@ def attention(qkv_list: list[Tensor], pe: Tensor, attn_params: AttentionParams) 
     del q, k, v
     x = unified_attention(qkv_list, attn_params=attn_params)
     return x
+
+
+def packed_attention(qkv: Tensor, attn_params: AttentionParams) -> Tensor:
+    """Attention on packed qkv (B, L, 3, H, D) with QKNorm and RoPE already applied.
+
+    Uses flash_attn_qkvpacked_func when possible (no unbind, no copies);
+    otherwise unbinds to views and reuses the unified attention dispatch.
+    Returns (B, L, H*D) like attention().
+    """
+    if attn_params.attn_mode == "flash" and not attn_params.split_attn and flash_attn_qkvpacked_func is not None:
+        x = flash_attn_qkvpacked_func(qkv, 0.0)  # B, L, H, D
+        return x.reshape(x.shape[0], x.shape[1], -1)
+    q, k, v = qkv.unbind(dim=2)  # views: B, L, H, D
+    return unified_attention([q, k, v], attn_params=attn_params)
 
 
 def rope(pos: Tensor, dim: int, theta: int) -> Tensor:

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -412,7 +412,7 @@ class AutoEncoder(nn.Module):
 
 
 class Flux2(nn.Module):
-    def __init__(self, params: Flux2Params, attn_mode: str = "flash", split_attn: bool = False) -> None:
+    def __init__(self, params: Flux2Params, attn_mode: str = "flash", split_attn: bool = False, fused_qknorm_rope: bool = False) -> None:
         super().__init__()
 
         self.in_channels = params.in_channels
@@ -436,13 +436,17 @@ class Flux2(nn.Module):
 
         self.attn_mode = attn_mode
         self.split_attn = split_attn
+        self.fused_qknorm_rope = fused_qknorm_rope
 
         self.double_blocks = nn.ModuleList(
-            [DoubleStreamBlock(self.hidden_size, self.num_heads, mlp_ratio=params.mlp_ratio) for _ in range(params.depth)]
+            [
+                DoubleStreamBlock(self.hidden_size, self.num_heads, mlp_ratio=params.mlp_ratio, fused_qknorm_rope=fused_qknorm_rope)
+                for _ in range(params.depth)
+            ]
         )
         self.single_blocks = nn.ModuleList(
             [
-                SingleStreamBlock(self.hidden_size, self.num_heads, mlp_ratio=params.mlp_ratio)
+                SingleStreamBlock(self.hidden_size, self.num_heads, mlp_ratio=params.mlp_ratio, fused_qknorm_rope=fused_qknorm_rope)
                 for _ in range(params.depth_single_blocks)
             ]
         )

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -1006,7 +1006,13 @@ def packed_attention(qkv: Tensor, attn_params: AttentionParams) -> Tensor:
     otherwise unbinds to views and reuses the unified attention dispatch.
     Returns (B, L, H*D) like attention().
     """
-    if attn_params.attn_mode == "flash" and not attn_params.split_attn and flash_attn_qkvpacked_func is not None:
+    if (
+        attn_params.attn_mode == "flash"
+        and not attn_params.split_attn
+        and flash_attn_qkvpacked_func is not None
+        and attn_params.cu_seqlens is None
+        and attn_params.attention_mask is None
+    ):
         x = flash_attn_qkvpacked_func(qkv, 0.0)  # B, L, H, D
         return x.reshape(x.shape[0], x.shape[1], -1)
     q, k, v = qkv.unbind(dim=2)  # views: B, L, H, D

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -412,7 +412,9 @@ class AutoEncoder(nn.Module):
 
 
 class Flux2(nn.Module):
-    def __init__(self, params: Flux2Params, attn_mode: str = "flash", split_attn: bool = False, fused_qknorm_rope: bool = False) -> None:
+    def __init__(
+        self, params: Flux2Params, attn_mode: str = "flash", split_attn: bool = False, fused_qknorm_rope: bool = False
+    ) -> None:
         super().__init__()
 
         self.in_channels = params.in_channels
@@ -867,13 +869,9 @@ class DoubleStreamBlock(nn.Module):
         if self.fused_qknorm_rope:
             head_dim = self.hidden_size // self.num_heads
             img_qkv = img_qkv.view(img_qkv.shape[0], img_qkv.shape[1], 3, self.num_heads, head_dim)
-            img_qkv = fused_qknorm_rope(
-                img_qkv, self.img_attn.norm.query_norm.scale, self.img_attn.norm.key_norm.scale, pe
-            )
+            img_qkv = fused_qknorm_rope(img_qkv, self.img_attn.norm.query_norm.scale, self.img_attn.norm.key_norm.scale, pe)
             txt_qkv = txt_qkv.view(txt_qkv.shape[0], txt_qkv.shape[1], 3, self.num_heads, head_dim)
-            txt_qkv = fused_qknorm_rope(
-                txt_qkv, self.txt_attn.norm.query_norm.scale, self.txt_attn.norm.key_norm.scale, pe_ctx
-            )
+            txt_qkv = fused_qknorm_rope(txt_qkv, self.txt_attn.norm.query_norm.scale, self.txt_attn.norm.key_norm.scale, pe_ctx)
             qkv = torch.cat((txt_qkv, img_qkv), dim=1)
             del txt_qkv, img_qkv, pe, pe_ctx
             attn = packed_attention(qkv, attn_params)

--- a/src/musubi_tuner/flux_2/flux2_utils.py
+++ b/src/musubi_tuner/flux_2/flux2_utils.py
@@ -450,6 +450,7 @@ def load_flow_model(
     lora_weights_list: Optional[dict[str, torch.Tensor]] = None,
     lora_multipliers: Optional[list[float]] = None,
     disable_numpy_memmap: bool = False,
+    fused_qknorm_rope: bool = False,
 ) -> flux2_models.Flux2:
     # dit_weight_dtype is None for fp8_scaled
     assert (not fp8_scaled and dit_weight_dtype is not None) or (fp8_scaled and dit_weight_dtype is None)
@@ -460,7 +461,7 @@ def load_flow_model(
     # build model
     with init_empty_weights():
         params = model_version_info.params
-        model = flux2_models.Flux2(params, attn_mode, split_attn)
+        model = flux2_models.Flux2(params, attn_mode, split_attn, fused_qknorm_rope=fused_qknorm_rope)
         if dit_weight_dtype is not None:
             model.to(dit_weight_dtype)
 

--- a/src/musubi_tuner/flux_2_generate_image.py
+++ b/src/musubi_tuner/flux_2_generate_image.py
@@ -129,6 +129,12 @@ def parse_args() -> argparse.Namespace:
         choices=["flash", "torch", "sageattn", "xformers", "sdpa"],  #  "flash2", "flash3",
         help="attention mode",
     )
+    parser.add_argument(
+        "--fused_qknorm_rope",
+        action="store_true",
+        help="use fused Triton QKNorm+RoPE with packed QKV (requires triton; uses flash_attn_qkvpacked_func when --attn_mode flash)"
+        " / Triton融合QKNorm+RoPE(packed QKV)を使う",
+    )
     parser.add_argument("--blocks_to_swap", type=int, default=0, help="number of blocks to swap in the model")
     parser.add_argument(
         "--use_pinned_memory_for_block_swap",
@@ -325,6 +331,7 @@ def load_dit_model(
         lora_weights_list,
         args.lora_multiplier,
         args.disable_numpy_memmap,
+        fused_qknorm_rope=args.fused_qknorm_rope,
     )
 
     # merge LoRA weights

--- a/src/musubi_tuner/flux_2_train_network.py
+++ b/src/musubi_tuner/flux_2_train_network.py
@@ -244,6 +244,7 @@ class Flux2NetworkTrainer(NetworkTrainer):
             dit_weight_dtype=dit_weight_dtype,
             fp8_scaled=args.fp8_scaled,
             disable_numpy_memmap=args.disable_numpy_memmap,
+            fused_qknorm_rope=getattr(args, "fused_qknorm_rope", False),
         )
         return model
 
@@ -342,6 +343,12 @@ def flux2_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     parser.add_argument("--fp8_scaled", action="store_true", help="use scaled fp8 for DiT / DiTにスケーリングされたfp8を使う")
     parser.add_argument("--text_encoder", type=str, default=None, help="text encoder checkpoint path")
     parser.add_argument("--fp8_text_encoder", action="store_true", help="use fp8 for Text Encoder model")
+    parser.add_argument(
+        "--fused_qknorm_rope",
+        action="store_true",
+        help="use fused Triton QKNorm+RoPE with packed QKV (requires triton; uses flash_attn_qkvpacked_func when --attn_mode flash)"
+        " / Triton融合QKNorm+RoPE(packed QKV)を使う",
+    )
     flux2_utils.add_model_version_args(parser)
     return parser
 

--- a/src/musubi_tuner/flux_2_train_network.py
+++ b/src/musubi_tuner/flux_2_train_network.py
@@ -234,6 +234,12 @@ class Flux2NetworkTrainer(NetworkTrainer):
         loading_device: str,
         dit_weight_dtype: Optional[torch.dtype],
     ):
+        fused_qknorm_rope = getattr(args, "fused_qknorm_rope", False)
+        if fused_qknorm_rope:
+            logger.info(
+                "Using fused QKNorm+RoPE (Triton, packed QKV) for FLUX.2 blocks"
+                + (" with flash_attn_qkvpacked_func" if attn_mode == "flash" else "")
+            )
         model = flux2_utils.load_flow_model(
             accelerator.device,
             model_version_info=self.model_version_info,
@@ -244,7 +250,7 @@ class Flux2NetworkTrainer(NetworkTrainer):
             dit_weight_dtype=dit_weight_dtype,
             fp8_scaled=args.fp8_scaled,
             disable_numpy_memmap=args.disable_numpy_memmap,
-            fused_qknorm_rope=getattr(args, "fused_qknorm_rope", False),
+            fused_qknorm_rope=fused_qknorm_rope,
         )
         return model
 

--- a/src/musubi_tuner/modules/attention.py
+++ b/src/musubi_tuner/modules/attention.py
@@ -9,11 +9,13 @@ try:
     from flash_attn.flash_attn_interface import _flash_attn_forward
     from flash_attn.flash_attn_interface import flash_attn_varlen_func
     from flash_attn.flash_attn_interface import flash_attn_func
+    from flash_attn.flash_attn_interface import flash_attn_qkvpacked_func
 except ImportError:
     flash_attn = None
     flash_attn_varlen_func = None
     _flash_attn_forward = None
     flash_attn_func = None
+    flash_attn_qkvpacked_func = None
 
 try:
     from sageattention import sageattn_varlen, sageattn

--- a/src/musubi_tuner/modules/fused_qknorm_rope.py
+++ b/src/musubi_tuner/modules/fused_qknorm_rope.py
@@ -1,0 +1,141 @@
+"""Fused QKNorm (RMSNorm on q/k) + RoPE for packed QKV, in Triton.
+
+Input: packed qkv (B, L, 3, H, D) — typically a view of the attention qkv
+projection output. Applies per-head-dim RMSNorm (learnable scale, eps 1e-6
+semantics matching flux2_models.RMSNorm) to q and k, then rotary embedding
+using the FLUX-style pe tensor (B, 1, L, D//2, 2, 2); v is copied through.
+Returns a new contiguous (B, L, 3, H, D) tensor suitable for
+flash_attn_qkvpacked_func.
+
+Numerics: all math in fp32 with a single rounding to the input dtype on store
+(the eager path rounds at intermediate casts; agreement is within dtype
+tolerance, see tests).
+
+Determinism: backward accumulates RMSNorm scale gradients with atomic adds, so
+scale grads are bitwise non-deterministic run-to-run (numerically correct).
+"""
+
+import torch
+from torch import Tensor
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAS_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    HAS_TRITON = False
+
+
+if HAS_TRITON:
+
+    @triton.jit
+    def _norm_rope_row(
+        in_base, out_base, scale_ptr, cos, sin, offs, mask,
+        stride_in_d, stride_out_d, eps,
+        D: tl.constexpr,
+    ):
+        """RMSNorm + rotate one (b, l, h) row of q or k. Pairs are (x[2i], x[2i+1])."""
+        x_even = tl.load(in_base + (2 * offs) * stride_in_d, mask=mask, other=0.0).to(tl.float32)
+        x_odd = tl.load(in_base + (2 * offs + 1) * stride_in_d, mask=mask, other=0.0).to(tl.float32)
+        meansq = (tl.sum(x_even * x_even, axis=0) + tl.sum(x_odd * x_odd, axis=0)) / D
+        rrms = 1.0 / tl.sqrt(meansq + eps)
+        s_even = tl.load(scale_ptr + 2 * offs, mask=mask, other=0.0).to(tl.float32)
+        s_odd = tl.load(scale_ptr + 2 * offs + 1, mask=mask, other=0.0).to(tl.float32)
+        xn_even = x_even * rrms * s_even
+        xn_odd = x_odd * rrms * s_odd
+        o_even = cos * xn_even - sin * xn_odd
+        o_odd = sin * xn_even + cos * xn_odd
+        out_ty = out_base.dtype.element_ty
+        tl.store(out_base + (2 * offs) * stride_out_d, o_even.to(out_ty), mask=mask)
+        tl.store(out_base + (2 * offs + 1) * stride_out_d, o_odd.to(out_ty), mask=mask)
+
+    @triton.jit
+    def _fused_qknorm_rope_fwd_kernel(
+        x_ptr, out_ptr, q_scale_ptr, k_scale_ptr, pe_ptr,
+        L, H,
+        stride_xb, stride_xl, stride_xk, stride_xh, stride_xd,
+        stride_ob, stride_ol, stride_ok, stride_oh, stride_od,
+        stride_pb, stride_pl, stride_pd, stride_pi,
+        eps,
+        D: tl.constexpr,
+        BLOCK_DHALF: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        h = pid % H
+        l = (pid // H) % L
+        b = pid // (H * L)
+
+        offs = tl.arange(0, BLOCK_DHALF)
+        mask = offs < (D // 2)
+
+        # pe is (B or 1, L, D//2, 2, 2): cos at [..., 0, 0], sin at [..., 1, 0]
+        pe_base = pe_ptr + b * stride_pb + l * stride_pl + offs * stride_pd
+        cos = tl.load(pe_base, mask=mask, other=0.0)
+        sin = tl.load(pe_base + stride_pi, mask=mask, other=0.0)
+
+        x_base = x_ptr + b * stride_xb + l * stride_xl + h * stride_xh
+        out_base = out_ptr + b * stride_ob + l * stride_ol + h * stride_oh
+
+        # q (index 0 along K) and k (index 1)
+        _norm_rope_row(x_base, out_base, q_scale_ptr, cos, sin, offs, mask, stride_xd, stride_od, eps, D)
+        _norm_rope_row(
+            x_base + stride_xk, out_base + stride_ok, k_scale_ptr, cos, sin, offs, mask, stride_xd, stride_od, eps, D
+        )
+
+        # v passthrough (index 2 along K)
+        offs_d = tl.arange(0, 2 * BLOCK_DHALF)
+        mask_d = offs_d < D
+        v = tl.load(x_base + 2 * stride_xk + offs_d * stride_xd, mask=mask_d, other=0.0)
+        tl.store(out_base + 2 * stride_ok + offs_d * stride_od, v, mask=mask_d)
+
+
+class _FusedQKNormRoPE(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, qkv: Tensor, q_scale: Tensor, k_scale: Tensor, pe: Tensor, eps: float):
+        B, L, K, H, D = qkv.shape
+        out = torch.empty((B, L, 3, H, D), dtype=qkv.dtype, device=qkv.device)
+        stride_pb = pe.stride(0) if pe.shape[0] != 1 else 0
+        grid = (B * L * H,)
+        _fused_qknorm_rope_fwd_kernel[grid](
+            qkv, out, q_scale, k_scale, pe,
+            L, H,
+            qkv.stride(0), qkv.stride(1), qkv.stride(2), qkv.stride(3), qkv.stride(4),
+            out.stride(0), out.stride(1), out.stride(2), out.stride(3), out.stride(4),
+            stride_pb, pe.stride(1), pe.stride(2), pe.stride(3),
+            eps,
+            D=D,
+            BLOCK_DHALF=triton.next_power_of_2(D // 2),
+            num_warps=2,
+        )
+        ctx.save_for_backward(qkv, q_scale, k_scale, pe)
+        ctx.eps = eps
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):
+        raise NotImplementedError("backward implemented in Task 2")
+
+
+def fused_qknorm_rope(qkv: Tensor, q_scale: Tensor, k_scale: Tensor, pe: Tensor, eps: float = 1e-6) -> Tensor:
+    """Apply RMSNorm (q/k) + RoPE to packed qkv (B, L, 3, H, D); v passes through.
+
+    pe: (B or 1, 1, L, D//2, 2, 2) or (B or 1, L, D//2, 2, 2), fp32, as produced
+    by flux2_models.EmbedND / rope().
+    """
+    if not HAS_TRITON:
+        raise RuntimeError("fused_qknorm_rope requires triton; install triton or disable the fused path")
+    if qkv.ndim != 5 or qkv.shape[2] != 3:
+        raise ValueError(f"expected packed qkv of shape (B, L, 3, H, D), got {tuple(qkv.shape)}")
+    D = qkv.shape[-1]
+    if D % 2 != 0:
+        raise ValueError(f"head dim must be even, got {D}")
+    if pe.ndim == 6:
+        pe = pe.squeeze(1)  # drop broadcast head dim
+    if pe.ndim != 5 or pe.shape[-3] != D // 2 or pe.shape[-2:] != (2, 2):
+        raise ValueError(f"expected pe of shape (B, [1,] L, {D // 2}, 2, 2), got {tuple(pe.shape)}")
+    if pe.shape[1] != qkv.shape[1]:
+        raise ValueError(f"pe seq len {pe.shape[1]} != qkv seq len {qkv.shape[1]}")
+    return _FusedQKNormRoPE.apply(qkv, q_scale.contiguous(), k_scale.contiguous(), pe.float(), eps)

--- a/src/musubi_tuner/modules/fused_qknorm_rope.py
+++ b/src/musubi_tuner/modules/fused_qknorm_rope.py
@@ -91,6 +91,80 @@ if HAS_TRITON:
         v = tl.load(x_base + 2 * stride_xk + offs_d * stride_xd, mask=mask_d, other=0.0)
         tl.store(out_base + 2 * stride_ok + offs_d * stride_od, v, mask=mask_d)
 
+    @triton.jit
+    def _bwd_row(
+        go_base, x_base, gx_base, scale_ptr, dscale_ptr, cos, sin, offs, mask,
+        stride_go_d, stride_x_d, stride_gx_d, eps,
+        D: tl.constexpr,
+    ):
+        """Backward for one q or k row: un-rotate, RMSNorm backward, dscale atomics."""
+        go_even = tl.load(go_base + (2 * offs) * stride_go_d, mask=mask, other=0.0).to(tl.float32)
+        go_odd = tl.load(go_base + (2 * offs + 1) * stride_go_d, mask=mask, other=0.0).to(tl.float32)
+        # RoPE backward = transposed rotation
+        g_even = cos * go_even + sin * go_odd
+        g_odd = -sin * go_even + cos * go_odd
+
+        x_even = tl.load(x_base + (2 * offs) * stride_x_d, mask=mask, other=0.0).to(tl.float32)
+        x_odd = tl.load(x_base + (2 * offs + 1) * stride_x_d, mask=mask, other=0.0).to(tl.float32)
+        meansq = (tl.sum(x_even * x_even, axis=0) + tl.sum(x_odd * x_odd, axis=0)) / D
+        rrms = 1.0 / tl.sqrt(meansq + eps)
+
+        # dscale += g * x_hat (fp32 atomics; non-deterministic ordering)
+        tl.atomic_add(dscale_ptr + 2 * offs, g_even * (x_even * rrms), mask=mask)
+        tl.atomic_add(dscale_ptr + 2 * offs + 1, g_odd * (x_odd * rrms), mask=mask)
+
+        s_even = tl.load(scale_ptr + 2 * offs, mask=mask, other=0.0).to(tl.float32)
+        s_odd = tl.load(scale_ptr + 2 * offs + 1, mask=mask, other=0.0).to(tl.float32)
+        gs_even = g_even * s_even
+        gs_odd = g_odd * s_odd
+        dot = (tl.sum(gs_even * x_even, axis=0) + tl.sum(gs_odd * x_odd, axis=0)) / D
+        coef = rrms * rrms * rrms * dot
+        gx_even = rrms * gs_even - x_even * coef
+        gx_odd = rrms * gs_odd - x_odd * coef
+        ty = gx_base.dtype.element_ty
+        tl.store(gx_base + (2 * offs) * stride_gx_d, gx_even.to(ty), mask=mask)
+        tl.store(gx_base + (2 * offs + 1) * stride_gx_d, gx_odd.to(ty), mask=mask)
+
+    @triton.jit
+    def _fused_qknorm_rope_bwd_kernel(
+        go_ptr, x_ptr, gx_ptr, q_scale_ptr, k_scale_ptr, dq_scale_ptr, dk_scale_ptr, pe_ptr,
+        L, H,
+        stride_gob, stride_gol, stride_gok, stride_goh, stride_god,
+        stride_xb, stride_xl, stride_xk, stride_xh, stride_xd,
+        stride_gxb, stride_gxl, stride_gxk, stride_gxh, stride_gxd,
+        stride_pb, stride_pl, stride_pd, stride_pi,
+        eps,
+        D: tl.constexpr,
+        BLOCK_DHALF: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        h = pid % H
+        l = (pid // H) % L
+        b = pid // (H * L)
+
+        offs = tl.arange(0, BLOCK_DHALF)
+        mask = offs < (D // 2)
+
+        pe_base = pe_ptr + b * stride_pb + l * stride_pl + offs * stride_pd
+        cos = tl.load(pe_base, mask=mask, other=0.0)
+        sin = tl.load(pe_base + stride_pi, mask=mask, other=0.0)
+
+        go_base = go_ptr + b * stride_gob + l * stride_gol + h * stride_goh
+        x_base = x_ptr + b * stride_xb + l * stride_xl + h * stride_xh
+        gx_base = gx_ptr + b * stride_gxb + l * stride_gxl + h * stride_gxh
+
+        _bwd_row(go_base, x_base, gx_base, q_scale_ptr, dq_scale_ptr, cos, sin, offs, mask,
+                 stride_god, stride_xd, stride_gxd, eps, D)
+        _bwd_row(go_base + stride_gok, x_base + stride_xk, gx_base + stride_gxk,
+                 k_scale_ptr, dk_scale_ptr, cos, sin, offs, mask,
+                 stride_god, stride_xd, stride_gxd, eps, D)
+
+        # grad_v passthrough
+        offs_d = tl.arange(0, 2 * BLOCK_DHALF)
+        mask_d = offs_d < D
+        gv = tl.load(go_base + 2 * stride_gok + offs_d * stride_god, mask=mask_d, other=0.0)
+        tl.store(gx_base + 2 * stride_gxk + offs_d * stride_gxd, gv, mask=mask_d)
+
 
 class _FusedQKNormRoPE(torch.autograd.Function):
     @staticmethod
@@ -116,7 +190,29 @@ class _FusedQKNormRoPE(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_out: Tensor):
-        raise NotImplementedError("backward implemented in Task 2")
+        qkv, q_scale, k_scale, pe = ctx.saved_tensors
+        B, L, K, H, D = qkv.shape
+        grad_out = grad_out.contiguous()
+        grad_qkv = torch.empty((B, L, 3, H, D), dtype=qkv.dtype, device=qkv.device)
+        dq_scale = torch.zeros(D, dtype=torch.float32, device=qkv.device)
+        dk_scale = torch.zeros(D, dtype=torch.float32, device=qkv.device)
+        stride_pb = pe.stride(0) if pe.shape[0] != 1 else 0
+        grid = (B * L * H,)
+        _fused_qknorm_rope_bwd_kernel[grid](
+            grad_out, qkv, grad_qkv, q_scale, k_scale, dq_scale, dk_scale, pe,
+            L, H,
+            grad_out.stride(0), grad_out.stride(1), grad_out.stride(2), grad_out.stride(3), grad_out.stride(4),
+            qkv.stride(0), qkv.stride(1), qkv.stride(2), qkv.stride(3), qkv.stride(4),
+            grad_qkv.stride(0), grad_qkv.stride(1), grad_qkv.stride(2), grad_qkv.stride(3), grad_qkv.stride(4),
+            stride_pb, pe.stride(1), pe.stride(2), pe.stride(3),
+            ctx.eps,
+            D=D,
+            BLOCK_DHALF=triton.next_power_of_2(D // 2),
+            num_warps=2,
+        )
+        grad_q_scale = dq_scale.to(q_scale.dtype) if ctx.needs_input_grad[1] else None
+        grad_k_scale = dk_scale.to(k_scale.dtype) if ctx.needs_input_grad[2] else None
+        return grad_qkv, grad_q_scale, grad_k_scale, None, None
 
 
 def fused_qknorm_rope(qkv: Tensor, q_scale: Tensor, k_scale: Tensor, pe: Tensor, eps: float = 1e-6) -> Tensor:
@@ -138,4 +234,6 @@ def fused_qknorm_rope(qkv: Tensor, q_scale: Tensor, k_scale: Tensor, pe: Tensor,
         raise ValueError(f"expected pe of shape (B, [1,] L, {D // 2}, 2, 2), got {tuple(pe.shape)}")
     if pe.shape[1] != qkv.shape[1]:
         raise ValueError(f"pe seq len {pe.shape[1]} != qkv seq len {qkv.shape[1]}")
+    if pe.shape[0] not in (1, qkv.shape[0]):
+        raise ValueError(f"pe batch dim {pe.shape[0]} must be 1 or match qkv batch dim {qkv.shape[0]}")
     return _FusedQKNormRoPE.apply(qkv, q_scale.contiguous(), k_scale.contiguous(), pe.float(), eps)

--- a/src/musubi_tuner/modules/fused_qknorm_rope.py
+++ b/src/musubi_tuner/modules/fused_qknorm_rope.py
@@ -33,8 +33,16 @@ if HAS_TRITON:
 
     @triton.jit
     def _norm_rope_row(
-        in_base, out_base, scale_ptr, cos, sin, offs, mask,
-        stride_in_d, stride_out_d, eps,
+        in_base,
+        out_base,
+        scale_ptr,
+        cos,
+        sin,
+        offs,
+        mask,
+        stride_in_d,
+        stride_out_d,
+        eps,
         D: tl.constexpr,
     ):
         """RMSNorm + rotate one (b, l, h) row of q or k. Pairs are (x[2i], x[2i+1])."""
@@ -54,11 +62,27 @@ if HAS_TRITON:
 
     @triton.jit
     def _fused_qknorm_rope_fwd_kernel(
-        x_ptr, out_ptr, q_scale_ptr, k_scale_ptr, pe_ptr,
-        L, H,
-        stride_xb, stride_xl, stride_xk, stride_xh, stride_xd,
-        stride_ob, stride_ol, stride_ok, stride_oh, stride_od,
-        stride_pb, stride_pl, stride_pd, stride_pi,
+        x_ptr,
+        out_ptr,
+        q_scale_ptr,
+        k_scale_ptr,
+        pe_ptr,
+        L,
+        H,
+        stride_xb,
+        stride_xl,
+        stride_xk,
+        stride_xh,
+        stride_xd,
+        stride_ob,
+        stride_ol,
+        stride_ok,
+        stride_oh,
+        stride_od,
+        stride_pb,
+        stride_pl,
+        stride_pd,
+        stride_pi,
         eps,
         D: tl.constexpr,
         BLOCK_DHALF: tl.constexpr,
@@ -81,9 +105,7 @@ if HAS_TRITON:
 
         # q (index 0 along K) and k (index 1)
         _norm_rope_row(x_base, out_base, q_scale_ptr, cos, sin, offs, mask, stride_xd, stride_od, eps, D)
-        _norm_rope_row(
-            x_base + stride_xk, out_base + stride_ok, k_scale_ptr, cos, sin, offs, mask, stride_xd, stride_od, eps, D
-        )
+        _norm_rope_row(x_base + stride_xk, out_base + stride_ok, k_scale_ptr, cos, sin, offs, mask, stride_xd, stride_od, eps, D)
 
         # v passthrough (index 2 along K)
         offs_d = tl.arange(0, 2 * BLOCK_DHALF)
@@ -93,8 +115,19 @@ if HAS_TRITON:
 
     @triton.jit
     def _bwd_row(
-        go_base, x_base, gx_base, scale_ptr, dscale_ptr, cos, sin, offs, mask,
-        stride_go_d, stride_x_d, stride_gx_d, eps,
+        go_base,
+        x_base,
+        gx_base,
+        scale_ptr,
+        dscale_ptr,
+        cos,
+        sin,
+        offs,
+        mask,
+        stride_go_d,
+        stride_x_d,
+        stride_gx_d,
+        eps,
         D: tl.constexpr,
         NEEDS_DSCALE: tl.constexpr,
     ):
@@ -129,12 +162,35 @@ if HAS_TRITON:
 
     @triton.jit
     def _fused_qknorm_rope_bwd_kernel(
-        go_ptr, x_ptr, gx_ptr, q_scale_ptr, k_scale_ptr, dq_scale_ptr, dk_scale_ptr, pe_ptr,
-        L, H,
-        stride_gob, stride_gol, stride_gok, stride_goh, stride_god,
-        stride_xb, stride_xl, stride_xk, stride_xh, stride_xd,
-        stride_gxb, stride_gxl, stride_gxk, stride_gxh, stride_gxd,
-        stride_pb, stride_pl, stride_pd, stride_pi,
+        go_ptr,
+        x_ptr,
+        gx_ptr,
+        q_scale_ptr,
+        k_scale_ptr,
+        dq_scale_ptr,
+        dk_scale_ptr,
+        pe_ptr,
+        L,
+        H,
+        stride_gob,
+        stride_gol,
+        stride_gok,
+        stride_goh,
+        stride_god,
+        stride_xb,
+        stride_xl,
+        stride_xk,
+        stride_xh,
+        stride_xd,
+        stride_gxb,
+        stride_gxl,
+        stride_gxk,
+        stride_gxh,
+        stride_gxd,
+        stride_pb,
+        stride_pl,
+        stride_pd,
+        stride_pi,
         eps,
         D: tl.constexpr,
         BLOCK_DHALF: tl.constexpr,
@@ -156,11 +212,40 @@ if HAS_TRITON:
         x_base = x_ptr + b * stride_xb + l * stride_xl + h * stride_xh
         gx_base = gx_ptr + b * stride_gxb + l * stride_gxl + h * stride_gxh
 
-        _bwd_row(go_base, x_base, gx_base, q_scale_ptr, dq_scale_ptr, cos, sin, offs, mask,
-                 stride_god, stride_xd, stride_gxd, eps, D, NEEDS_DSCALE)
-        _bwd_row(go_base + stride_gok, x_base + stride_xk, gx_base + stride_gxk,
-                 k_scale_ptr, dk_scale_ptr, cos, sin, offs, mask,
-                 stride_god, stride_xd, stride_gxd, eps, D, NEEDS_DSCALE)
+        _bwd_row(
+            go_base,
+            x_base,
+            gx_base,
+            q_scale_ptr,
+            dq_scale_ptr,
+            cos,
+            sin,
+            offs,
+            mask,
+            stride_god,
+            stride_xd,
+            stride_gxd,
+            eps,
+            D,
+            NEEDS_DSCALE,
+        )
+        _bwd_row(
+            go_base + stride_gok,
+            x_base + stride_xk,
+            gx_base + stride_gxk,
+            k_scale_ptr,
+            dk_scale_ptr,
+            cos,
+            sin,
+            offs,
+            mask,
+            stride_god,
+            stride_xd,
+            stride_gxd,
+            eps,
+            D,
+            NEEDS_DSCALE,
+        )
 
         # grad_v passthrough
         offs_d = tl.arange(0, 2 * BLOCK_DHALF)
@@ -177,11 +262,27 @@ class _FusedQKNormRoPE(torch.autograd.Function):
         stride_pb = pe.stride(0) if pe.shape[0] != 1 else 0
         grid = (B * L * H,)
         _fused_qknorm_rope_fwd_kernel[grid](
-            qkv, out, q_scale, k_scale, pe,
-            L, H,
-            qkv.stride(0), qkv.stride(1), qkv.stride(2), qkv.stride(3), qkv.stride(4),
-            out.stride(0), out.stride(1), out.stride(2), out.stride(3), out.stride(4),
-            stride_pb, pe.stride(1), pe.stride(2), pe.stride(3),
+            qkv,
+            out,
+            q_scale,
+            k_scale,
+            pe,
+            L,
+            H,
+            qkv.stride(0),
+            qkv.stride(1),
+            qkv.stride(2),
+            qkv.stride(3),
+            qkv.stride(4),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+            out.stride(4),
+            stride_pb,
+            pe.stride(1),
+            pe.stride(2),
+            pe.stride(3),
             eps,
             D=D,
             BLOCK_DHALF=triton.next_power_of_2(D // 2),
@@ -208,12 +309,35 @@ class _FusedQKNormRoPE(torch.autograd.Function):
         stride_pb = pe.stride(0) if pe.shape[0] != 1 else 0
         grid = (B * L * H,)
         _fused_qknorm_rope_bwd_kernel[grid](
-            grad_out, qkv, grad_qkv, q_scale, k_scale, dq_scale, dk_scale, pe,
-            L, H,
-            grad_out.stride(0), grad_out.stride(1), grad_out.stride(2), grad_out.stride(3), grad_out.stride(4),
-            qkv.stride(0), qkv.stride(1), qkv.stride(2), qkv.stride(3), qkv.stride(4),
-            grad_qkv.stride(0), grad_qkv.stride(1), grad_qkv.stride(2), grad_qkv.stride(3), grad_qkv.stride(4),
-            stride_pb, pe.stride(1), pe.stride(2), pe.stride(3),
+            grad_out,
+            qkv,
+            grad_qkv,
+            q_scale,
+            k_scale,
+            dq_scale,
+            dk_scale,
+            pe,
+            L,
+            H,
+            grad_out.stride(0),
+            grad_out.stride(1),
+            grad_out.stride(2),
+            grad_out.stride(3),
+            grad_out.stride(4),
+            qkv.stride(0),
+            qkv.stride(1),
+            qkv.stride(2),
+            qkv.stride(3),
+            qkv.stride(4),
+            grad_qkv.stride(0),
+            grad_qkv.stride(1),
+            grad_qkv.stride(2),
+            grad_qkv.stride(3),
+            grad_qkv.stride(4),
+            stride_pb,
+            pe.stride(1),
+            pe.stride(2),
+            pe.stride(3),
             ctx.eps,
             D=D,
             BLOCK_DHALF=triton.next_power_of_2(D // 2),

--- a/src/musubi_tuner/modules/fused_qknorm_rope.py
+++ b/src/musubi_tuner/modules/fused_qknorm_rope.py
@@ -96,6 +96,7 @@ if HAS_TRITON:
         go_base, x_base, gx_base, scale_ptr, dscale_ptr, cos, sin, offs, mask,
         stride_go_d, stride_x_d, stride_gx_d, eps,
         D: tl.constexpr,
+        NEEDS_DSCALE: tl.constexpr,
     ):
         """Backward for one q or k row: un-rotate, RMSNorm backward, dscale atomics."""
         go_even = tl.load(go_base + (2 * offs) * stride_go_d, mask=mask, other=0.0).to(tl.float32)
@@ -110,8 +111,9 @@ if HAS_TRITON:
         rrms = 1.0 / tl.sqrt(meansq + eps)
 
         # dscale += g * x_hat (fp32 atomics; non-deterministic ordering)
-        tl.atomic_add(dscale_ptr + 2 * offs, g_even * (x_even * rrms), mask=mask)
-        tl.atomic_add(dscale_ptr + 2 * offs + 1, g_odd * (x_odd * rrms), mask=mask)
+        if NEEDS_DSCALE:
+            tl.atomic_add(dscale_ptr + 2 * offs, g_even * (x_even * rrms), mask=mask)
+            tl.atomic_add(dscale_ptr + 2 * offs + 1, g_odd * (x_odd * rrms), mask=mask)
 
         s_even = tl.load(scale_ptr + 2 * offs, mask=mask, other=0.0).to(tl.float32)
         s_odd = tl.load(scale_ptr + 2 * offs + 1, mask=mask, other=0.0).to(tl.float32)
@@ -136,6 +138,7 @@ if HAS_TRITON:
         eps,
         D: tl.constexpr,
         BLOCK_DHALF: tl.constexpr,
+        NEEDS_DSCALE: tl.constexpr,
     ):
         pid = tl.program_id(0)
         h = pid % H
@@ -154,10 +157,10 @@ if HAS_TRITON:
         gx_base = gx_ptr + b * stride_gxb + l * stride_gxl + h * stride_gxh
 
         _bwd_row(go_base, x_base, gx_base, q_scale_ptr, dq_scale_ptr, cos, sin, offs, mask,
-                 stride_god, stride_xd, stride_gxd, eps, D)
+                 stride_god, stride_xd, stride_gxd, eps, D, NEEDS_DSCALE)
         _bwd_row(go_base + stride_gok, x_base + stride_xk, gx_base + stride_gxk,
                  k_scale_ptr, dk_scale_ptr, cos, sin, offs, mask,
-                 stride_god, stride_xd, stride_gxd, eps, D)
+                 stride_god, stride_xd, stride_gxd, eps, D, NEEDS_DSCALE)
 
         # grad_v passthrough
         offs_d = tl.arange(0, 2 * BLOCK_DHALF)
@@ -194,8 +197,14 @@ class _FusedQKNormRoPE(torch.autograd.Function):
         B, L, K, H, D = qkv.shape
         grad_out = grad_out.contiguous()
         grad_qkv = torch.empty((B, L, 3, H, D), dtype=qkv.dtype, device=qkv.device)
-        dq_scale = torch.zeros(D, dtype=torch.float32, device=qkv.device)
-        dk_scale = torch.zeros(D, dtype=torch.float32, device=qkv.device)
+        needs_dscale = ctx.needs_input_grad[1] or ctx.needs_input_grad[2]
+        if needs_dscale:
+            dq_scale = torch.zeros(D, dtype=torch.float32, device=qkv.device)
+            dk_scale = torch.zeros(D, dtype=torch.float32, device=qkv.device)
+        else:
+            # Pass valid pointers the kernel won't touch when NEEDS_DSCALE=False
+            dq_scale = grad_qkv
+            dk_scale = grad_qkv
         stride_pb = pe.stride(0) if pe.shape[0] != 1 else 0
         grid = (B * L * H,)
         _fused_qknorm_rope_bwd_kernel[grid](
@@ -209,6 +218,7 @@ class _FusedQKNormRoPE(torch.autograd.Function):
             D=D,
             BLOCK_DHALF=triton.next_power_of_2(D // 2),
             num_warps=2,
+            NEEDS_DSCALE=needs_dscale,
         )
         grad_q_scale = dq_scale.to(q_scale.dtype) if ctx.needs_input_grad[1] else None
         grad_k_scale = dk_scale.to(k_scale.dtype) if ctx.needs_input_grad[2] else None

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1836,6 +1836,7 @@ class NetworkTrainer:
             "ss_max_grad_norm": args.max_grad_norm,
             "ss_fp8_base": bool(args.fp8_base),
             # "ss_fp8_llm": bool(args.fp8_llm), # remove this because this is only for HuanyuanVideo TODO set architecure dependent metadata
+            "ss_fused_qknorm_rope": bool(getattr(args, "fused_qknorm_rope", False)),  # FLUX.2 only
             "ss_full_fp16": bool(args.full_fp16),
             "ss_full_bf16": bool(args.full_bf16),
             "ss_weighting_scheme": args.weighting_scheme,

--- a/tests/test_fused_qknorm_rope.py
+++ b/tests/test_fused_qknorm_rope.py
@@ -20,8 +20,13 @@ TOLS = {
 
 
 def make_pe(B: int, L: int, D: int, device, theta: int = 2000) -> torch.Tensor:
-    """Build pe matching EmbedND output: (B, 1, L, D//2, 2, 2), fp32."""
+    """Build pe matching EmbedND output: (B, 1, L, D//2, 2, 2), fp32.
+
+    Rows differ per batch element so a kernel bug that always reads b=0 is caught.
+    """
     pos = torch.arange(L, device=device).unsqueeze(0).expand(B, -1).float()
+    # shift each batch element's positions so pe[b] != pe[0] for b > 0
+    pos = pos + torch.arange(B, device=device)[:, None] * 100
     return rope(pos, D, theta).unsqueeze(1)
 
 
@@ -57,7 +62,7 @@ def make_inputs(B, L, H, D, dtype, device="cuda", seed=0, requires_grad=False):
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("shape", [(2, 33, 4, 128), (1, 64, 1, 128), (2, 17, 3, 64)])
+@pytest.mark.parametrize("shape", [(2, 33, 4, 128), (1, 64, 1, 128), (2, 17, 3, 64), (2, 17, 3, 96)])
 def test_forward_parity(dtype, shape):
     from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
 
@@ -84,3 +89,62 @@ def test_forward_strided_input_view():
     out = fused_qknorm_rope(qkv, q_scale, k_scale, pe)
     ref = eager_reference(qkv, q_scale, k_scale, pe)
     torch.testing.assert_close(out, ref, **TOLS[torch.float32])
+
+
+def test_forward_pe_broadcast_batch1():
+    """Batch-1 pe with B=2 qkv exercises the stride-0 broadcast path."""
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, L, H, D = 2, 16, 2, 64
+    qkv, q_scale, k_scale, _ = make_inputs(B, L, H, D, torch.float32)
+    # build a batch-1 pe and broadcast manually for the reference
+    pe1 = make_pe(1, L, D, "cuda")  # shape (1, 1, L, D//2, 2, 2)
+    # reference: expand pe1 to B so eager uses the same values for all batches
+    pe_expanded = pe1.expand(B, -1, -1, -1, -1, -1)
+    out = fused_qknorm_rope(qkv, q_scale, k_scale, pe1)
+    ref = eager_reference(qkv, q_scale, k_scale, pe_expanded)
+    torch.testing.assert_close(out.float(), ref.float(), **TOLS[torch.float32])
+
+
+@pytest.mark.parametrize("dtype,tol,scale_tol", [
+    (torch.float32, dict(rtol=1e-4, atol=1e-4), dict(rtol=1e-4, atol=1e-4)),
+    # dscale sums B*H*L bf16 values via fp32 atomics; when scale grads are near
+    # zero the relative error is meaningless — use absolute tolerance only.
+    # Max abs diff is ~0.25 (1 bf16 ULP at value ~16). atol=0.5 catches real bugs.
+    # per plan: bf16 dscale is the noisiest comparison, loosen beyond rtol=5e-2.
+    (torch.bfloat16, dict(rtol=3e-2, atol=3e-2), dict(rtol=0.0, atol=0.5)),
+])
+@pytest.mark.parametrize("shape", [(2, 33, 4, 128), (2, 17, 3, 64)])
+def test_backward_parity(dtype, tol, scale_tol, shape):
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, L, H, D = shape
+    qkv_f, qs_f, ks_f, pe = make_inputs(B, L, H, D, dtype, seed=1, requires_grad=True)
+    qkv_e = qkv_f.detach().clone().requires_grad_(True)
+    qs_e = qs_f.detach().clone().requires_grad_(True)
+    ks_e = ks_f.detach().clone().requires_grad_(True)
+
+    grad_out = torch.randn(B, L, 3, H, D, dtype=dtype, device="cuda")
+
+    out_f = fused_qknorm_rope(qkv_f, qs_f, ks_f, pe)
+    out_f.backward(grad_out)
+
+    out_e = eager_reference(qkv_e, qs_e, ks_e, pe)
+    out_e.backward(grad_out)
+
+    torch.testing.assert_close(qkv_f.grad.float(), qkv_e.grad.float(), **tol)
+    torch.testing.assert_close(qs_f.grad.float(), qs_e.grad.float(), **scale_tol)
+    torch.testing.assert_close(ks_f.grad.float(), ks_e.grad.float(), **scale_tol)
+
+
+def test_backward_frozen_scales():
+    """LoRA training case: scales frozen, only qkv needs grad."""
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, L, H, D = 2, 9, 2, 64
+    qkv, qs, ks, pe = make_inputs(B, L, H, D, torch.float32, seed=2)
+    qkv.requires_grad_(True)
+    out = fused_qknorm_rope(qkv, qs, ks, pe)
+    out.sum().backward()
+    assert qkv.grad is not None
+    assert qs.grad is None and ks.grad is None

--- a/tests/test_fused_qknorm_rope.py
+++ b/tests/test_fused_qknorm_rope.py
@@ -82,13 +82,20 @@ def test_forward_strided_input_view():
 
     B, L, H, D = 2, 33, 4, 128
     flat = torch.randn(B, L, 3 * H * D + 16, dtype=torch.float32, device="cuda")
-    qkv = flat[..., : 3 * H * D].reshape(B, L, 3, H, D)  # non-contiguous parent slice
+    qkv_f = flat[..., : 3 * H * D].reshape(B, L, 3, H, D).clone().requires_grad_(True)
+    qkv_e = qkv_f.detach().clone().requires_grad_(True)
     q_scale = torch.ones(D, device="cuda")
     k_scale = torch.ones(D, device="cuda")
     pe = make_pe(B, L, D, "cuda")
-    out = fused_qknorm_rope(qkv, q_scale, k_scale, pe)
-    ref = eager_reference(qkv, q_scale, k_scale, pe)
-    torch.testing.assert_close(out, ref, **TOLS[torch.float32])
+    grad_out = torch.randn(B, L, 3, H, D, device="cuda")
+
+    out_f = fused_qknorm_rope(qkv_f, q_scale, k_scale, pe)
+    ref = eager_reference(qkv_e, q_scale, k_scale, pe)
+    torch.testing.assert_close(out_f, ref, **TOLS[torch.float32])
+
+    out_f.backward(grad_out)
+    ref.backward(grad_out)
+    torch.testing.assert_close(qkv_f.grad, qkv_e.grad, **TOLS[torch.float32])
 
 
 def test_forward_pe_broadcast_batch1():
@@ -96,14 +103,21 @@ def test_forward_pe_broadcast_batch1():
     from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
 
     B, L, H, D = 2, 16, 2, 64
-    qkv, q_scale, k_scale, _ = make_inputs(B, L, H, D, torch.float32)
+    qkv_f, q_scale, k_scale, _ = make_inputs(B, L, H, D, torch.float32, requires_grad=True)
+    qkv_e = qkv_f.detach().clone().requires_grad_(True)
     # build a batch-1 pe and broadcast manually for the reference
     pe1 = make_pe(1, L, D, "cuda")  # shape (1, 1, L, D//2, 2, 2)
     # reference: expand pe1 to B so eager uses the same values for all batches
     pe_expanded = pe1.expand(B, -1, -1, -1, -1, -1)
-    out = fused_qknorm_rope(qkv, q_scale, k_scale, pe1)
-    ref = eager_reference(qkv, q_scale, k_scale, pe_expanded)
-    torch.testing.assert_close(out.float(), ref.float(), **TOLS[torch.float32])
+    grad_out = torch.randn(B, L, 3, H, D, device="cuda")
+
+    out_f = fused_qknorm_rope(qkv_f, q_scale, k_scale, pe1)
+    ref = eager_reference(qkv_e, q_scale, k_scale, pe_expanded)
+    torch.testing.assert_close(out_f.float(), ref.float(), **TOLS[torch.float32])
+
+    out_f.backward(grad_out)
+    ref.backward(grad_out)
+    torch.testing.assert_close(qkv_f.grad, qkv_e.grad, **TOLS[torch.float32])
 
 
 @pytest.mark.parametrize("dtype,tol,scale_tol", [
@@ -114,7 +128,7 @@ def test_forward_pe_broadcast_batch1():
     # per plan: bf16 dscale is the noisiest comparison, loosen beyond rtol=5e-2.
     (torch.bfloat16, dict(rtol=3e-2, atol=3e-2), dict(rtol=0.0, atol=0.5)),
 ])
-@pytest.mark.parametrize("shape", [(2, 33, 4, 128), (2, 17, 3, 64)])
+@pytest.mark.parametrize("shape", [(2, 33, 4, 128), (2, 17, 3, 64), (2, 17, 3, 96)])
 def test_backward_parity(dtype, tol, scale_tol, shape):
     from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
 

--- a/tests/test_fused_qknorm_rope.py
+++ b/tests/test_fused_qknorm_rope.py
@@ -218,3 +218,59 @@ def test_packed_attention_flash_matches_torch_backend():
     out_flash = packed_attention(packed, AttentionParams.create_attention_params("flash", False))
     out_torch = packed_attention(packed, AttentionParams.create_attention_params("torch", False))
     torch.testing.assert_close(out_flash.float(), out_torch.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_parity_production_shape_real_rope():
+    """Klein 4B production shape with real EmbedND rope (audit follow-up).
+
+    Covers what the synthetic shapes above don't: L=4608 (512 txt + 64x64 img
+    tokens for a 1024px image), H=24, real 4-axis frequencies with image
+    positions to 63x63, and the real Klein 4B qk-norm scale range [0.32, 2.86]
+    — the actual input regime of FLUX.2 LoRA training (frozen scales, bf16).
+
+    At scales up to ~2.8 the eager path's extra intermediate roundings exceed
+    a fixed eager-as-oracle tolerance, so this compares both paths against an
+    fp64 ground truth instead and asserts fused is at least as accurate.
+    """
+    from musubi_tuner.flux_2.flux2_models import EmbedND
+    from musubi_tuner.flux_2.flux2_utils import prc_img, prc_txt
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, H, D = 1, 24, 128
+    _, txt_ids = prc_txt(torch.zeros(B, 512, 8))
+    _, img_ids = prc_img(torch.zeros(B, 16, 64, 64))
+    ids = torch.cat([txt_ids, img_ids], dim=1).to("cuda")  # (B, 4608, 4)
+    pe = EmbedND(dim=D, theta=2000, axes_dim=[32, 32, 32, 32])(ids)
+    L = ids.shape[1]
+
+    gen = torch.Generator(device="cuda").manual_seed(0)
+    qkv_f = torch.randn(B, L, 3, H, D, dtype=torch.bfloat16, device="cuda", generator=gen).requires_grad_(True)
+    qkv_e = qkv_f.detach().clone().requires_grad_(True)
+    # span the real Klein 4B qk-norm scale range [0.32, 2.86] (frozen base weights)
+    q_scale = torch.rand(D, dtype=torch.bfloat16, device="cuda", generator=gen) * 2.5 + 0.3
+    k_scale = torch.rand(D, dtype=torch.bfloat16, device="cuda", generator=gen) * 2.5 + 0.3
+    grad_out = torch.randn(B, L, 3, H, D, dtype=torch.bfloat16, device="cuda", generator=gen)
+
+    out_f = fused_qknorm_rope(qkv_f, q_scale, k_scale, pe)
+    ref = eager_reference(qkv_e, q_scale, k_scale, pe)
+
+    # fp64 ground truth through the same eager math, including backward
+    qkv_64 = qkv_f.detach().double().requires_grad_(True)
+    ref64 = eager_reference(qkv_64, q_scale.double(), k_scale.double(), pe.double())
+
+    err_fused = (out_f.double() - ref64).abs()
+    err_eager = (ref.double() - ref64).abs()
+    assert err_fused.max() <= err_eager.max() * 1.1, (err_fused.max(), err_eager.max())
+    assert err_fused.mean() <= err_eager.mean() * 1.1, (err_fused.mean(), err_eager.mean())
+    # both stay within ordinary bf16 rounding of the truth
+    torch.testing.assert_close(out_f.double(), ref64, rtol=3e-2, atol=4e-2)
+
+    out_f.backward(grad_out)
+    ref.backward(grad_out)
+    ref64.backward(grad_out.double())
+
+    gerr_fused = (qkv_f.grad.double() - qkv_64.grad).abs()
+    gerr_eager = (qkv_e.grad.double() - qkv_64.grad).abs()
+    assert gerr_fused.max() <= gerr_eager.max() * 1.1, (gerr_fused.max(), gerr_eager.max())
+    assert gerr_fused.mean() <= gerr_eager.mean() * 1.1, (gerr_fused.mean(), gerr_eager.mean())
+    torch.testing.assert_close(qkv_f.grad.double(), qkv_64.grad, rtol=3e-2, atol=4e-2)

--- a/tests/test_fused_qknorm_rope.py
+++ b/tests/test_fused_qknorm_rope.py
@@ -1,0 +1,86 @@
+"""Kernel-level parity tests: fused_qknorm_rope vs eager QKNorm + apply_rope.
+
+Run with:
+  uv run --extra cu132 pytest tests/test_fused_qknorm_rope.py -v
+"""
+
+import pytest
+import torch
+from einops import rearrange
+
+from musubi_tuner.flux_2.flux2_models import apply_rope, rope
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+TOLS = {
+    torch.float32: dict(rtol=1e-5, atol=1e-5),
+    torch.float16: dict(rtol=2e-3, atol=2e-3),
+    torch.bfloat16: dict(rtol=2e-2, atol=2e-2),
+}
+
+
+def make_pe(B: int, L: int, D: int, device, theta: int = 2000) -> torch.Tensor:
+    """Build pe matching EmbedND output: (B, 1, L, D//2, 2, 2), fp32."""
+    pos = torch.arange(L, device=device).unsqueeze(0).expand(B, -1).float()
+    return rope(pos, D, theta).unsqueeze(1)
+
+
+def eager_rms(x: torch.Tensor, scale: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    # mirrors flux2_models.RMSNorm.forward
+    x_dtype = x.dtype
+    x = x.float()
+    rrms = torch.rsqrt(torch.mean(x**2, dim=-1, keepdim=True) + eps)
+    return (x * rrms).to(dtype=x_dtype) * scale
+
+
+def eager_reference(qkv: torch.Tensor, q_scale, k_scale, pe, eps: float = 1e-6) -> torch.Tensor:
+    """Eager QKNorm + RoPE on packed (B, L, 3, H, D); returns same packed layout."""
+    q, k, v = rearrange(qkv, "B L K H D -> K B H L D")
+    q = eager_rms(q, q_scale, eps).to(v.dtype)
+    k = eager_rms(k, k_scale, eps).to(v.dtype)
+    q, k = apply_rope(q, k, pe)
+    out = torch.stack([q, k, v], dim=0)  # K B H L D
+    return rearrange(out, "K B H L D -> B L K H D")
+
+
+def make_inputs(B, L, H, D, dtype, device="cuda", seed=0, requires_grad=False):
+    gen = torch.Generator(device=device).manual_seed(seed)
+    qkv = torch.randn(B, L, 3, H, D, dtype=dtype, device=device, generator=gen)
+    q_scale = torch.randn(D, dtype=dtype, device=device, generator=gen) * 0.1 + 1.0
+    k_scale = torch.randn(D, dtype=dtype, device=device, generator=gen) * 0.1 + 1.0
+    if requires_grad:
+        qkv.requires_grad_(True)
+        q_scale.requires_grad_(True)
+        k_scale.requires_grad_(True)
+    pe = make_pe(B, L, D, device)
+    return qkv, q_scale, k_scale, pe
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", [(2, 33, 4, 128), (1, 64, 1, 128), (2, 17, 3, 64)])
+def test_forward_parity(dtype, shape):
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, L, H, D = shape
+    qkv, q_scale, k_scale, pe = make_inputs(B, L, H, D, dtype)
+    out = fused_qknorm_rope(qkv, q_scale, k_scale, pe)
+    ref = eager_reference(qkv, q_scale, k_scale, pe)
+    assert out.shape == (B, L, 3, H, D)
+    assert out.dtype == dtype
+    assert out.is_contiguous()
+    torch.testing.assert_close(out.float(), ref.float(), **TOLS[dtype])
+
+
+def test_forward_strided_input_view():
+    """Input as a non-contiguous view of (B, L, 3*H*D), like the linear output."""
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, L, H, D = 2, 33, 4, 128
+    flat = torch.randn(B, L, 3 * H * D + 16, dtype=torch.float32, device="cuda")
+    qkv = flat[..., : 3 * H * D].reshape(B, L, 3, H, D)  # non-contiguous parent slice
+    q_scale = torch.ones(D, device="cuda")
+    k_scale = torch.ones(D, device="cuda")
+    pe = make_pe(B, L, D, "cuda")
+    out = fused_qknorm_rope(qkv, q_scale, k_scale, pe)
+    ref = eager_reference(qkv, q_scale, k_scale, pe)
+    torch.testing.assert_close(out, ref, **TOLS[torch.float32])

--- a/tests/test_fused_qknorm_rope.py
+++ b/tests/test_fused_qknorm_rope.py
@@ -77,13 +77,23 @@ def test_forward_parity(dtype, shape):
 
 
 def test_forward_strided_input_view():
-    """Input as a non-contiguous view of (B, L, 3*H*D), like the linear output."""
+    """Input as a non-contiguous view of (B, L, 3*H*D), like the linear output.
+
+    Exercises the NEEDS_DSCALE=False kernel variant (scales non-requiring-grad).
+    The flat buffer is the grad leaf so the fused op actually receives a strided view.
+    """
     from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
 
     B, L, H, D = 2, 33, 4, 128
     flat = torch.randn(B, L, 3 * H * D + 16, dtype=torch.float32, device="cuda")
-    qkv_f = flat[..., : 3 * H * D].reshape(B, L, 3, H, D).clone().requires_grad_(True)
+    # base_f is the grad leaf; qkv_f is a non-contiguous view into it
+    base_f = flat.clone().requires_grad_(True)
+    qkv_f = base_f[..., : 3 * H * D].reshape(B, L, 3, H, D)
+    assert not qkv_f.is_contiguous(), "guard: qkv_f must be strided to exercise this path"
+    # eager reference uses contiguous clone of same values
     qkv_e = qkv_f.detach().clone().requires_grad_(True)
+    assert qkv_e.is_contiguous()
+
     q_scale = torch.ones(D, device="cuda")
     k_scale = torch.ones(D, device="cuda")
     pe = make_pe(B, L, D, "cuda")
@@ -95,7 +105,9 @@ def test_forward_strided_input_view():
 
     out_f.backward(grad_out)
     ref.backward(grad_out)
-    torch.testing.assert_close(qkv_f.grad, qkv_e.grad, **TOLS[torch.float32])
+    # grad flows back through the view to base_f; compare the qkv slice
+    grad_view = base_f.grad[..., : 3 * H * D].reshape(B, L, 3, H, D)
+    torch.testing.assert_close(grad_view, qkv_e.grad, **TOLS[torch.float32])
 
 
 def test_forward_pe_broadcast_batch1():

--- a/tests/test_fused_qknorm_rope.py
+++ b/tests/test_fused_qknorm_rope.py
@@ -162,3 +162,47 @@ def test_backward_frozen_scales():
     out.sum().backward()
     assert qkv.grad is not None
     assert qs.grad is None and ks.grad is None
+
+
+def _has_flash_attn():
+    try:
+        from flash_attn import flash_attn_qkvpacked_func  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def test_packed_attention_torch_backend_matches_eager():
+    from musubi_tuner.flux_2.flux2_models import attention as flux_attention, packed_attention
+    from musubi_tuner.modules.attention import AttentionParams
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, L, H, D = 2, 33, 4, 128
+    qkv, qs, ks, pe = make_inputs(B, L, H, D, torch.float32, seed=3)
+    attn_params = AttentionParams.create_attention_params("torch", False)
+
+    packed = fused_qknorm_rope(qkv, qs, ks, pe)
+    out_packed = packed_attention(packed, attn_params)
+
+    q, k, v = rearrange(qkv, "B L K H D -> K B H L D")
+    q = eager_rms(q, qs).to(v.dtype)
+    k = eager_rms(k, ks).to(v.dtype)
+    out_eager = flux_attention([q, k, v], pe, attn_params)
+
+    assert out_packed.shape == (B, L, H * D)
+    torch.testing.assert_close(out_packed, out_eager, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.skipif(not _has_flash_attn(), reason="flash_attn not installed")
+def test_packed_attention_flash_matches_torch_backend():
+    from musubi_tuner.flux_2.flux2_models import packed_attention
+    from musubi_tuner.modules.attention import AttentionParams
+    from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
+
+    B, L, H, D = 2, 33, 4, 128
+    qkv, qs, ks, pe = make_inputs(B, L, H, D, torch.bfloat16, seed=4)
+    packed = fused_qknorm_rope(qkv, qs, ks, pe)
+
+    out_flash = packed_attention(packed, AttentionParams.create_attention_params("flash", False))
+    out_torch = packed_attention(packed, AttentionParams.create_attention_params("torch", False))
+    torch.testing.assert_close(out_flash.float(), out_torch.float(), rtol=2e-2, atol=2e-2)

--- a/tests/test_fused_qknorm_rope.py
+++ b/tests/test_fused_qknorm_rope.py
@@ -132,14 +132,17 @@ def test_forward_pe_broadcast_batch1():
     torch.testing.assert_close(qkv_f.grad, qkv_e.grad, **TOLS[torch.float32])
 
 
-@pytest.mark.parametrize("dtype,tol,scale_tol", [
-    (torch.float32, dict(rtol=1e-4, atol=1e-4), dict(rtol=1e-4, atol=1e-4)),
-    # dscale sums B*H*L bf16 values via fp32 atomics; when scale grads are near
-    # zero the relative error is meaningless — use absolute tolerance only.
-    # Max abs diff is ~0.25 (1 bf16 ULP at value ~16). atol=0.5 catches real bugs.
-    # per plan: bf16 dscale is the noisiest comparison, loosen beyond rtol=5e-2.
-    (torch.bfloat16, dict(rtol=3e-2, atol=3e-2), dict(rtol=0.0, atol=0.5)),
-])
+@pytest.mark.parametrize(
+    "dtype,tol,scale_tol",
+    [
+        (torch.float32, dict(rtol=1e-4, atol=1e-4), dict(rtol=1e-4, atol=1e-4)),
+        # dscale sums B*H*L bf16 values via fp32 atomics; when scale grads are near
+        # zero the relative error is meaningless — use absolute tolerance only.
+        # Max abs diff is ~0.25 (1 bf16 ULP at value ~16). atol=0.5 catches real bugs.
+        # per plan: bf16 dscale is the noisiest comparison, loosen beyond rtol=5e-2.
+        (torch.bfloat16, dict(rtol=3e-2, atol=3e-2), dict(rtol=0.0, atol=0.5)),
+    ],
+)
 @pytest.mark.parametrize("shape", [(2, 33, 4, 128), (2, 17, 3, 64), (2, 17, 3, 96)])
 def test_backward_parity(dtype, tol, scale_tol, shape):
     from musubi_tuner.modules.fused_qknorm_rope import fused_qknorm_rope
@@ -179,6 +182,7 @@ def test_backward_frozen_scales():
 def _has_flash_attn():
     try:
         from flash_attn import flash_attn_qkvpacked_func  # noqa: F401
+
         return True
     except ImportError:
         return False

--- a/tests/test_fused_qknorm_rope_blocks.py
+++ b/tests/test_fused_qknorm_rope_blocks.py
@@ -20,8 +20,9 @@ HEADS = 4  # head_dim = 128, matching FLUX.2
 DEVICE = "cuda"
 
 
-def make_pe(B, L, D, device, theta=2000):
+def make_pe(B, L, D, device, theta=2000, offset: int = 0):
     pos = torch.arange(L, device=device).unsqueeze(0).expand(B, -1).float()
+    pos = pos + offset
     return rope(pos, D, theta).unsqueeze(1)
 
 
@@ -88,7 +89,9 @@ def test_double_stream_block_fused_matches_eager():
 
     img = torch.randn(B, L_img, HIDDEN, device=DEVICE)
     txt = torch.randn(B, L_txt, HIDDEN, device=DEVICE)
-    pe = make_pe(B, L_img, head_dim, DEVICE)
+    # img positions offset by 100 to mirror disjoint id spaces in real model,
+    # keeping the test sensitive to pe/pe_ctx swaps even if lengths are equalized.
+    pe = make_pe(B, L_img, head_dim, DEVICE, offset=100)
     pe_ctx = make_pe(B, L_txt, head_dim, DEVICE)
     mod_img = (make_mod(B, HIDDEN, DEVICE, seed=2), make_mod(B, HIDDEN, DEVICE, seed=3))
     mod_txt = (make_mod(B, HIDDEN, DEVICE, seed=4), make_mod(B, HIDDEN, DEVICE, seed=5))
@@ -109,3 +112,82 @@ def test_double_stream_block_fused_matches_eager():
 def test_double_stream_block_fused_constructor_flag():
     block = DoubleStreamBlock(HIDDEN, HEADS, mlp_ratio=4.0, fused_qknorm_rope=True)
     assert block.fused_qknorm_rope is True
+    assert DoubleStreamBlock(HIDDEN, HEADS, mlp_ratio=4.0).fused_qknorm_rope is False
+
+
+def test_single_stream_block_fused_with_checkpointing():
+    """Regression guard: fused path must be numerically equivalent under gradient checkpointing.
+
+    autograd.Function composes with torch.utils.checkpoint; this test guards against
+    regressions where recompute changes the result.
+    """
+    torch.manual_seed(0)
+    B, L = 2, 33
+    head_dim = HIDDEN // HEADS
+    block = SingleStreamBlock(HIDDEN, HEADS, fused_qknorm_rope=True).to(DEVICE).float()
+    block_ckpt = copy.deepcopy(block)
+    block_ckpt.enable_gradient_checkpointing()
+    block.train()
+    block_ckpt.train()
+
+    x = torch.randn(B, L, HIDDEN, device=DEVICE)
+    pe = make_pe(B, L, head_dim, DEVICE)
+    mod = make_mod(B, HIDDEN, DEVICE, seed=1)
+    attn_params = AttentionParams.create_attention_params("torch", False)
+
+    out_a, gx_a, grads_a = run_single(block, x, pe, mod, attn_params)
+    out_b, gx_b, grads_b = run_single(block_ckpt, x, pe, mod, attn_params)
+
+    tol = dict(rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(out_b, out_a, **tol)
+    torch.testing.assert_close(gx_b, gx_a, **tol)
+    for name in grads_a:
+        # dscale atomics are non-deterministic in the Triton kernel; if only the norm
+        # scale grads differ slightly between the two runs, loosen tolerance for those.
+        if "norm" in name and "scale" in name:
+            scale_tol = dict(rtol=1e-4, atol=1e-4)
+            torch.testing.assert_close(grads_b[name], grads_a[name], **scale_tol, msg=f"grad mismatch: {name}")
+        else:
+            torch.testing.assert_close(grads_b[name], grads_a[name], **tol, msg=f"grad mismatch: {name}")
+
+
+def test_double_stream_block_fused_with_checkpointing():
+    """Regression guard: fused DoubleStreamBlock path must be numerically equivalent
+    under gradient checkpointing.
+
+    autograd.Function composes with torch.utils.checkpoint; this test guards against
+    regressions where recompute changes the result.
+    """
+    torch.manual_seed(0)
+    B, L_img, L_txt = 2, 33, 11
+    head_dim = HIDDEN // HEADS
+    block = DoubleStreamBlock(HIDDEN, HEADS, mlp_ratio=4.0, fused_qknorm_rope=True).to(DEVICE).float()
+    block_ckpt = copy.deepcopy(block)
+    block_ckpt.enable_gradient_checkpointing()
+    block.train()
+    block_ckpt.train()
+
+    img = torch.randn(B, L_img, HIDDEN, device=DEVICE)
+    txt = torch.randn(B, L_txt, HIDDEN, device=DEVICE)
+    # img positions offset by 100 to mirror disjoint id spaces in real model.
+    pe = make_pe(B, L_img, head_dim, DEVICE, offset=100)
+    pe_ctx = make_pe(B, L_txt, head_dim, DEVICE)
+    mod_img = (make_mod(B, HIDDEN, DEVICE, seed=2), make_mod(B, HIDDEN, DEVICE, seed=3))
+    mod_txt = (make_mod(B, HIDDEN, DEVICE, seed=4), make_mod(B, HIDDEN, DEVICE, seed=5))
+    attn_params = AttentionParams.create_attention_params("torch", False)
+
+    res_a = run_double(block, img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params)
+    res_b = run_double(block_ckpt, img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params)
+
+    tol = dict(rtol=1e-5, atol=1e-5)
+    for a, b, what in [(res_b[0], res_a[0], "img out"), (res_b[1], res_a[1], "txt out"),
+                       (res_b[2], res_a[2], "img grad"), (res_b[3], res_a[3], "txt grad")]:
+        torch.testing.assert_close(a, b, **tol, msg=f"mismatch: {what}")
+    for name in res_a[4]:
+        # dscale atomics are non-deterministic in the Triton kernel; if only the norm
+        # scale grads differ slightly between the two runs, loosen tolerance for those.
+        if "norm" in name and "scale" in name:
+            scale_tol = dict(rtol=1e-4, atol=1e-4)
+            torch.testing.assert_close(res_b[4][name], res_a[4][name], **scale_tol, msg=f"grad mismatch: {name}")
+        else:
+            torch.testing.assert_close(res_b[4][name], res_a[4][name], **tol, msg=f"grad mismatch: {name}")

--- a/tests/test_fused_qknorm_rope_blocks.py
+++ b/tests/test_fused_qknorm_rope_blocks.py
@@ -141,9 +141,10 @@ def test_single_stream_block_fused_with_checkpointing():
     tol = dict(rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(out_b, out_a, **tol)
     torch.testing.assert_close(gx_b, gx_a, **tol)
+    assert grads_a.keys() == grads_b.keys()
     for name in grads_a:
-        # dscale atomics are non-deterministic in the Triton kernel; if only the norm
-        # scale grads differ slightly between the two runs, loosen tolerance for those.
+        # norm scale grads use a looser tolerance because dscale accumulates via atomic adds
+        # (non-deterministic ordering)
         if "norm" in name and "scale" in name:
             scale_tol = dict(rtol=1e-4, atol=1e-4)
             torch.testing.assert_close(grads_b[name], grads_a[name], **scale_tol, msg=f"grad mismatch: {name}")
@@ -183,11 +184,29 @@ def test_double_stream_block_fused_with_checkpointing():
     for a, b, what in [(res_b[0], res_a[0], "img out"), (res_b[1], res_a[1], "txt out"),
                        (res_b[2], res_a[2], "img grad"), (res_b[3], res_a[3], "txt grad")]:
         torch.testing.assert_close(a, b, **tol, msg=f"mismatch: {what}")
+    assert res_a[4].keys() == res_b[4].keys()
     for name in res_a[4]:
-        # dscale atomics are non-deterministic in the Triton kernel; if only the norm
-        # scale grads differ slightly between the two runs, loosen tolerance for those.
+        # norm scale grads use a looser tolerance because dscale accumulates via atomic adds
+        # (non-deterministic ordering)
         if "norm" in name and "scale" in name:
             scale_tol = dict(rtol=1e-4, atol=1e-4)
             torch.testing.assert_close(res_b[4][name], res_a[4][name], **scale_tol, msg=f"grad mismatch: {name}")
         else:
             torch.testing.assert_close(res_b[4][name], res_a[4][name], **tol, msg=f"grad mismatch: {name}")
+
+
+def test_flux2_model_threads_fused_flag():
+    # construction-only; no CUDA needed
+    from musubi_tuner.flux_2.flux2_models import Flux2, Flux2Params
+
+    params = Flux2Params(
+        in_channels=64, context_in_dim=512, hidden_size=256, mlp_ratio=4.0,
+        num_heads=2, depth=1, depth_single_blocks=1, axes_dim=[32, 32, 32, 32],
+        theta=2000, use_guidance_embed=False,
+    )
+    model = Flux2(params, attn_mode="torch", split_attn=False, fused_qknorm_rope=True)
+    assert all(b.fused_qknorm_rope for b in model.double_blocks)
+    assert all(b.fused_qknorm_rope for b in model.single_blocks)
+
+    model_off = Flux2(params, attn_mode="torch", split_attn=False)
+    assert not any(b.fused_qknorm_rope for b in model_off.single_blocks)

--- a/tests/test_fused_qknorm_rope_blocks.py
+++ b/tests/test_fused_qknorm_rope_blocks.py
@@ -67,3 +67,45 @@ def test_single_stream_block_fused_constructor_flag():
     block = SingleStreamBlock(HIDDEN, HEADS, fused_qknorm_rope=True)
     assert block.fused_qknorm_rope is True
     assert SingleStreamBlock(HIDDEN, HEADS).fused_qknorm_rope is False
+
+
+def run_double(block, img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params):
+    img = img.detach().clone().requires_grad_(True)
+    txt = txt.detach().clone().requires_grad_(True)
+    out_img, out_txt = block(img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params)
+    (out_img.sum() + out_txt.sum()).backward()
+    grads = {n: p.grad.detach().clone() for n, p in block.named_parameters() if p.grad is not None}
+    return out_img.detach(), out_txt.detach(), img.grad.detach().clone(), txt.grad.detach().clone(), grads
+
+
+def test_double_stream_block_fused_matches_eager():
+    torch.manual_seed(0)
+    B, L_img, L_txt = 2, 33, 11
+    head_dim = HIDDEN // HEADS
+    block = DoubleStreamBlock(HIDDEN, HEADS, mlp_ratio=4.0).to(DEVICE).float()
+    block_fused = copy.deepcopy(block)
+    block_fused.fused_qknorm_rope = True
+
+    img = torch.randn(B, L_img, HIDDEN, device=DEVICE)
+    txt = torch.randn(B, L_txt, HIDDEN, device=DEVICE)
+    pe = make_pe(B, L_img, head_dim, DEVICE)
+    pe_ctx = make_pe(B, L_txt, head_dim, DEVICE)
+    mod_img = (make_mod(B, HIDDEN, DEVICE, seed=2), make_mod(B, HIDDEN, DEVICE, seed=3))
+    mod_txt = (make_mod(B, HIDDEN, DEVICE, seed=4), make_mod(B, HIDDEN, DEVICE, seed=5))
+    attn_params = AttentionParams.create_attention_params("torch", False)
+
+    res_e = run_double(block, img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params)
+    res_f = run_double(block_fused, img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params)
+
+    tol = dict(rtol=1e-4, atol=1e-4)
+    for a, b, what in [(res_f[0], res_e[0], "img out"), (res_f[1], res_e[1], "txt out"),
+                       (res_f[2], res_e[2], "img grad"), (res_f[3], res_e[3], "txt grad")]:
+        torch.testing.assert_close(a, b, **tol, msg=f"mismatch: {what}")
+    assert res_e[4].keys() == res_f[4].keys()
+    for name in res_e[4]:
+        torch.testing.assert_close(res_f[4][name], res_e[4][name], **tol, msg=f"grad mismatch: {name}")
+
+
+def test_double_stream_block_fused_constructor_flag():
+    block = DoubleStreamBlock(HIDDEN, HEADS, mlp_ratio=4.0, fused_qknorm_rope=True)
+    assert block.fused_qknorm_rope is True

--- a/tests/test_fused_qknorm_rope_blocks.py
+++ b/tests/test_fused_qknorm_rope_blocks.py
@@ -101,8 +101,12 @@ def test_double_stream_block_fused_matches_eager():
     res_f = run_double(block_fused, img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params)
 
     tol = dict(rtol=1e-4, atol=1e-4)
-    for a, b, what in [(res_f[0], res_e[0], "img out"), (res_f[1], res_e[1], "txt out"),
-                       (res_f[2], res_e[2], "img grad"), (res_f[3], res_e[3], "txt grad")]:
+    for a, b, what in [
+        (res_f[0], res_e[0], "img out"),
+        (res_f[1], res_e[1], "txt out"),
+        (res_f[2], res_e[2], "img grad"),
+        (res_f[3], res_e[3], "txt grad"),
+    ]:
         torch.testing.assert_close(a, b, **tol, msg=f"mismatch: {what}")
     assert res_e[4].keys() == res_f[4].keys()
     for name in res_e[4]:
@@ -181,8 +185,12 @@ def test_double_stream_block_fused_with_checkpointing():
     res_b = run_double(block_ckpt, img, txt, pe, pe_ctx, mod_img, mod_txt, attn_params)
 
     tol = dict(rtol=1e-5, atol=1e-5)
-    for a, b, what in [(res_b[0], res_a[0], "img out"), (res_b[1], res_a[1], "txt out"),
-                       (res_b[2], res_a[2], "img grad"), (res_b[3], res_a[3], "txt grad")]:
+    for a, b, what in [
+        (res_b[0], res_a[0], "img out"),
+        (res_b[1], res_a[1], "txt out"),
+        (res_b[2], res_a[2], "img grad"),
+        (res_b[3], res_a[3], "txt grad"),
+    ]:
         torch.testing.assert_close(a, b, **tol, msg=f"mismatch: {what}")
     assert res_a[4].keys() == res_b[4].keys()
     for name in res_a[4]:
@@ -244,13 +252,15 @@ def test_double_stream_block_fused_flash_matches_eager_bf16():
     mod_txt = (make_mod(B, HIDDEN, DEVICE, seed=4, dtype=torch.bfloat16), make_mod(B, HIDDEN, DEVICE, seed=5, dtype=torch.bfloat16))
 
     res_e = run_double(block, img, txt, pe, pe_ctx, mod_img, mod_txt, AttentionParams.create_attention_params("torch", False))
-    res_f = run_double(
-        block_fused, img, txt, pe, pe_ctx, mod_img, mod_txt, AttentionParams.create_attention_params("flash", False)
-    )
+    res_f = run_double(block_fused, img, txt, pe, pe_ctx, mod_img, mod_txt, AttentionParams.create_attention_params("flash", False))
 
     tol = dict(rtol=2e-2, atol=2e-2)
-    for a, b, what in [(res_f[0], res_e[0], "img out"), (res_f[1], res_e[1], "txt out"),
-                       (res_f[2], res_e[2], "img grad"), (res_f[3], res_e[3], "txt grad")]:
+    for a, b, what in [
+        (res_f[0], res_e[0], "img out"),
+        (res_f[1], res_e[1], "txt out"),
+        (res_f[2], res_e[2], "img grad"),
+        (res_f[3], res_e[3], "txt grad"),
+    ]:
         torch.testing.assert_close(a.float(), b.float(), **tol, msg=f"mismatch: {what}")
 
 
@@ -259,9 +269,16 @@ def test_flux2_model_threads_fused_flag():
     from musubi_tuner.flux_2.flux2_models import Flux2, Flux2Params
 
     params = Flux2Params(
-        in_channels=64, context_in_dim=512, hidden_size=256, mlp_ratio=4.0,
-        num_heads=2, depth=1, depth_single_blocks=1, axes_dim=[32, 32, 32, 32],
-        theta=2000, use_guidance_embed=False,
+        in_channels=64,
+        context_in_dim=512,
+        hidden_size=256,
+        mlp_ratio=4.0,
+        num_heads=2,
+        depth=1,
+        depth_single_blocks=1,
+        axes_dim=[32, 32, 32, 32],
+        theta=2000,
+        use_guidance_embed=False,
     )
     model = Flux2(params, attn_mode="torch", split_attn=False, fused_qknorm_rope=True)
     assert all(b.fused_qknorm_rope for b in model.double_blocks)

--- a/tests/test_fused_qknorm_rope_blocks.py
+++ b/tests/test_fused_qknorm_rope_blocks.py
@@ -26,9 +26,9 @@ def make_pe(B, L, D, device, theta=2000, offset: int = 0):
     return rope(pos, D, theta).unsqueeze(1)
 
 
-def make_mod(B, hidden, device, seed):
+def make_mod(B, hidden, device, seed, dtype=torch.float32):
     gen = torch.Generator(device=device).manual_seed(seed)
-    return tuple(torch.randn(B, 1, hidden, device=device, generator=gen) * 0.1 for _ in range(3))
+    return tuple(torch.randn(B, 1, hidden, device=device, dtype=dtype, generator=gen) * 0.1 for _ in range(3))
 
 
 def run_single(block, x, pe, mod, attn_params):
@@ -193,6 +193,65 @@ def test_double_stream_block_fused_with_checkpointing():
             torch.testing.assert_close(res_b[4][name], res_a[4][name], **scale_tol, msg=f"grad mismatch: {name}")
         else:
             torch.testing.assert_close(res_b[4][name], res_a[4][name], **tol, msg=f"grad mismatch: {name}")
+
+
+def _flash_available():
+    from musubi_tuner.modules.attention import flash_attn_qkvpacked_func
+
+    return flash_attn_qkvpacked_func is not None
+
+
+@pytest.mark.skipif(not _flash_available(), reason="flash_attn not available")
+def test_single_stream_block_fused_flash_matches_eager_bf16():
+    """Production path: bf16 fused block with attn_mode=flash (packed handoff to
+    flash_attn_qkvpacked_func) vs the eager block on the torch backend."""
+    torch.manual_seed(0)
+    B, L = 2, 33
+    head_dim = HIDDEN // HEADS
+    block = SingleStreamBlock(HIDDEN, HEADS).to(DEVICE).to(torch.bfloat16)
+    block_fused = copy.deepcopy(block)
+    block_fused.fused_qknorm_rope = True
+
+    x = torch.randn(B, L, HIDDEN, device=DEVICE, dtype=torch.bfloat16)
+    pe = make_pe(B, L, head_dim, DEVICE)
+    mod = make_mod(B, HIDDEN, DEVICE, seed=1, dtype=torch.bfloat16)
+
+    out_e, gx_e, _ = run_single(block, x, pe, mod, AttentionParams.create_attention_params("torch", False))
+    out_f, gx_f, _ = run_single(block_fused, x, pe, mod, AttentionParams.create_attention_params("flash", False))
+
+    # bf16 + different attention backends: param grads are checked by the fp32
+    # torch-backend tests; here outputs and input grads pin the flash packed path.
+    tol = dict(rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(out_f.float(), out_e.float(), **tol)
+    torch.testing.assert_close(gx_f.float(), gx_e.float(), **tol)
+
+
+@pytest.mark.skipif(not _flash_available(), reason="flash_attn not available")
+def test_double_stream_block_fused_flash_matches_eager_bf16():
+    """Production path: bf16 fused DoubleStreamBlock with attn_mode=flash vs eager/torch."""
+    torch.manual_seed(0)
+    B, L_img, L_txt = 2, 33, 11
+    head_dim = HIDDEN // HEADS
+    block = DoubleStreamBlock(HIDDEN, HEADS, mlp_ratio=4.0).to(DEVICE).to(torch.bfloat16)
+    block_fused = copy.deepcopy(block)
+    block_fused.fused_qknorm_rope = True
+
+    img = torch.randn(B, L_img, HIDDEN, device=DEVICE, dtype=torch.bfloat16)
+    txt = torch.randn(B, L_txt, HIDDEN, device=DEVICE, dtype=torch.bfloat16)
+    pe = make_pe(B, L_img, head_dim, DEVICE, offset=100)
+    pe_ctx = make_pe(B, L_txt, head_dim, DEVICE)
+    mod_img = (make_mod(B, HIDDEN, DEVICE, seed=2, dtype=torch.bfloat16), make_mod(B, HIDDEN, DEVICE, seed=3, dtype=torch.bfloat16))
+    mod_txt = (make_mod(B, HIDDEN, DEVICE, seed=4, dtype=torch.bfloat16), make_mod(B, HIDDEN, DEVICE, seed=5, dtype=torch.bfloat16))
+
+    res_e = run_double(block, img, txt, pe, pe_ctx, mod_img, mod_txt, AttentionParams.create_attention_params("torch", False))
+    res_f = run_double(
+        block_fused, img, txt, pe, pe_ctx, mod_img, mod_txt, AttentionParams.create_attention_params("flash", False)
+    )
+
+    tol = dict(rtol=2e-2, atol=2e-2)
+    for a, b, what in [(res_f[0], res_e[0], "img out"), (res_f[1], res_e[1], "txt out"),
+                       (res_f[2], res_e[2], "img grad"), (res_f[3], res_e[3], "txt grad")]:
+        torch.testing.assert_close(a.float(), b.float(), **tol, msg=f"mismatch: {what}")
 
 
 def test_flux2_model_threads_fused_flag():

--- a/tests/test_fused_qknorm_rope_blocks.py
+++ b/tests/test_fused_qknorm_rope_blocks.py
@@ -1,0 +1,69 @@
+"""Block-level tests: SingleStreamBlock / DoubleStreamBlock with
+fused_qknorm_rope on vs off must match (outputs and grads).
+
+Run with:
+  uv run --no-sync pytest tests/test_fused_qknorm_rope_blocks.py -v
+"""
+
+import copy
+
+import pytest
+import torch
+
+from musubi_tuner.flux_2.flux2_models import DoubleStreamBlock, SingleStreamBlock, rope
+from musubi_tuner.modules.attention import AttentionParams
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+HIDDEN = 512
+HEADS = 4  # head_dim = 128, matching FLUX.2
+DEVICE = "cuda"
+
+
+def make_pe(B, L, D, device, theta=2000):
+    pos = torch.arange(L, device=device).unsqueeze(0).expand(B, -1).float()
+    return rope(pos, D, theta).unsqueeze(1)
+
+
+def make_mod(B, hidden, device, seed):
+    gen = torch.Generator(device=device).manual_seed(seed)
+    return tuple(torch.randn(B, 1, hidden, device=device, generator=gen) * 0.1 for _ in range(3))
+
+
+def run_single(block, x, pe, mod, attn_params):
+    x = x.detach().clone().requires_grad_(True)
+    out = block(x, pe, mod, attn_params)
+    out.sum().backward()
+    grads = {n: p.grad.detach().clone() for n, p in block.named_parameters() if p.grad is not None}
+    return out.detach(), x.grad.detach().clone(), grads
+
+
+@pytest.mark.parametrize("L", [33, 64])
+def test_single_stream_block_fused_matches_eager(L):
+    torch.manual_seed(0)
+    B = 2
+    head_dim = HIDDEN // HEADS
+    block = SingleStreamBlock(HIDDEN, HEADS).to(DEVICE).float()
+    block_fused = copy.deepcopy(block)
+    block_fused.fused_qknorm_rope = True
+
+    x = torch.randn(B, L, HIDDEN, device=DEVICE)
+    pe = make_pe(B, L, head_dim, DEVICE)
+    mod = make_mod(B, HIDDEN, DEVICE, seed=1)
+    attn_params = AttentionParams.create_attention_params("torch", False)
+
+    out_e, gx_e, grads_e = run_single(block, x, pe, mod, attn_params)
+    out_f, gx_f, grads_f = run_single(block_fused, x, pe, mod, attn_params)
+
+    tol = dict(rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out_f, out_e, **tol)
+    torch.testing.assert_close(gx_f, gx_e, **tol)
+    assert grads_e.keys() == grads_f.keys()
+    for name in grads_e:
+        torch.testing.assert_close(grads_f[name], grads_e[name], **tol, msg=f"grad mismatch: {name}")
+
+
+def test_single_stream_block_fused_constructor_flag():
+    block = SingleStreamBlock(HIDDEN, HEADS, fused_qknorm_rope=True)
+    assert block.fused_qknorm_rope is True
+    assert SingleStreamBlock(HIDDEN, HEADS).fused_qknorm_rope is False


### PR DESCRIPTION
## Summary

Adds an opt-in `--fused_qknorm_rope` flag for FLUX.2 training and inference: a Triton kernel that fuses RMSNorm (QKNorm) + RoPE application on the packed QKV tensor, replacing the eager unbind → norm → rope → rebind sequence in double and single stream blocks. When `--attn_mode flash` is used, the packed output is handed directly to `flash_attn_qkvpacked_func` with no re-packing.

FLUX.2の学習・推論にオプトインの `--fused_qknorm_rope` フラグを追加します。パックされたQKVテンソル上でRMSNorm（QKNorm）とRoPE適用を融合するTritonカーネルで、double/singleストリームブロックのeagerな unbind → norm → rope → rebind 処理を置き換えます。`--attn_mode flash` の場合、パックされた出力はそのまま `flash_attn_qkvpacked_func` に渡されます。

## Performance / 性能

For the norm+rope segment (Klein 4B shapes, bf16): ~12x forward, 5-8x forward+backward, ~2.9x lower peak memory vs eager. / norm+rope部分（Klein 4B形状、bf16）：eager比で forward 約12倍、forward+backward 5-8倍、ピークメモリ約2.9分の1。

## Correctness verification / 正確性の検証

- Kernel- and block-level parity tests vs eager: within 1-2 bf16 ULPs (fwd + bwd), all dtypes (fp32/fp16/bf16), strided-view inputs, pe broadcasting, frozen and trainable scales / カーネル・ブロックレベルのeagerとのパリティテスト：1-2 bf16 ULP以内
- Production-shape test against fp64 ground truth: 512 txt + 4096 img tokens, 24 heads, real 4-axis EmbedND frequencies, real Klein 4B qk-norm scale range [0.32, 2.86] — the fused path is *more* accurate than eager (~1.5x lower mean error; single rounding vs eager's repeated intermediate casts) / fp64基準との本番形状テスト：fusedパスはeagerより高精度（平均誤差約1.5分の1）
- Training-level A/B (LoRA, identical seed/config): fused-vs-eager weight divergence is within the eager-vs-eager run-to-run noise floor, verified with control experiments at 250 and 25 steps including fp32 snapshots / 学習レベルのA/B検証：fused対eagerの重み乖離はeager同士のrun間ノイズフロア以内

## Notes / 備考

- Requires triton; falls back to nothing — the flag is opt-in, default off / tritonが必要。フラグはオプトイン、デフォルトはオフ
- The RMSNorm scale gradients (full fine-tuning only) accumulate via fp32 atomics and are non-deterministic in ordering (documented in the module). In LoRA training scales are frozen and this path is compiled out (`NEEDS_DSCALE=False`) — the kernel backward is then deterministic / RMSNormスケール勾配（フルファインチューニング時のみ）はfp32アトミックで蓄積され順序非決定的（モジュール内に記載）。LoRA学習ではスケールが凍結されるためこのパスはコンパイル時に除外され、backwardは決定的です
- `ss_fused_qknorm_rope` is recorded in training metadata / 学習メタデータに `ss_fused_qknorm_rope` を記録

Draft for early feedback — happy to adjust scope (e.g. inference-only first, or splitting the metadata commit out). / 早期フィードバックのためのドラフトです。スコープの調整も可能です。