### PR TITLE
feat: Self-Flow training for FLUX.2 via extension seams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ name = "pytorch-cu130"
 url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+
 [tool.ruff]
 line-length = 132
 indent-width = 4

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -60,6 +60,31 @@ def reconstruct_noisy_input(
     return (1 - t_exp) * latents + t_exp * noise
 
 
+def apply_per_token_mask(
+    noisy_input_student: torch.Tensor,
+    noisy_input_teacher: torch.Tensor,
+    mask_ratio: float,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-token masking (paper Eq. 4-5): masked tokens take the teacher (cleaner) values.
+
+    Returns (masked_input, mask_flat) with mask_flat (B, N) bool, True = masked.
+    N indexes latent pixels, which map 1:1 to packed FLUX.2 image tokens (prc_img
+    does no patchify). Independent per-token draw; locality modes are a follow-up.
+    """
+    B = noisy_input_student.shape[0]
+    if noisy_input_student.ndim == 5:
+        _, _, T, H, W = noisy_input_student.shape
+        mask_flat = torch.rand(B, T * H * W, device=device) < mask_ratio
+        mask_spatial = mask_flat.view(B, 1, T, H, W).expand_as(noisy_input_student)
+    else:
+        _, _, H, W = noisy_input_student.shape
+        mask_flat = torch.rand(B, H * W, device=device) < mask_ratio
+        mask_spatial = mask_flat.view(B, 1, H, W).expand_as(noisy_input_student)
+    masked_input = torch.where(mask_spatial, noisy_input_teacher, noisy_input_student)
+    return masked_input, mask_flat
+
+
 # endregion self-flow math helpers
 
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -17,11 +17,12 @@ this repo; if you fork, expect breakage on updates.
 
 import argparse
 import logging
+import os
 from typing import Optional
 
 import torch
 from accelerate import Accelerator
-from safetensors.torch import load_file
+from safetensors.torch import load_file, save_file
 
 from musubi_tuner.flux_2.flux2_models import timestep_embedding
 from musubi_tuner.flux_2_train_network import Flux2NetworkTrainer, flux2_setup_parser
@@ -30,6 +31,7 @@ from musubi_tuner.hv_train_network import (
     setup_parser_common,
     read_config_from_file,
 )
+from musubi_tuner.utils import huggingface_utils
 
 
 logger = logging.getLogger(__name__)
@@ -736,10 +738,34 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         - ``<ckpt_name stem>-proj.safetensors`` (raw rep_proj state_dict)
         Each follows the main checkpoint's HuggingFace upload toggle.
         """
+        super().on_post_save(args, accelerator, network, transformer, ckpt_name, save_dtype, metadata, force_sync_upload)
         if not args.self_flow:
             return
-        # TODO: see PR #913 hv_train_network.py around lines 2750-2774.
-        raise NotImplementedError("Self-Flow companion file saving — see PR #913")
+
+        unwrapped_nw = accelerator.unwrap_model(network)
+
+        if self.rep_proj is not None:
+            proj_ckpt_name = ckpt_name.replace(".safetensors", "-proj.safetensors")
+            proj_ckpt_file = os.path.join(args.output_dir, proj_ckpt_name)
+            accelerator.print(f"saving projection head: {proj_ckpt_file}")
+            proj_state = {
+                k: v.to(save_dtype) if save_dtype is not None else v
+                for k, v in accelerator.unwrap_model(self.rep_proj).state_dict().items()
+            }
+            save_file(proj_state, proj_ckpt_file)
+            if args.huggingface_repo_id is not None:
+                huggingface_utils.upload(args, proj_ckpt_file, "/" + proj_ckpt_name, force_sync_upload=force_sync_upload)
+
+        if self.ema_lora_state is not None:
+            ema_ckpt_name = ckpt_name.replace(".safetensors", "-ema.safetensors")
+            ema_ckpt_file = os.path.join(args.output_dir, ema_ckpt_name)
+            accelerator.print(f"saving EMA checkpoint: {ema_ckpt_file}")
+            student_state = {k: v.clone() for k, v in unwrapped_nw.state_dict().items()}
+            unwrapped_nw.load_state_dict(self.ema_lora_state)
+            unwrapped_nw.save_weights(ema_ckpt_file, save_dtype, metadata)
+            unwrapped_nw.load_state_dict(student_state)
+            if args.huggingface_repo_id is not None:
+                huggingface_utils.upload(args, ema_ckpt_file, "/" + ema_ckpt_name, force_sync_upload=force_sync_upload)
 
     def extra_metadata(self, args: argparse.Namespace) -> dict:
         """Return ``ss_self_flow_*`` keys for embedding into safetensors metadata."""

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -142,6 +142,24 @@ def compute_ema_weight_drift(
         return torch.stack(dists).mean()
 
 
+def compute_representation_loss(
+    student_features: torch.Tensor,
+    teacher_features: torch.Tensor,
+    rep_proj: torch.nn.Module,
+) -> torch.Tensor:
+    """L_rep (paper Eq. 6): negative mean cosine similarity of projected student vs teacher."""
+    student_proj = rep_proj(student_features)
+    cos_sim = torch.nn.functional.cosine_similarity(student_proj, teacher_features, dim=-1)
+    return -cos_sim.mean()
+
+
+def effective_gamma(gamma: float, global_step: int, warmup_steps: int) -> float:
+    """Linear warmup of the L_rep weight: 0 -> gamma over warmup_steps, then constant."""
+    if warmup_steps <= 0:
+        return gamma
+    return gamma * min(1.0, global_step / warmup_steps)
+
+
 # endregion self-flow math helpers
 
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -433,21 +433,42 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
     ) -> None:
         """Finish Self-Flow setup once everything is on-device.
 
-        Steps to perform here:
+        Steps performed:
         1. Snapshot ``network.state_dict()`` into ``self.ema_lora_state``.
         2. If ``--network_weights_ema`` is given, load it into the network,
            re-snapshot, then restore student weights from ``--network_weights``.
         3. ``self.rep_proj = accelerator.prepare(self.rep_proj)``.
-        4. Optionally load ``--network_weights_proj`` into ``self.rep_proj``.
-        5. Build ``self._coupling_scheduler`` (constant / cosine / linear / rex).
 
         Forward-hook registration for feature extraction lives in
         ``on_transformer_loaded`` (runs earlier, before accelerator.prepare).
         """
+        super().on_train_start(args, accelerator, network, transformer, optimizer)
         if not args.self_flow:
             return
-        # TODO: see PR #913 hv_train_network.py around lines 2490-2522.
-        raise NotImplementedError("Self-Flow on_train_start — see PR #913")
+
+        # EMA snapshot after accelerator.prepare so tensors are on-device
+        self.ema_lora_state = {k: v.detach().clone() for k, v in network.state_dict().items()}
+        if args.network_weights_ema is not None:
+            if args.network_weights is None:
+                raise ValueError("--network_weights_ema requires --network_weights to be set")
+            unwrapped_nw = accelerator.unwrap_model(network)
+            info = unwrapped_nw.load_weights(args.network_weights_ema)
+            accelerator.print(f"load EMA network weights from {args.network_weights_ema}: {info}")
+            self.ema_lora_state = {k: v.detach().clone() for k, v in unwrapped_nw.state_dict().items()}
+            unwrapped_nw.load_weights(args.network_weights)  # restore student weights
+
+        self.rep_proj = accelerator.prepare(self.rep_proj)
+
+        if args.self_flow_teacher_coupling_decay != "constant":
+            logger.warning(
+                "self_flow_teacher_coupling_decay schedules are not implemented in this extension yet; "
+                "using constant coupling probability."
+            )
+        logger.info(
+            f"Self-Flow enabled: gamma={args.self_flow_gamma}, mask_ratio={args.mask_ratio}, "
+            f"ema_decay={args.ema_decay}, student_layer={args.student_feature_layer}, "
+            f"teacher_layer={args.teacher_feature_layer}"
+        )
 
     def call_dit(
         self,
@@ -569,16 +590,11 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         sync_gradients: bool,
         global_step: int,
     ) -> None:
-        """EMA update of LoRA weights only on real optimizer steps.
-
-        ema_lora_state[k].lerp_(network.state_dict()[k], 1 - args.ema_decay)
-        """
-        if not args.self_flow or not sync_gradients:
+        """EMA update of LoRA weights only on real optimizer steps."""
+        super().on_post_optimizer_step(args, accelerator, network, transformer, sync_gradients, global_step)
+        if not args.self_flow or not sync_gradients or self.ema_lora_state is None:
             return
-        if self.ema_lora_state is None:
-            return
-        # TODO: in-place lerp_ across floating-point params; copy_ otherwise.
-        raise NotImplementedError("Self-Flow EMA update — see PR #913 _update_ema_weights")
+        update_ema_weights(self.ema_lora_state, network.state_dict(), args.ema_decay)
 
     def on_before_sample_images(
         self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -22,6 +22,7 @@ from typing import Optional
 import torch
 from accelerate import Accelerator
 
+from musubi_tuner.flux_2.flux2_models import timestep_embedding
 from musubi_tuner.flux_2_train_network import Flux2NetworkTrainer, flux2_setup_parser
 from musubi_tuner.hv_train_network import (
     DiTOutput,
@@ -155,6 +156,78 @@ def effective_gamma(gamma: float, global_step: int, warmup_steps: int) -> float:
 
 
 # endregion self-flow math helpers
+
+
+class PerTokenModulationController:
+    """Reroutes Flux2's modulation path to per-token timesteps via forward hooks.
+
+    When staged with a per-token map tau (B, N_img) in model scale [0, 1], the
+    hooks turn the modulation vec from (B, D) into (B, N_img, D); Modulation and
+    LastLayer broadcast 3D vecs natively, so no model code changes. When not
+    staged, every hook is a pass-through and the model is bit-identical to
+    vanilla. Install on the raw (unwrapped) model before accelerator.prepare.
+    """
+
+    REQUIRED_MODULES = ("time_in", "double_stream_modulation_txt", "single_stream_modulation")
+
+    def __init__(self) -> None:
+        self._handles: list = []
+        self._tau: Optional[torch.Tensor] = None
+        self._num_txt_tokens: Optional[int] = None
+
+    def install(self, model) -> None:
+        for name in self.REQUIRED_MODULES:
+            if not hasattr(model, name):
+                raise AttributeError(
+                    f"Flux2 model has no module '{name}' — upstream may have renamed it; "
+                    "the Self-Flow per-token hooks need updating."
+                )
+        self._handles.append(model.time_in.register_forward_hook(self._time_in_hook))
+        if model.use_guidance_embed:
+            self._handles.append(model.guidance_in.register_forward_hook(self._guidance_in_hook))
+        self._handles.append(model.double_stream_modulation_txt.register_forward_pre_hook(self._txt_modulation_pre_hook))
+        self._handles.append(model.single_stream_modulation.register_forward_pre_hook(self._single_modulation_pre_hook))
+
+    def remove(self) -> None:
+        for handle in self._handles:
+            handle.remove()
+        self._handles.clear()
+
+    def stage(self, per_token_timesteps: torch.Tensor, num_txt_tokens: int) -> None:
+        """Arm the hooks for the next forward. tau in model scale [0, 1], shape (B, N_img)."""
+        self._tau = per_token_timesteps
+        self._num_txt_tokens = num_txt_tokens
+
+    def clear(self) -> None:
+        self._tau = None
+        self._num_txt_tokens = None
+
+    def _time_in_hook(self, module, inputs, output):
+        if self._tau is None:
+            return None
+        B, N = self._tau.shape
+        emb = timestep_embedding(self._tau.reshape(-1), 256)
+        # module.forward (not module.__call__): bypasses hooks, so no recursion
+        return module.forward(emb).reshape(B, N, -1)
+
+    def _guidance_in_hook(self, module, inputs, output):
+        if self._tau is None:
+            return None
+        return output.unsqueeze(1)  # (B, D) -> (B, 1, D): broadcasts in `vec + guidance`
+
+    def _txt_modulation_pre_hook(self, module, args):
+        if self._tau is None:
+            return None
+        (vec,) = args  # (B, N_img, D) after the time_in hook (+ guidance)
+        return (vec.mean(dim=1),)  # text tokens get the global (mean) vec
+
+    def _single_modulation_pre_hook(self, module, args):
+        if self._tau is None:
+            return None
+        (vec,) = args  # (B, N_img, D)
+        vec_global = vec.mean(dim=1)
+        vec_txt = vec_global.unsqueeze(1).expand(-1, self._num_txt_tokens, -1)
+        return (torch.cat([vec_txt, vec], dim=1),)
 
 
 class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -15,6 +15,10 @@ Per-token conditioning is achieved by hooking ``time_in`` /
 unmodified Flux2 model — its Modulation and LastLayer already broadcast 3D
 vectors natively.
 
+Limitations (first pass): coupling-prob decay schedules are constant-only,
+patch-locality mask modes are not ported, and control images
+(``latents_control_*``) raise ``NotImplementedError`` with ``--self_flow``.
+
 Internal extension point — no API stability guarantees. Subclasses live in
 this repo; if you fork, expect breakage on updates.
 """
@@ -768,8 +772,10 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
             accelerator.print(f"saving EMA checkpoint: {ema_ckpt_file}")
             student_state = {k: v.clone() for k, v in unwrapped_nw.state_dict().items()}
             unwrapped_nw.load_state_dict(self.ema_lora_state)
-            unwrapped_nw.save_weights(ema_ckpt_file, save_dtype, metadata)
-            unwrapped_nw.load_state_dict(student_state)
+            try:
+                unwrapped_nw.save_weights(ema_ckpt_file, save_dtype, metadata)
+            finally:
+                unwrapped_nw.load_state_dict(student_state)
             if args.huggingface_repo_id is not None:
                 huggingface_utils.upload(args, ema_ckpt_file, "/" + ema_ckpt_name, force_sync_upload=force_sync_upload)
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -1,15 +1,19 @@
 """Self-Flow training entry point for FLUX.2.
 
-Skeleton for Self-Supervised Flow Matching (Self-Flow) on the FLUX.2 backbone.
-Each base-class extension seam is overridden here as a stub showing how the
-algorithm hooks in. Actual algorithmic logic is intentionally left as
-``NotImplementedError`` / ``# TODO`` markers — to be filled in by porting
-rockerBOO's PR #913 implementation onto these seams.
+Implements Self-Supervised Flow Matching (Self-Flow, arXiv:2603.06507) on the
+FLUX.2 backbone via extension seams and runtime forward hooks — zero
+modifications to ``flux2_models.py`` or any base trainer are required.
 
-Reference: https://github.com/kohya-ss/musubi-tuner/pull/913
+Algorithm: dual-timestep scheduling assigns a cleaner (teacher) and a noisier
+(student) timestep per sample each step; per-token masking injects teacher
+values into a fraction of student tokens; a representation alignment loss
+(L_rep) distils knowledge from a deeper EMA teacher block into the shallower
+student block via a learnable projection head.
 
-This file is the proposed extension surface, not a runnable trainer. Do not
-use it to start a training run yet.
+Per-token conditioning is achieved by hooking ``time_in`` /
+``double_stream_modulation_txt`` / ``single_stream_modulation`` on the
+unmodified Flux2 model — its Modulation and LastLayer already broadcast 3D
+vectors natively.
 
 Internal extension point — no API stability guarantees. Subclasses live in
 this repo; if you fork, expect breakage on updates.
@@ -299,7 +303,7 @@ class BlockFeatureExtractor:
 
 
 class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
-    """FLUX.2 + Self-Flow.
+    """FLUX.2 + Self-Flow trainer.
 
     Owned state (set during the relevant lifecycle seams, used across steps):
     - ``self.rep_proj``: representation projection head (paper §3.3, Eq. 6).
@@ -307,22 +311,22 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
     - ``self.ema_lora_state``: EMA snapshot of LoRA weights (the "teacher").
       Initialised in ``on_train_start`` after ``accelerator.prepare`` so it
       sits on-device. Updated by ``on_post_optimizer_step``.
-    - ``self._coupling_scheduler``: dummy LR scheduler whose "lr" is the
-      teacher coupling probability (decays over training).
     - ``self._feature_extractor``: holds DiT layer outputs captured via
       ``register_forward_hook`` (no DiT model edit required). Hooks are
       registered in ``on_transformer_loaded``.
+    - ``self._modulation_controller``: reroutes Flux2's modulation path to
+      per-token timesteps via forward hooks (no model code changes).
     - ``self._self_flow_logs``: per-step state metrics dict drained by
-      ``extra_step_logs`` (e.g. coupling-scheduler value). Loss decomposition
-      itself (``loss/gen``, ``loss/rep``) flows through ``process_batch``'s
-      ``loss_metrics`` return, not through here.
+      ``extra_step_logs``. Loss decomposition (``loss/gen``, ``loss/rep``)
+      flows through ``process_batch``'s ``loss_metrics`` return, not through here.
+    - ``self._saved_student_state``: snapshot of student LoRA weights while
+      EMA weights are swapped in for sampling; restored in ``on_after_sample_images``.
     """
 
     def __init__(self) -> None:
         super().__init__()
         self.rep_proj: Optional[torch.nn.Module] = None
         self.ema_lora_state: Optional[dict] = None
-        self._coupling_scheduler = None
         self._feature_extractor: Optional[BlockFeatureExtractor] = None
         self._modulation_controller: Optional[PerTokenModulationController] = None
         self._self_flow_logs: dict = {}
@@ -346,6 +350,8 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
                 )
             if args.mask_ratio > 0.5:
                 raise ValueError(f"--mask_ratio ({args.mask_ratio}) must be <= 0.5 (paper constraint R_M <= 0.5)")
+            if getattr(args, "compile", False):
+                logger.warning("--compile with --self_flow: forward hooks cause graph breaks; expect reduced compile benefit.")
 
     # endregion
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -316,7 +316,8 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         self.rep_proj: Optional[torch.nn.Module] = None
         self.ema_lora_state: Optional[dict] = None
         self._coupling_scheduler = None
-        self._feature_extractor = None
+        self._feature_extractor: Optional[BlockFeatureExtractor] = None
+        self._modulation_controller: Optional[PerTokenModulationController] = None
         self._self_flow_logs: dict = {}
         self._saved_student_state: Optional[dict] = None
 
@@ -377,12 +378,29 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         captured tensors aligned with the unwrapped block indices the user
         supplied via ``--student_feature_layer`` / ``--teacher_feature_layer``.
         """
+        super().on_transformer_loaded(args, accelerator, transformer)
         if not args.self_flow:
             return
-        # TODO: register forward_hook on transformer.double_blocks[student_layer]
-        #       and transformer.double_blocks[teacher_layer], stashing outputs
-        #       into self._feature_extractor for call_dit to drain.
-        raise NotImplementedError("Self-Flow forward-hook registration — see PR #913")
+
+        num_blocks = len(transformer.double_blocks) + len(transformer.single_blocks)
+        if args.student_feature_layer is None:
+            args.student_feature_layer = max(0, int(num_blocks * 0.3))
+        if args.teacher_feature_layer is None:
+            args.teacher_feature_layer = min(num_blocks - 1, int(num_blocks * 0.7))
+        if args.student_feature_layer >= args.teacher_feature_layer:
+            raise ValueError(
+                f"--student_feature_layer ({args.student_feature_layer}) must be less than "
+                f"--teacher_feature_layer ({args.teacher_feature_layer})."
+            )
+
+        self._modulation_controller = PerTokenModulationController()
+        self._modulation_controller.install(transformer)
+        self._feature_extractor = BlockFeatureExtractor()
+        self._feature_extractor.install(transformer, [args.student_feature_layer, args.teacher_feature_layer])
+        logger.info(
+            f"Self-Flow hooks installed: student_layer={args.student_feature_layer}, "
+            f"teacher_layer={args.teacher_feature_layer} (of {num_blocks} blocks)"
+        )
 
     def on_train_start(
         self,
@@ -430,17 +448,37 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
           ``DiTOutput.extra["features"]`` (drained from ``self._feature_extractor``).
         - ``feature_layer`` (int): which registered layer's output to return.
         - ``per_token_timesteps`` (Tensor): per-token timestep map for
-          dual-timestep conditioning (paper §A.3). Requires per-token
-          timestep support inside the FLUX.2 transformer — out of scope of
-          this skeleton, see open question (3) below.
-
-        For the skeleton we delegate to the parent and ignore kwargs; once
-        the FLUX.2 model side is wired up, this override forwards
-        per_token_timesteps and surfaces captured features.
+          dual-timestep conditioning (paper §A.3). Staged into
+          ``self._modulation_controller`` before the forward and cleared after.
         """
-        return super().call_dit(
-            args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs
-        )
+        hidden_features = kwargs.pop("hidden_features", False)
+        feature_layer = kwargs.pop("feature_layer", None)
+        per_token_timesteps = kwargs.pop("per_token_timesteps", None)
+
+        if not hidden_features and per_token_timesteps is None:
+            return super().call_dit(
+                args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs
+            )
+
+        if any(k.startswith("latents_control_") for k in batch):
+            raise NotImplementedError("Self-Flow does not support control images yet")
+
+        num_txt_tokens = batch["ctx_vec"].shape[1]
+        if per_token_timesteps is not None:
+            # model scale: base call_dit divides 1D timesteps by 1000; mirror that here
+            tau = per_token_timesteps.to(device=accelerator.device) / 1000.0
+            self._modulation_controller.stage(tau, num_txt_tokens)
+        if hidden_features:
+            self._feature_extractor.arm(feature_layer, num_txt_tokens)
+        try:
+            output = super().call_dit(
+                args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs
+            )
+        finally:
+            self._modulation_controller.clear()
+        if hidden_features:
+            output.extra["features"] = self._feature_extractor.drain()
+        return output
 
     def process_batch(
         self,

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -112,6 +112,36 @@ def build_per_token_timestep_map(
     return per_token_t, mismatch_mask
 
 
+def update_ema_weights(
+    ema_state: dict[str, torch.Tensor],
+    current_state: dict[str, torch.Tensor],
+    decay: float,
+) -> None:
+    """In-place EMA update: ema = decay * ema + (1 - decay) * current."""
+    with torch.no_grad():
+        for k, v in current_state.items():
+            if v.is_floating_point():
+                ema_state[k].lerp_(v, 1 - decay)
+            else:
+                ema_state[k].copy_(v)
+
+
+def compute_ema_weight_drift(
+    ema_state: dict[str, torch.Tensor],
+    current_state: dict[str, torch.Tensor],
+) -> torch.Tensor:
+    """Mean L2 distance between EMA and current weights (floating-point only)."""
+    with torch.no_grad():
+        dists = [
+            torch.linalg.vector_norm(current_state[k].float() - v.float())
+            for k, v in ema_state.items()
+            if v.is_floating_point()
+        ]
+        if not dists:
+            return torch.tensor(0.0)
+        return torch.stack(dists).mean()
+
+
 # endregion self-flow math helpers
 
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -50,7 +50,18 @@ logging.basicConfig(level=logging.INFO)
 
 
 def assign_teacher_student_timesteps(timesteps_a: torch.Tensor, timesteps_b: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Per-sample teacher/student split (paper §3.3): teacher = min (cleaner), student = max."""
+    """Per-sample teacher/student split: teacher = min (cleaner), student = max.
+
+    Note: the paper does NOT say "student = max" is always the conditioning timestep.
+    Paper Eq. 4 gives each masked token timestep s as drawn (cleaner only half the
+    time). The distribution-equivalent implementation used here is: per-sample fair
+    coin selects effective fraction R_M (heads) or 1−R_M (tails), so masked tokens
+    always take the teacher (cleaner) values but the fraction flips — restoring the
+    per-token marginal timestep distribution p(t) for any R_M.
+    ``timesteps_student`` (max) is kept as the 1-D scalar passed to call_dit and
+    for optional SD3-style weighting; the per-token map overrides conditioning
+    in the model via PerTokenModulationController.
+    """
     t_a = timesteps_a.float()
     t_b = timesteps_b.float()
     timesteps_teacher = torch.min(t_a, t_b).to(timesteps_a.dtype)
@@ -71,23 +82,34 @@ def reconstruct_noisy_input(latents: torch.Tensor, noise: torch.Tensor, timestep
 def apply_per_token_mask(
     noisy_input_student: torch.Tensor,
     noisy_input_teacher: torch.Tensor,
-    mask_ratio: float,
+    mask_ratio: "float | torch.Tensor",
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Per-token masking (paper Eq. 4-5): masked tokens take the teacher (cleaner) values.
+
+    ``mask_ratio`` may be a float (uniform across the batch) or a 1-D per-sample
+    tensor of shape (B,), enabling the paper-faithful coin-flip scheduling where
+    each sample independently uses R_M or 1−R_M as its effective fraction.
 
     Returns (masked_input, mask_flat) with mask_flat (B, N) bool, True = masked.
     N indexes latent pixels, which map 1:1 to packed FLUX.2 image tokens (prc_img
     does no patchify). Independent per-token draw; locality modes are a follow-up.
     """
     B = noisy_input_student.shape[0]
+    # Normalise ratio: accept float, 0-dim tensor, or (B,) tensor.
+    ratio = torch.as_tensor(mask_ratio, dtype=torch.float32, device=device)
+    if ratio.ndim == 0:
+        ratio = ratio.expand(B)  # broadcast scalar to (B,)
+    # ratio is now (B,); broadcast to (B, N) for per-token comparison.
     if noisy_input_student.ndim == 5:
         _, _, T, H, W = noisy_input_student.shape
-        mask_flat = torch.rand(B, T * H * W, device=device) < mask_ratio
+        N = T * H * W
+        mask_flat = torch.rand(B, N, device=device) < ratio.unsqueeze(1)  # (B, N)
         mask_spatial = mask_flat.view(B, 1, T, H, W).expand_as(noisy_input_student)
     else:
         _, _, H, W = noisy_input_student.shape
-        mask_flat = torch.rand(B, H * W, device=device) < mask_ratio
+        N = H * W
+        mask_flat = torch.rand(B, N, device=device) < ratio.unsqueeze(1)  # (B, N)
         mask_spatial = mask_flat.view(B, 1, H, W).expand_as(noisy_input_student)
     masked_input = torch.where(mask_spatial, noisy_input_teacher, noisy_input_student)
     return masked_input, mask_flat
@@ -600,10 +622,20 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         timesteps_teacher, timesteps_student = assign_teacher_student_timesteps(timesteps_a, timesteps_b)
 
         # 2. noisy inputs + per-token mask (masked tokens take the cleaner teacher noise)
+        # Paper-faithful Eq. 4 coin-flip: per-sample fair coin selects effective fraction
+        # R_M (heads) or 1−R_M (tails). This preserves the per-token marginal p(t) for
+        # any R_M, which is the key invariant of paper Eq. 4.
         noisy_input_teacher = reconstruct_noisy_input(latents, noise, timesteps_teacher)
         noisy_input_student = reconstruct_noisy_input(latents, noise, timesteps_student)
+        B = latents.shape[0]
+        coin = torch.rand(B, device=accelerator.device) < 0.5
+        effective_ratio = torch.where(
+            coin,
+            torch.full((B,), args.mask_ratio, device=accelerator.device),
+            torch.full((B,), 1.0 - args.mask_ratio, device=accelerator.device),
+        )
         noisy_input_student, mask_flat = apply_per_token_mask(
-            noisy_input_student, noisy_input_teacher, args.mask_ratio, accelerator.device
+            noisy_input_student, noisy_input_teacher, effective_ratio, accelerator.device
         )
 
         coupling_prob = args.self_flow_teacher_coupling_prob  # constant; decay schedules are a follow-up
@@ -686,7 +718,10 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
             "self_flow/timestep_teacher_mean": timesteps_teacher.float().mean().item(),
             "self_flow/timestep_diff": (timesteps_student.float().mean() - timesteps_teacher.float().mean()).item(),
             "self_flow/teacher_coupling_prob": coupling_prob,
+            # actual_mask_ratio: mean of per-sample effective ratios (bimodal around R_M and 1-R_M, average ~0.5)
             "self_flow/actual_mask_ratio": mask_flat.float().mean().item(),
+            # cleaner_fraction_mean: mean effective ratio this step (shows per-step coin outcomes, hovers ~0.5)
+            "self_flow/cleaner_fraction_mean": effective_ratio.mean().item(),
             "self_flow/ema_weight_drift": ema_drift.item(),
         }
         masked_count = mask_flat.sum().item()

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -242,6 +242,7 @@ class BlockFeatureExtractor:
 
     def __init__(self) -> None:
         self._handles: list = []
+        self._installed_layers: set[int] = set()
         self._armed_layer: Optional[int] = None
         self._num_txt_tokens: Optional[int] = None
         self._features: Optional[torch.Tensor] = None
@@ -257,6 +258,7 @@ class BlockFeatureExtractor:
             else:
                 handle = model.single_blocks[layer - num_double].register_forward_hook(self._make_single_hook(layer))
             self._handles.append(handle)
+            self._installed_layers.add(layer)
 
     def remove(self) -> None:
         for handle in self._handles:
@@ -264,6 +266,8 @@ class BlockFeatureExtractor:
         self._handles.clear()
 
     def arm(self, layer: int, num_txt_tokens: int) -> None:
+        if layer not in self._installed_layers:
+            raise ValueError(f"feature layer {layer} was not installed (installed: {sorted(self._installed_layers)})")
         self._armed_layer = layer
         self._num_txt_tokens = num_txt_tokens
         self._features = None
@@ -470,14 +474,17 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
             self._modulation_controller.stage(tau, num_txt_tokens)
         if hidden_features:
             self._feature_extractor.arm(feature_layer, num_txt_tokens)
+        features = None
         try:
             output = super().call_dit(
                 args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs
             )
         finally:
             self._modulation_controller.clear()
+            if hidden_features:
+                features = self._feature_extractor.drain()
         if hidden_features:
-            output.extra["features"] = self._feature_extractor.drain()
+            output.extra["features"] = features
         return output
 
     def process_batch(

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -85,6 +85,33 @@ def apply_per_token_mask(
     return masked_input, mask_flat
 
 
+def build_per_token_timestep_map(
+    timesteps_teacher: torch.Tensor,
+    timesteps_student: torch.Tensor,
+    mask_flat: torch.Tensor,
+    mismatch_prob: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-token timestep map for dual-timestep conditioning (paper §3.3).
+
+    Unmasked tokens get the student timestep. Masked tokens get the teacher
+    timestep, except with probability ``mismatch_prob`` they get the student
+    timestep (deliberate mismatch — experimental, 0.0 = paper behaviour).
+    Returns (per_token_timesteps (B, N), mismatch_mask (B, N) bool).
+    """
+    B, N = mask_flat.shape
+    t_student = timesteps_student.unsqueeze(1).expand(B, N)
+    t_teacher = timesteps_teacher.unsqueeze(1).expand(B, N)
+
+    if mismatch_prob <= 0.0:
+        per_token_t = torch.where(mask_flat, t_teacher, t_student)
+        return per_token_t, torch.zeros_like(mask_flat)
+
+    coin = torch.rand(B, N, device=mask_flat.device)
+    mismatch_mask = mask_flat & (coin < mismatch_prob)
+    per_token_t = torch.where(mask_flat & ~mismatch_mask, t_teacher, t_student)
+    return per_token_t, mismatch_mask
+
+
 # endregion self-flow math helpers
 
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -37,9 +37,7 @@ logging.basicConfig(level=logging.INFO)
 # region self-flow math helpers
 
 
-def assign_teacher_student_timesteps(
-    timesteps_a: torch.Tensor, timesteps_b: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor]:
+def assign_teacher_student_timesteps(timesteps_a: torch.Tensor, timesteps_b: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Per-sample teacher/student split (paper §3.3): teacher = min (cleaner), student = max."""
     t_a = timesteps_a.float()
     t_b = timesteps_b.float()
@@ -48,9 +46,7 @@ def assign_teacher_student_timesteps(
     return timesteps_teacher, timesteps_student
 
 
-def reconstruct_noisy_input(
-    latents: torch.Tensor, noise: torch.Tensor, timesteps: torch.Tensor
-) -> torch.Tensor:
+def reconstruct_noisy_input(latents: torch.Tensor, noise: torch.Tensor, timesteps: torch.Tensor) -> torch.Tensor:
     """Flow-matching interpolation (1-t)*latents + t*noise; timesteps in [1, 1001]."""
     t = (timesteps.float() - 1.0) / 1000.0
     if latents.ndim == 5:
@@ -133,9 +129,7 @@ def compute_ema_weight_drift(
     """Mean L2 distance between EMA and current weights (floating-point only)."""
     with torch.no_grad():
         dists = [
-            torch.linalg.vector_norm(current_state[k].float() - v.float())
-            for k, v in ema_state.items()
-            if v.is_floating_point()
+            torch.linalg.vector_norm(current_state[k].float() - v.float()) for k, v in ema_state.items() if v.is_floating_point()
         ]
         if not dists:
             return torch.tensor(0.0)

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -675,11 +675,10 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
             "self_flow/actual_mask_ratio": mask_flat.float().mean().item(),
             "self_flow/ema_weight_drift": ema_drift.item(),
         }
-        if mismatch_mask.any():
-            masked_count = mask_flat.sum().item()
-            self._self_flow_logs["self_flow/mismatch_patch_frac"] = (
-                mismatch_mask.sum().item() / masked_count if masked_count > 0 else 0.0
-            )
+        masked_count = mask_flat.sum().item()
+        mismatch_count = mismatch_mask.sum().item()
+        self._self_flow_logs["self_flow/mismatch_patch_count"] = mismatch_count
+        self._self_flow_logs["self_flow/mismatch_patch_frac"] = mismatch_count / masked_count if masked_count > 0 else 0.0
 
         return loss, loss_metrics
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -34,6 +34,35 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+# region self-flow math helpers
+
+
+def assign_teacher_student_timesteps(
+    timesteps_a: torch.Tensor, timesteps_b: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-sample teacher/student split (paper §3.3): teacher = min (cleaner), student = max."""
+    t_a = timesteps_a.float()
+    t_b = timesteps_b.float()
+    timesteps_teacher = torch.min(t_a, t_b).to(timesteps_a.dtype)
+    timesteps_student = torch.max(t_a, t_b).to(timesteps_a.dtype)
+    return timesteps_teacher, timesteps_student
+
+
+def reconstruct_noisy_input(
+    latents: torch.Tensor, noise: torch.Tensor, timesteps: torch.Tensor
+) -> torch.Tensor:
+    """Flow-matching interpolation (1-t)*latents + t*noise; timesteps in [1, 1001]."""
+    t = (timesteps.float() - 1.0) / 1000.0
+    if latents.ndim == 5:
+        t_exp = t.view(-1, 1, 1, 1, 1)
+    else:
+        t_exp = t.view(-1, 1, 1, 1)
+    return (1 - t_exp) * latents + t_exp * noise
+
+
+# endregion self-flow math helpers
+
+
 class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
     """FLUX.2 + Self-Flow.
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -446,8 +446,10 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         if not args.self_flow:
             return
 
-        # EMA snapshot after accelerator.prepare so tensors are on-device
-        self.ema_lora_state = {k: v.detach().clone() for k, v in network.state_dict().items()}
+        # EMA snapshot after accelerator.prepare so tensors are on-device.
+        # Use unwrap_model so multi-GPU wrapped keys cannot mismatch.
+        unwrapped_nw = accelerator.unwrap_model(network)
+        self.ema_lora_state = {k: v.detach().clone() for k, v in unwrapped_nw.state_dict().items()}
         if args.network_weights_ema is not None:
             if args.network_weights is None:
                 raise ValueError("--network_weights_ema requires --network_weights to be set")
@@ -575,11 +577,111 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
                 vae,
                 global_step,
             )
-        # TODO: port PR #913's _self_flow_step body here, calling
-        #       ``self.call_dit(..., hidden_features=True, feature_layer=...)``
-        #       and ``self.call_dit(..., per_token_timesteps=...)`` for
-        #       teacher and student forwards respectively.
-        raise NotImplementedError("Self-Flow process_batch — see PR #913 _self_flow_step")
+
+        # 1. two timestep draws; per-sample teacher = min, student = max (paper §3.3)
+        _, timesteps_a = self.get_noisy_model_input_and_timesteps(
+            args, noise, latents, batch["timesteps"], noise_scheduler, accelerator.device, dit_dtype
+        )
+        _, timesteps_b = self.get_noisy_model_input_and_timesteps(
+            args, noise, latents, batch["timesteps"], noise_scheduler, accelerator.device, dit_dtype
+        )
+        timesteps_teacher, timesteps_student = assign_teacher_student_timesteps(timesteps_a, timesteps_b)
+
+        # 2. noisy inputs + per-token mask (masked tokens take the cleaner teacher noise)
+        noisy_input_teacher = reconstruct_noisy_input(latents, noise, timesteps_teacher)
+        noisy_input_student = reconstruct_noisy_input(latents, noise, timesteps_student)
+        noisy_input_student, mask_flat = apply_per_token_mask(
+            noisy_input_student, noisy_input_teacher, args.mask_ratio, accelerator.device
+        )
+
+        coupling_prob = args.self_flow_teacher_coupling_prob  # constant; decay schedules are a follow-up
+        gate_open = coupling_prob > 0.0 and torch.rand(1).item() < coupling_prob
+        effective_mismatch = args.self_flow_teacher_mismatch_ratio if gate_open else 0.0
+        per_token_timesteps_student, mismatch_mask = build_per_token_timestep_map(
+            timesteps_teacher, timesteps_student, mask_flat, mismatch_prob=effective_mismatch
+        )
+
+        # 3. teacher forward: EMA weights, no grad, uniform (cleaner) timestep
+        # Use unwrap_model so multi-GPU wrapped keys can never mismatch (Amendment 1).
+        unwrapped_nw = accelerator.unwrap_model(network)
+        student_lora_state = {k: v.clone() for k, v in unwrapped_nw.state_dict().items()}
+        unwrapped_nw.load_state_dict(self.ema_lora_state)
+        with torch.no_grad():
+            output = self.call_dit(
+                args,
+                accelerator,
+                transformer,
+                latents,
+                batch,
+                noise,
+                noisy_input_teacher,
+                timesteps_teacher,
+                network_dtype,
+                hidden_features=True,
+                feature_layer=args.teacher_feature_layer,
+            )
+            feat_teacher = output.extra.get("features")
+            feat_teacher = feat_teacher.detach() if feat_teacher is not None else None
+        unwrapped_nw.load_state_dict(student_lora_state)
+        # block swap ran forward-only for the teacher; re-prepare device placement
+        accelerator.unwrap_model(transformer).prepare_block_swap_before_forward()
+
+        # 4. student forward: gradients flow, per-token timesteps via hooks
+        output = self.call_dit(
+            args,
+            accelerator,
+            transformer,
+            latents,
+            batch,
+            noise,
+            noisy_input_student,
+            timesteps_student,
+            network_dtype,
+            hidden_features=True,
+            feature_layer=args.student_feature_layer,
+            per_token_timesteps=per_token_timesteps_student,
+        )
+        feat_student = output.extra.get("features")
+
+        # 5. L_gen via the base loss (weighting from student timesteps), then L_rep
+        L_gen, _ = self.compute_loss(args, output, timesteps_student, noise_scheduler, dit_dtype, network_dtype, global_step)
+
+        # Amendment 2: loud failure if feature hooks misconfigured; never silently drop L_rep.
+        if feat_student is None or feat_teacher is None:
+            raise RuntimeError(
+                f"Self-Flow: feature capture returned None "
+                f"(student={feat_student is not None}, teacher={feat_teacher is not None}) "
+                "— feature hooks misconfigured"
+            )
+
+        gamma = effective_gamma(args.self_flow_gamma, global_step, args.self_flow_gamma_warmup_steps)
+        L_rep = compute_representation_loss(feat_student, feat_teacher, self.rep_proj)
+        loss = L_gen + gamma * L_rep
+        loss_metrics = {
+            "loss/gen": L_gen.detach().item(),
+            "loss/rep": L_rep.detach().item(),
+        }
+
+        # 6. state metrics drained later by extra_step_logs
+        # Use unwrap_model for ema-drift metric (Amendment 1).
+        ema_drift = compute_ema_weight_drift(self.ema_lora_state, unwrapped_nw.state_dict())
+        self._self_flow_logs = {
+            "self_flow/gamma": gamma,
+            "self_flow/feat_cosine_sim": -L_rep.detach().item(),
+            "self_flow/timestep_student_mean": timesteps_student.float().mean().item(),
+            "self_flow/timestep_teacher_mean": timesteps_teacher.float().mean().item(),
+            "self_flow/timestep_diff": (timesteps_student.float().mean() - timesteps_teacher.float().mean()).item(),
+            "self_flow/teacher_coupling_prob": coupling_prob,
+            "self_flow/actual_mask_ratio": mask_flat.float().mean().item(),
+            "self_flow/ema_weight_drift": ema_drift.item(),
+        }
+        if mismatch_mask.any():
+            masked_count = mask_flat.sum().item()
+            self._self_flow_logs["self_flow/mismatch_patch_frac"] = (
+                mismatch_mask.sum().item() / masked_count if masked_count > 0 else 0.0
+            )
+
+        return loss, loss_metrics
 
     def on_post_optimizer_step(
         self,
@@ -594,7 +696,7 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         super().on_post_optimizer_step(args, accelerator, network, transformer, sync_gradients, global_step)
         if not args.self_flow or not sync_gradients or self.ema_lora_state is None:
             return
-        update_ema_weights(self.ema_lora_state, network.state_dict(), args.ema_decay)
+        update_ema_weights(self.ema_lora_state, accelerator.unwrap_model(network).state_dict(), args.ema_decay)
 
     def on_before_sample_images(
         self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 import torch
 from accelerate import Accelerator
+from safetensors.torch import load_file
 
 from musubi_tuner.flux_2.flux2_models import timestep_embedding
 from musubi_tuner.flux_2_train_network import Flux2NetworkTrainer, flux2_setup_parser
@@ -362,12 +363,28 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         the projection head's parameters share the network LR schedule because
         Prodigy and friends don't support per-group LRs.
         """
+        trainable_params = super().extra_trainable_params(args, accelerator, network, transformer, trainable_params)
         if not args.self_flow:
             return trainable_params
 
-        # TODO: build Sequential(Linear, GELU, Linear) sized from transformer.hidden_size.
-        #       See PR #913 hv_train_network.py around line 2395.
-        raise NotImplementedError("Self-Flow rep_proj construction — see PR #913")
+        hidden_size = accelerator.unwrap_model(transformer).hidden_size
+        self.rep_proj = torch.nn.Sequential(
+            torch.nn.Linear(hidden_size, hidden_size),
+            torch.nn.GELU(),
+            torch.nn.Linear(hidden_size, hidden_size),
+        )
+        if args.network_weights_proj is not None:
+            proj_state = load_file(args.network_weights_proj)
+            self.rep_proj.load_state_dict(proj_state)
+            accelerator.print(f"loaded projection head weights from {args.network_weights_proj}")
+
+        # Merge into the first param group: shares the network LR schedule because
+        # Prodigy and friends don't support per-group LRs.
+        if trainable_params:
+            trainable_params[0]["params"] = list(trainable_params[0]["params"]) + list(self.rep_proj.parameters())
+        else:
+            trainable_params = [{"params": list(self.rep_proj.parameters())}]
+        return trainable_params
 
     def on_transformer_loaded(
         self,

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -230,6 +230,67 @@ class PerTokenModulationController:
         return (torch.cat([vec_txt, vec], dim=1),)
 
 
+class BlockFeatureExtractor:
+    """Captures hidden states from Flux2 blocks via forward hooks.
+
+    Layer indices are global, matching the old branch and the CLI help:
+    0..len(double_blocks)-1 address double blocks (img stream is captured),
+    len(double_blocks).. address single blocks (text tokens are sliced off).
+    Blocks self-checkpoint internally, so hook outputs are differentiable
+    even with gradient checkpointing enabled.
+    """
+
+    def __init__(self) -> None:
+        self._handles: list = []
+        self._armed_layer: Optional[int] = None
+        self._num_txt_tokens: Optional[int] = None
+        self._features: Optional[torch.Tensor] = None
+
+    def install(self, model, layer_indices: list[int]) -> None:
+        num_double = len(model.double_blocks)
+        num_total = num_double + len(model.single_blocks)
+        for layer in sorted(set(layer_indices)):
+            if not 0 <= layer < num_total:
+                raise ValueError(f"feature layer {layer} out of range (model has {num_total} blocks)")
+            if layer < num_double:
+                handle = model.double_blocks[layer].register_forward_hook(self._make_double_hook(layer))
+            else:
+                handle = model.single_blocks[layer - num_double].register_forward_hook(self._make_single_hook(layer))
+            self._handles.append(handle)
+
+    def remove(self) -> None:
+        for handle in self._handles:
+            handle.remove()
+        self._handles.clear()
+
+    def arm(self, layer: int, num_txt_tokens: int) -> None:
+        self._armed_layer = layer
+        self._num_txt_tokens = num_txt_tokens
+        self._features = None
+
+    def drain(self) -> Optional[torch.Tensor]:
+        features = self._features
+        self._features = None
+        self._armed_layer = None
+        self._num_txt_tokens = None
+        return features
+
+    def _make_double_hook(self, layer: int):
+        def hook(module, inputs, output):
+            if self._armed_layer == layer:
+                img, _txt = output
+                self._features = img
+
+        return hook
+
+    def _make_single_hook(self, layer: int):
+        def hook(module, inputs, output):
+            if self._armed_layer == layer:
+                self._features = output[:, self._num_txt_tokens :, ...]
+
+        return hook
+
+
 class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
     """FLUX.2 + Self-Flow.
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -618,23 +618,25 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
         unwrapped_nw = accelerator.unwrap_model(network)
         student_lora_state = {k: v.clone() for k, v in unwrapped_nw.state_dict().items()}
         unwrapped_nw.load_state_dict(self.ema_lora_state)
-        with torch.no_grad():
-            output = self.call_dit(
-                args,
-                accelerator,
-                transformer,
-                latents,
-                batch,
-                noise,
-                noisy_input_teacher,
-                timesteps_teacher,
-                network_dtype,
-                hidden_features=True,
-                feature_layer=args.teacher_feature_layer,
-            )
-            feat_teacher = output.extra.get("features")
-            feat_teacher = feat_teacher.detach() if feat_teacher is not None else None
-        unwrapped_nw.load_state_dict(student_lora_state)
+        try:
+            with torch.no_grad():
+                output = self.call_dit(
+                    args,
+                    accelerator,
+                    transformer,
+                    latents,
+                    batch,
+                    noise,
+                    noisy_input_teacher,
+                    timesteps_teacher,
+                    network_dtype,
+                    hidden_features=True,
+                    feature_layer=args.teacher_feature_layer,
+                )
+                feat_teacher = output.extra.get("features")
+                feat_teacher = feat_teacher.detach() if feat_teacher is not None else None
+        finally:
+            unwrapped_nw.load_state_dict(student_lora_state)
         # block swap ran forward-only for the teacher; re-prepare device placement
         accelerator.unwrap_model(transformer).prepare_block_swap_before_forward()
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -374,8 +374,8 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
                     f"--student_feature_layer ({args.student_feature_layer}) must be less than "
                     f"--teacher_feature_layer ({args.teacher_feature_layer})."
                 )
-            if args.mask_ratio > 0.5:
-                raise ValueError(f"--mask_ratio ({args.mask_ratio}) must be <= 0.5 (paper constraint R_M <= 0.5)")
+            if not 0.0 <= args.mask_ratio <= 0.5:
+                raise ValueError(f"--mask_ratio ({args.mask_ratio}) must be in [0, 0.5] (paper constraint R_M <= 0.5)")
             num_buckets = getattr(args, "num_timestep_buckets", None)
             if num_buckets is not None and num_buckets >= 2:
                 raise ValueError(
@@ -726,7 +726,7 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
             "self_flow/timestep_teacher_mean": timesteps_teacher.float().mean().item(),
             "self_flow/timestep_diff": (timesteps_student.float().mean() - timesteps_teacher.float().mean()).item(),
             "self_flow/teacher_coupling_prob": coupling_prob,
-            # actual_mask_ratio: mean of per-sample effective ratios (bimodal around R_M and 1-R_M, average ~0.5)
+            # actual_mask_ratio: empirical masked-token fraction (per-sample bimodal around R_M / 1-R_M, average ~0.5)
             "self_flow/actual_mask_ratio": mask_flat.float().mean().item(),
             # cleaner_fraction_mean: mean effective ratio this step (shows per-step coin outcomes, hovers ~0.5)
             "self_flow/cleaner_fraction_mean": effective_ratio.mean().item(),
@@ -922,7 +922,8 @@ def self_flow_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argument
         "--self_flow_teacher_mismatch_ratio",
         type=float,
         default=1.0,
-        help="When the coupling gate fires, fraction of masked patches receiving the timestep mismatch.",
+        help="When the coupling gate fires, fraction of masked patches receiving the timestep mismatch. "
+        "Note: the masked population is per-sample bimodal (R_M or 1-R_M of tokens) under paper-faithful scheduling.",
     )
     parser.add_argument(
         "--network_weights_ema",

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -899,6 +899,10 @@ def main():
     args = parser.parse_args()
     args = read_config_from_file(args, parser)
 
+    args.dit_dtype = None  # set from mixed_precision
+    if args.vae_dtype is None:
+        args.vae_dtype = "float32"  # make float32 as default for VAE
+
     trainer = Flux2SelfFlowNetworkTrainer()
     trainer.train(args)
 

--- a/src/musubi_tuner/flux_2_train_network_self_flow.py
+++ b/src/musubi_tuner/flux_2_train_network_self_flow.py
@@ -376,6 +376,14 @@ class Flux2SelfFlowNetworkTrainer(Flux2NetworkTrainer):
                 )
             if args.mask_ratio > 0.5:
                 raise ValueError(f"--mask_ratio ({args.mask_ratio}) must be <= 0.5 (paper constraint R_M <= 0.5)")
+            num_buckets = getattr(args, "num_timestep_buckets", None)
+            if num_buckets is not None and num_buckets >= 2:
+                raise ValueError(
+                    f"--num_timestep_buckets ({num_buckets}) is incompatible with --self_flow: "
+                    "bucketed timestep sampling forces both self-flow draws to the same bucket "
+                    "value (t == s), collapsing the dual-timestep schedule to a no-op. "
+                    "Unset --num_timestep_buckets when using --self_flow."
+                )
             if getattr(args, "compile", False):
                 logger.warning("--compile with --self_flow: forward hooks cause graph breaks; expect reduced compile benefit.")
 
@@ -872,7 +880,12 @@ def self_flow_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argument
         "--ema_decay",
         type=float,
         default=0.999,
-        help="EMA decay for the Self-Flow teacher LoRA weights.",
+        help=(
+            "EMA decay for the Self-Flow teacher LoRA weights. "
+            "The paper used 0.9999 at pretraining scale; 0.999 is the default here as a "
+            "conservative choice for short LoRA fine-tuning runs where faster EMA tracking "
+            "is preferable."
+        ),
     )
     parser.add_argument(
         "--student_feature_layer",
@@ -921,7 +934,12 @@ def self_flow_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argument
         "--network_weights_proj",
         type=str,
         default=None,
-        help="Pretrained projection head weights for resumption.",
+        help=(
+            "Pretrained projection head weights for resumption. "
+            "Note: the projection head here is a 2-layer Linear-GELU-Linear MLP; "
+            "the paper (Self-Flow/REPA) used a 3-layer MLP at ~10M params — "
+            "this smaller head is adequate for LoRA-scale runs."
+        ),
     )
     return parser
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures: tiny CPU-only Flux2 for self-flow extension tests."""
+
+import pytest
+import torch
+
+from musubi_tuner.flux_2.flux2_models import Flux2, Flux2Params
+
+
+@pytest.fixture
+def tiny_params():
+    """Minimal Flux2 config for fast CPU tests — not real weights.
+
+    hidden_size=16, num_heads=2 -> pe_dim=8, axes_dim must sum to 8.
+    """
+    return Flux2Params(
+        in_channels=4,
+        context_in_dim=8,
+        hidden_size=16,
+        num_heads=2,
+        depth=2,
+        depth_single_blocks=2,
+        axes_dim=[2, 2, 2, 2],
+        theta=2000,
+        mlp_ratio=2.0,
+        use_guidance_embed=False,
+    )
+
+
+@pytest.fixture
+def tiny_model(tiny_params):
+    torch.manual_seed(0)
+    model = Flux2(tiny_params, attn_mode="torch")
+    model.eval()
+    return model
+
+
+def make_inputs(B=2, N_img=4, N_txt=3, in_channels=4, hidden_ctx=8, seed=0):
+    """Build minimal packed inputs for Flux2.forward."""
+    torch.manual_seed(seed)
+    x = torch.randn(B, N_img, in_channels)
+    x_ids = torch.zeros(B, N_img, 4, dtype=torch.long)
+    ctx = torch.randn(B, N_txt, hidden_ctx)
+    ctx_ids = torch.zeros(B, N_txt, 4, dtype=torch.long)
+    guidance = None
+    return x, x_ids, ctx, ctx_ids, guidance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,31 @@ def tiny_model(tiny_params):
     return model
 
 
+@pytest.fixture
+def tiny_params_guidance():
+    """Same as tiny_params but with use_guidance_embed=True (production FLUX.2 dev path)."""
+    return Flux2Params(
+        in_channels=4,
+        context_in_dim=8,
+        hidden_size=16,
+        num_heads=2,
+        depth=2,
+        depth_single_blocks=2,
+        axes_dim=[2, 2, 2, 2],
+        theta=2000,
+        mlp_ratio=2.0,
+        use_guidance_embed=True,
+    )
+
+
+@pytest.fixture
+def tiny_model_guidance(tiny_params_guidance):
+    torch.manual_seed(0)
+    model = Flux2(tiny_params_guidance, attn_mode="torch")
+    model.eval()
+    return model
+
+
 def make_inputs(B=2, N_img=4, N_txt=3, in_channels=4, hidden_ctx=8, seed=0):
     """Build minimal packed inputs for Flux2.forward."""
     torch.manual_seed(seed)

--- a/tests/test_feature_hooks.py
+++ b/tests/test_feature_hooks.py
@@ -1,0 +1,63 @@
+import pytest
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import BlockFeatureExtractor
+
+from .conftest import make_inputs
+
+
+def _run(model, **kw):
+    x, x_ids, ctx, ctx_ids, guidance = make_inputs(**kw)
+    timesteps = torch.tensor([0.3, 0.7])
+    return model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+
+def test_double_block_capture_shape(tiny_model):
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [0])
+    ex.arm(0, num_txt_tokens=3)
+    _run(tiny_model)
+    feats = ex.drain()
+    assert feats.shape == (2, 4, 16)  # (B, N_img, hidden) — img stream only
+
+
+def test_single_block_capture_slices_txt(tiny_model):
+    # tiny model: 2 double + 2 single; global index 2 = single_blocks[0]
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [2])
+    ex.arm(2, num_txt_tokens=3)
+    _run(tiny_model)
+    feats = ex.drain()
+    assert feats.shape == (2, 4, 16)  # txt tokens sliced off
+
+
+def test_disarmed_captures_nothing(tiny_model):
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [0])
+    _run(tiny_model)
+    assert ex.drain() is None
+
+
+def test_drain_resets(tiny_model):
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [0])
+    ex.arm(0, num_txt_tokens=3)
+    _run(tiny_model)
+    assert ex.drain() is not None
+    assert ex.drain() is None
+
+
+def test_captured_features_carry_grad(tiny_model):
+    tiny_model.train()
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [0])
+    ex.arm(0, num_txt_tokens=3)
+    _run(tiny_model)
+    feats = ex.drain()
+    assert feats.requires_grad
+
+
+def test_out_of_range_layer_raises(tiny_model):
+    ex = BlockFeatureExtractor()
+    with pytest.raises(ValueError, match="out of range"):
+        ex.install(tiny_model, [99])

--- a/tests/test_feature_hooks.py
+++ b/tests/test_feature_hooks.py
@@ -61,3 +61,57 @@ def test_out_of_range_layer_raises(tiny_model):
     ex = BlockFeatureExtractor()
     with pytest.raises(ValueError, match="out of range"):
         ex.install(tiny_model, [99])
+
+
+# --- Fix 2: arm() validation ---
+
+
+def test_arm_uninstalled_layer_raises(tiny_model):
+    """arm() on a layer that was never installed should raise ValueError."""
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [0])  # only layer 0 installed
+    with pytest.raises(ValueError, match="not installed"):
+        ex.arm(1, num_txt_tokens=3)  # layer 1 not installed
+
+
+def test_arm_installed_layer_ok(tiny_model):
+    """arm() on a properly installed layer should not raise."""
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [0])
+    ex.arm(0, num_txt_tokens=3)  # should not raise
+
+
+# --- Fix 3: grad flow under gradient checkpointing ---
+
+
+def test_grad_flows_through_features_with_gradient_checkpointing(tiny_model):
+    """Features captured under gradient checkpointing must carry grad; backward must flow to params.
+
+    Teeth-check: this test would catch a regression where drain() is called
+    outside the checkpointed region, returning a detached tensor (requires_grad
+    False) — so feats.sum().backward() would raise RuntimeError or block
+    parameter grads would stay None.
+    """
+    tiny_model.enable_gradient_checkpointing()
+    tiny_model.train()
+
+    ex = BlockFeatureExtractor()
+    ex.install(tiny_model, [0])
+    ex.arm(0, num_txt_tokens=3)
+
+    # At least one input must have requires_grad for reentrant=False checkpoint
+    # to propagate gradients through the hooked block.
+    from .conftest import make_inputs
+
+    x, x_ids, ctx, ctx_ids, guidance = make_inputs()
+    x = x.detach().requires_grad_(True)
+    timesteps = torch.tensor([0.3, 0.7])
+    tiny_model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+    feats = ex.drain()
+    assert feats is not None
+    assert feats.requires_grad, "features must carry grad (needed for L_rep backward)"
+
+    feats.sum().backward()
+    first_param = next(tiny_model.double_blocks[0].parameters())
+    assert first_param.grad is not None, "backward must flow into double_blocks[0] parameters"

--- a/tests/test_per_token_hooks.py
+++ b/tests/test_per_token_hooks.py
@@ -127,3 +127,41 @@ def test_install_raises_on_missing_module(tiny_model):
     controller = PerTokenModulationController()
     with pytest.raises(AttributeError, match="time_in"):
         controller.install(tiny_model)
+
+
+def test_unstaged_hooks_are_bitwise_noop_with_guidance(tiny_model_guidance):
+    """Install hooks (including guidance_in hook) but don't stage — must be bitwise noop."""
+    B = 2
+    x, x_ids, ctx, ctx_ids, _ = make_inputs(B=B)
+    timesteps = torch.tensor([0.3, 0.7])
+    guidance = torch.full((B,), 1.0)
+
+    baseline = tiny_model_guidance(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+    controller = PerTokenModulationController()
+    controller.install(tiny_model_guidance)
+    hooked = tiny_model_guidance(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+    assert torch.equal(baseline, hooked)  # bitwise — unstaged guidance path untouched
+
+
+def test_heterogeneous_map_matches_reference_with_guidance(tiny_model_guidance):
+    """Heterogeneous tau with guidance embed must match reference_per_token_forward."""
+    B, N_img = 2, 4
+    x, x_ids, ctx, ctx_ids, _ = make_inputs(B=B, N_img=N_img)
+    guidance = torch.full((B,), 1.0)
+    torch.manual_seed(7)
+    tau = torch.rand(B, N_img)  # genuinely heterogeneous
+    decoy = tau.max(dim=1).values  # what the trainer passes as 1D timesteps
+
+    expected = reference_per_token_forward(tiny_model_guidance, x, x_ids, tau, ctx, ctx_ids, guidance)
+
+    controller = PerTokenModulationController()
+    controller.install(tiny_model_guidance)
+    controller.stage(tau, num_txt_tokens=ctx.shape[1])
+    try:
+        actual = tiny_model_guidance(x=x, x_ids=x_ids, timesteps=decoy, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+    finally:
+        controller.clear()
+
+    assert torch.allclose(expected, actual, atol=1e-5)

--- a/tests/test_per_token_hooks.py
+++ b/tests/test_per_token_hooks.py
@@ -1,0 +1,129 @@
+"""Tests for PerTokenModulationController forward hooks (Task 7).
+
+Three proof tests:
+1. hooks installed but unstaged → bitwise identical to vanilla forward
+2. uniform per-token map → allclose with the global 1D path
+3. heterogeneous map → allclose with reference_per_token_forward (verbatim port
+   of self-flow-network branch's modified Flux2.forward per-token path)
+"""
+
+import torch
+
+from musubi_tuner.flux_2.flux2_models import AttentionParams, timestep_embedding
+from musubi_tuner.flux_2_train_network_self_flow import PerTokenModulationController
+
+from .conftest import make_inputs
+
+
+def reference_per_token_forward(model, x, x_ids, tau, ctx, ctx_ids, guidance):
+    """Ground truth: verbatim port of the self-flow-network branch's modified
+    Flux2.forward per-token path (git show self-flow-network:src/musubi_tuner/
+    flux_2/flux2_models.py, forward()). Kept in the test so the production
+    model needs no modification."""
+    num_txt_tokens = ctx.shape[1]
+    B, N_img = tau.shape
+
+    emb_flat = timestep_embedding(tau.reshape(-1), 256)
+    vec_img = model.time_in(emb_flat).reshape(B, N_img, -1)
+    if model.use_guidance_embed:
+        guidance_emb = timestep_embedding(guidance, 256)
+        vec_img = vec_img + model.guidance_in(guidance_emb).unsqueeze(1)
+
+    vec_global = vec_img.mean(dim=1)
+
+    double_block_mod_img = model.double_stream_modulation_img(vec_img)
+    double_block_mod_txt = model.double_stream_modulation_txt(vec_global)
+    vec_txt_expanded = vec_global.unsqueeze(1).expand(-1, num_txt_tokens, -1)
+    vec_combined = torch.cat([vec_txt_expanded, vec_img], dim=1)
+    single_block_mod, _ = model.single_stream_modulation(vec_combined)
+
+    img = model.img_in(x)
+    txt = model.txt_in(ctx)
+    pe_x = model.pe_embedder(x_ids)
+    pe_ctx = model.pe_embedder(ctx_ids)
+    attn_params = AttentionParams.create_attention_params(model.attn_mode, model.split_attn)
+
+    for block in model.double_blocks:
+        img, txt = block(img, txt, pe_x, pe_ctx, double_block_mod_img, double_block_mod_txt, attn_params)
+
+    img = torch.cat((txt, img), dim=1)
+    pe = torch.cat((pe_ctx, pe_x), dim=2)
+    for block in model.single_blocks:
+        img = block(img, pe, single_block_mod, attn_params)
+
+    img = img[:, num_txt_tokens:, ...]
+    return model.final_layer(img, vec_img)
+
+
+def test_unstaged_hooks_are_bitwise_noop(tiny_model):
+    x, x_ids, ctx, ctx_ids, guidance = make_inputs()
+    timesteps = torch.tensor([0.3, 0.7])
+
+    baseline = tiny_model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+    controller = PerTokenModulationController()
+    controller.install(tiny_model)
+    hooked = tiny_model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+    assert torch.equal(baseline, hooked)  # bitwise — vanilla path untouched
+
+
+def test_uniform_per_token_map_matches_global_path(tiny_model):
+    B, N_img = 2, 4
+    x, x_ids, ctx, ctx_ids, guidance = make_inputs(B=B, N_img=N_img)
+    timesteps = torch.tensor([0.3, 0.7])
+
+    baseline = tiny_model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+    controller = PerTokenModulationController()
+    controller.install(tiny_model)
+    tau = timesteps.unsqueeze(1).expand(B, N_img)  # every token at its sample's global t
+    controller.stage(tau, num_txt_tokens=ctx.shape[1])
+    try:
+        per_token = tiny_model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+    finally:
+        controller.clear()
+
+    assert torch.allclose(baseline, per_token, atol=1e-5)
+
+
+def test_heterogeneous_map_matches_reference(tiny_model):
+    B, N_img = 2, 4
+    x, x_ids, ctx, ctx_ids, guidance = make_inputs(B=B, N_img=N_img)
+    torch.manual_seed(7)
+    tau = torch.rand(B, N_img)  # genuinely heterogeneous
+    decoy = tau.max(dim=1).values  # what the trainer passes as 1D timesteps
+
+    expected = reference_per_token_forward(tiny_model, x, x_ids, tau, ctx, ctx_ids, guidance)
+
+    controller = PerTokenModulationController()
+    controller.install(tiny_model)
+    controller.stage(tau, num_txt_tokens=ctx.shape[1])
+    try:
+        actual = tiny_model(x=x, x_ids=x_ids, timesteps=decoy, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+    finally:
+        controller.clear()
+
+    assert torch.allclose(expected, actual, atol=1e-5)
+
+
+def test_stage_clear_round_trip(tiny_model):
+    x, x_ids, ctx, ctx_ids, guidance = make_inputs()
+    timesteps = torch.tensor([0.3, 0.7])
+    baseline = tiny_model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+
+    controller = PerTokenModulationController()
+    controller.install(tiny_model)
+    controller.stage(torch.rand(2, 4), num_txt_tokens=3)
+    controller.clear()
+    after = tiny_model(x=x, x_ids=x_ids, timesteps=timesteps, ctx=ctx, ctx_ids=ctx_ids, guidance=guidance)
+    assert torch.equal(baseline, after)
+
+
+def test_install_raises_on_missing_module(tiny_model):
+    import pytest
+
+    del tiny_model.time_in  # simulate upstream rename
+    controller = PerTokenModulationController()
+    with pytest.raises(AttributeError, match="time_in"):
+        controller.install(tiny_model)

--- a/tests/test_rep_proj_optimizer.py
+++ b/tests/test_rep_proj_optimizer.py
@@ -1,0 +1,34 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import Flux2SelfFlowNetworkTrainer
+
+from .test_self_flow_call_dit import FakeAccelerator, make_args
+
+
+def test_rep_proj_merged_into_first_group(tiny_model):
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args()
+    lora_params = [{"params": [torch.nn.Parameter(torch.zeros(4))], "lr": 1e-4}]
+    out = trainer.extra_trainable_params(args, FakeAccelerator(), None, tiny_model, lora_params)
+    assert len(out) == 1
+    # 2 Linear layers x (weight + bias) = 4 extra params
+    assert len(list(out[0]["params"])) == 1 + 4
+    assert trainer.rep_proj is not None
+    first_linear = trainer.rep_proj[0]
+    assert first_linear.in_features == tiny_model.hidden_size
+
+
+def test_rep_proj_creates_group_when_empty(tiny_model):
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args()
+    out = trainer.extra_trainable_params(args, FakeAccelerator(), None, tiny_model, [])
+    assert len(out) == 1
+    assert len(list(out[0]["params"])) == 4
+
+
+def test_no_self_flow_passthrough(tiny_model):
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(self_flow=False)
+    params = [{"params": []}]
+    assert trainer.extra_trainable_params(args, FakeAccelerator(), None, tiny_model, params) is params
+    assert trainer.rep_proj is None

--- a/tests/test_self_flow_arg_validation.py
+++ b/tests/test_self_flow_arg_validation.py
@@ -1,0 +1,59 @@
+"""Tests for handle_model_specific_args validation in Flux2SelfFlowNetworkTrainer."""
+
+import pytest
+
+from musubi_tuner.flux_2_train_network_self_flow import Flux2SelfFlowNetworkTrainer
+
+from .test_self_flow_call_dit import make_args
+
+
+def test_num_timestep_buckets_raises_with_self_flow():
+    """Fix 2: --num_timestep_buckets with --self_flow must raise ValueError.
+
+    Bucketed timesteps force the two self-flow draws to the same bucket value
+    (t == s), collapsing dual-timestep scheduling to a no-op.
+    """
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(num_timestep_buckets=4)
+    with pytest.raises(ValueError, match="num_timestep_buckets"):
+        trainer.handle_model_specific_args(args)
+
+
+def test_num_timestep_buckets_one_does_not_raise():
+    """num_timestep_buckets=1 is treated as disabled (same as None) — should not raise."""
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(num_timestep_buckets=1)
+    # Should not raise
+    trainer.handle_model_specific_args(args)
+
+
+def test_num_timestep_buckets_none_does_not_raise():
+    """num_timestep_buckets=None (default) must not raise."""
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(num_timestep_buckets=None)
+    # Should not raise
+    trainer.handle_model_specific_args(args)
+
+
+def test_num_timestep_buckets_without_self_flow_does_not_raise():
+    """num_timestep_buckets should only be blocked when --self_flow is active."""
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(self_flow=False, num_timestep_buckets=4)
+    # Should not raise — self_flow is off
+    trainer.handle_model_specific_args(args)
+
+
+def test_student_ge_teacher_raises():
+    """Existing guard: student_feature_layer >= teacher_feature_layer must raise."""
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(student_feature_layer=5, teacher_feature_layer=3)
+    with pytest.raises(ValueError, match="student_feature_layer"):
+        trainer.handle_model_specific_args(args)
+
+
+def test_mask_ratio_gt_half_raises():
+    """Existing guard: mask_ratio > 0.5 must raise."""
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(mask_ratio=0.6)
+    with pytest.raises(ValueError, match="mask_ratio"):
+        trainer.handle_model_specific_args(args)

--- a/tests/test_self_flow_arg_validation.py
+++ b/tests/test_self_flow_arg_validation.py
@@ -57,3 +57,11 @@ def test_mask_ratio_gt_half_raises():
     args = make_args(mask_ratio=0.6)
     with pytest.raises(ValueError, match="mask_ratio"):
         trainer.handle_model_specific_args(args)
+
+
+def test_negative_mask_ratio_raises():
+    """Guard: mask_ratio < 0 must raise (would yield 1 - R_M > 1 on coin tails)."""
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(mask_ratio=-0.1)
+    with pytest.raises(ValueError, match="mask_ratio"):
+        trainer.handle_model_specific_args(args)

--- a/tests/test_self_flow_call_dit.py
+++ b/tests/test_self_flow_call_dit.py
@@ -1,0 +1,126 @@
+import pytest
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import (
+    Flux2SelfFlowNetworkTrainer,
+    flux2_setup_parser,
+    self_flow_setup_parser,
+)
+from musubi_tuner.hv_train_network import setup_parser_common
+
+
+class FakeAccelerator:
+    device = torch.device("cpu")
+
+    class _NullCtx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def autocast(self):
+        return self._NullCtx()
+
+    def unwrap_model(self, m):
+        return m
+
+
+def make_args(**overrides):
+    parser = setup_parser_common()
+    parser = flux2_setup_parser(parser)
+    parser = self_flow_setup_parser(parser)
+    args = parser.parse_args([])
+    args.self_flow = True
+    args.gradient_checkpointing = False
+    for k, v in overrides.items():
+        setattr(args, k, v)
+    return args
+
+
+@pytest.fixture
+def trainer_with_model(tiny_model):
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(student_feature_layer=0, teacher_feature_layer=2)
+    trainer.handle_model_specific_args(args)
+    trainer.on_transformer_loaded(args, FakeAccelerator(), tiny_model)
+    return trainer, args, tiny_model
+
+
+def make_batch(B=2, H=4, W=4, n_txt=3, ctx_dim=8):
+    latents = torch.randn(B, 4, H, W)
+    noise = torch.randn_like(latents)
+    return (
+        {
+            "ctx_vec": torch.randn(B, n_txt, ctx_dim),
+        },
+        latents,
+        noise,
+    )
+
+
+def test_call_dit_returns_features_and_pred(trainer_with_model):
+    trainer, args, model = trainer_with_model
+    batch, latents, noise = make_batch()
+    timesteps = torch.tensor([500.0, 800.0])
+    noisy = latents  # contents irrelevant for shape test
+
+    output = trainer.call_dit(
+        args,
+        FakeAccelerator(),
+        model,
+        latents,
+        batch,
+        noise,
+        noisy,
+        timesteps,
+        torch.float32,
+        hidden_features=True,
+        feature_layer=0,
+    )
+    assert output.pred.shape[0] == 2
+    assert output.extra["features"] is not None
+    assert output.extra["features"].shape == (2, 16, 16)  # (B, H*W, hidden)
+
+
+def test_call_dit_per_token_map_staged_and_cleared(trainer_with_model):
+    trainer, args, model = trainer_with_model
+    batch, latents, noise = make_batch()
+    timesteps = torch.tensor([500.0, 800.0])
+    tau = torch.full((2, 16), 800.0)
+
+    trainer.call_dit(
+        args,
+        FakeAccelerator(),
+        model,
+        latents,
+        batch,
+        noise,
+        latents,
+        timesteps,
+        torch.float32,
+        hidden_features=True,
+        feature_layer=0,
+        per_token_timesteps=tau,
+    )
+    assert trainer._modulation_controller._tau is None  # cleared after forward
+
+
+def test_call_dit_control_images_unsupported(trainer_with_model):
+    trainer, args, model = trainer_with_model
+    batch, latents, noise = make_batch()
+    batch["latents_control_0"] = torch.randn(2, 4, 4, 4)
+    with pytest.raises(NotImplementedError, match="control"):
+        trainer.call_dit(
+            args,
+            FakeAccelerator(),
+            model,
+            latents,
+            batch,
+            noise,
+            latents,
+            torch.tensor([500.0, 800.0]),
+            torch.float32,
+            hidden_features=True,
+            feature_layer=0,
+        )

--- a/tests/test_self_flow_call_dit.py
+++ b/tests/test_self_flow_call_dit.py
@@ -106,6 +106,40 @@ def test_call_dit_per_token_map_staged_and_cleared(trainer_with_model):
     assert trainer._modulation_controller._tau is None  # cleared after forward
 
 
+def test_call_dit_hidden_features_requires_grad_in_train_mode(trainer_with_model):
+    """Student features must stay in the autograd graph (requires_grad=True) when the model
+    is in train mode and torch.no_grad is NOT active.  A future refactor that accidentally
+    detaches hidden_features would silently stop L_rep from training the transformer."""
+    trainer, args, model = trainer_with_model
+    model.train()
+    batch, latents, noise = make_batch()
+    timesteps = torch.tensor([500.0, 800.0])
+    noisy = latents
+
+    # Ensure we are NOT inside no_grad
+    with torch.enable_grad():
+        output = trainer.call_dit(
+            args,
+            FakeAccelerator(),
+            model,
+            latents,
+            batch,
+            noise,
+            noisy,
+            timesteps,
+            torch.float32,
+            hidden_features=True,
+            feature_layer=0,
+        )
+
+    features = output.extra["features"]
+    assert features is not None, "features must not be None in train mode"
+    assert features.requires_grad is True, (
+        "features.requires_grad must be True in grad-enabled train mode; "
+        "detaching here would silently break L_rep backprop through the transformer"
+    )
+
+
 def test_call_dit_control_images_unsupported(trainer_with_model):
     trainer, args, model = trainer_with_model
     batch, latents, noise = make_batch()

--- a/tests/test_self_flow_ema.py
+++ b/tests/test_self_flow_ema.py
@@ -1,0 +1,46 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import (
+    compute_ema_weight_drift,
+    update_ema_weights,
+)
+
+
+def test_ema_lerp():
+    ema = {"w": torch.zeros(4)}
+    cur = {"w": torch.ones(4)}
+    update_ema_weights(ema, cur, decay=0.9)
+    assert torch.allclose(ema["w"], torch.full((4,), 0.1))
+
+
+def test_ema_decay_one_freezes_teacher():
+    ema = {"w": torch.zeros(4)}
+    cur = {"w": torch.ones(4)}
+    update_ema_weights(ema, cur, decay=1.0)
+    assert torch.equal(ema["w"], torch.zeros(4))
+
+
+def test_ema_non_float_copied():
+    ema = {"step": torch.tensor(0)}
+    cur = {"step": torch.tensor(5)}
+    update_ema_weights(ema, cur, decay=0.9)
+    assert ema["step"].item() == 5
+
+
+def test_ema_updates_in_place():
+    w = torch.zeros(4)
+    ema = {"w": w}
+    update_ema_weights(ema, {"w": torch.ones(4)}, decay=0.5)
+    assert torch.allclose(w, torch.full((4,), 0.5))  # same tensor object mutated
+
+
+def test_drift_zero_when_identical():
+    state = {"w": torch.ones(4)}
+    assert compute_ema_weight_drift(state, {"w": torch.ones(4)}).item() == 0.0
+
+
+def test_drift_positive_when_different():
+    ema = {"w": torch.zeros(4), "step": torch.tensor(3)}
+    cur = {"w": torch.ones(4), "step": torch.tensor(9)}
+    drift = compute_ema_weight_drift(ema, cur)
+    assert drift.item() > 0.0

--- a/tests/test_self_flow_lifecycle.py
+++ b/tests/test_self_flow_lifecycle.py
@@ -9,11 +9,24 @@ class StubNetwork(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.lora_w = torch.nn.Parameter(torch.ones(4))
+        self._load_calls: list[str] = []
+        # Registry of path -> weight value for load_weights stub
+        self._weight_registry: dict[str, float] = {}
+
+    def load_weights(self, path: str):
+        """Stub: set lora_w to registered value for this path (or 0.0 if unknown)."""
+        self._load_calls.append(path)
+        val = self._weight_registry.get(path, 0.0)
+        self.lora_w.data.fill_(val)
+        return f"loaded from {path}"
 
 
 class PreparingAccelerator(FakeAccelerator):
     def prepare(self, m):
         return m
+
+    def print(self, *args, **kwargs):
+        pass
 
 
 def test_on_train_start_snapshots_ema():
@@ -48,3 +61,40 @@ def test_no_self_flow_is_noop():
     args = make_args(self_flow=False)
     trainer.on_train_start(args, PreparingAccelerator(), StubNetwork(), None, None)
     assert trainer.ema_lora_state is None
+
+
+def test_network_weights_ema_without_network_weights_raises():
+    """--network_weights_ema requires --network_weights to be set."""
+    trainer = Flux2SelfFlowNetworkTrainer()
+    trainer.rep_proj = torch.nn.Linear(4, 4)
+    args = make_args(network_weights_ema="ema.safetensors", network_weights=None)
+    import pytest
+
+    with pytest.raises(ValueError, match="network_weights"):
+        trainer.on_train_start(args, PreparingAccelerator(), StubNetwork(), None, None)
+
+
+def test_network_weights_ema_with_both_set_restores_order():
+    """With both --network_weights_ema and --network_weights:
+    - ema_lora_state equals EMA file weights
+    - live network weights equal the student file weights afterward (restore order)
+    """
+    trainer = Flux2SelfFlowNetworkTrainer()
+    trainer.rep_proj = torch.nn.Linear(4, 4)
+
+    student_path = "student.safetensors"
+    ema_path = "ema.safetensors"
+
+    args = make_args(network_weights_ema=ema_path, network_weights=student_path)
+
+    net = StubNetwork()
+    # EMA file -> lora_w=2.0, student file -> lora_w=3.0
+    net._weight_registry[ema_path] = 2.0
+    net._weight_registry[student_path] = 3.0
+
+    trainer.on_train_start(args, PreparingAccelerator(), net, None, None)
+
+    # EMA state should reflect the EMA file weights
+    assert torch.allclose(trainer.ema_lora_state["lora_w"], torch.full((4,), 2.0))
+    # Live network weights must be the student weights (restored last)
+    assert torch.allclose(net.lora_w.detach(), torch.full((4,), 3.0))

--- a/tests/test_self_flow_lifecycle.py
+++ b/tests/test_self_flow_lifecycle.py
@@ -1,0 +1,50 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import Flux2SelfFlowNetworkTrainer
+
+from .test_self_flow_call_dit import FakeAccelerator, make_args
+
+
+class StubNetwork(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lora_w = torch.nn.Parameter(torch.ones(4))
+
+
+class PreparingAccelerator(FakeAccelerator):
+    def prepare(self, m):
+        return m
+
+
+def test_on_train_start_snapshots_ema():
+    trainer = Flux2SelfFlowNetworkTrainer()
+    trainer.rep_proj = torch.nn.Linear(4, 4)
+    args = make_args()
+    net = StubNetwork()
+    trainer.on_train_start(args, PreparingAccelerator(), net, None, None)
+    assert torch.equal(trainer.ema_lora_state["lora_w"], torch.ones(4))
+    # snapshot is a copy, not a view
+    net.lora_w.data.fill_(5.0)
+    assert torch.equal(trainer.ema_lora_state["lora_w"], torch.ones(4))
+
+
+def test_on_post_optimizer_step_lerps_only_on_sync():
+    trainer = Flux2SelfFlowNetworkTrainer()
+    trainer.rep_proj = torch.nn.Linear(4, 4)
+    args = make_args(ema_decay=0.9)
+    net = StubNetwork()
+    trainer.on_train_start(args, PreparingAccelerator(), net, None, None)
+
+    net.lora_w.data.fill_(2.0)
+    trainer.on_post_optimizer_step(args, PreparingAccelerator(), net, None, sync_gradients=False, global_step=1)
+    assert torch.equal(trainer.ema_lora_state["lora_w"], torch.ones(4))  # unchanged
+
+    trainer.on_post_optimizer_step(args, PreparingAccelerator(), net, None, sync_gradients=True, global_step=1)
+    assert torch.allclose(trainer.ema_lora_state["lora_w"], torch.full((4,), 1.1))
+
+
+def test_no_self_flow_is_noop():
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(self_flow=False)
+    trainer.on_train_start(args, PreparingAccelerator(), StubNetwork(), None, None)
+    assert trainer.ema_lora_state is None

--- a/tests/test_self_flow_loss.py
+++ b/tests/test_self_flow_loss.py
@@ -1,0 +1,38 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import (
+    compute_representation_loss,
+    effective_gamma,
+)
+
+
+def test_rep_loss_identical_features_is_minus_one():
+    feats = torch.randn(2, 4, 8)
+    loss = compute_representation_loss(feats, feats, torch.nn.Identity())
+    assert torch.allclose(loss, torch.tensor(-1.0), atol=1e-6)
+
+
+def test_rep_loss_opposite_features_is_plus_one():
+    feats = torch.randn(2, 4, 8)
+    loss = compute_representation_loss(feats, -feats, torch.nn.Identity())
+    assert torch.allclose(loss, torch.tensor(1.0), atol=1e-6)
+
+
+def test_rep_loss_grad_flows_through_projection():
+    proj = torch.nn.Linear(8, 8)
+    student = torch.randn(2, 4, 8, requires_grad=True)
+    teacher = torch.randn(2, 4, 8)
+    loss = compute_representation_loss(student, teacher, proj)
+    loss.backward()
+    assert student.grad is not None
+    assert proj.weight.grad is not None
+
+
+def test_effective_gamma_no_warmup():
+    assert effective_gamma(0.8, global_step=0, warmup_steps=0) == 0.8
+
+
+def test_effective_gamma_ramps_linearly():
+    assert effective_gamma(0.8, global_step=50, warmup_steps=100) == 0.8 * 0.5
+    assert effective_gamma(0.8, global_step=100, warmup_steps=100) == 0.8
+    assert effective_gamma(0.8, global_step=500, warmup_steps=100) == 0.8

--- a/tests/test_self_flow_masking.py
+++ b/tests/test_self_flow_masking.py
@@ -56,3 +56,96 @@ def test_approximate_ratio():
     teacher = torch.ones(8, 4, 32, 32)
     _, mask = apply_per_token_mask(student, teacher, 0.25, torch.device("cpu"))
     assert abs(mask.float().mean().item() - 0.25) < 0.03
+
+
+# --- Fix 1: tensor mask_ratio support ---
+
+
+def test_tensor_ratio_per_sample_zero_one():
+    """Tensor mask_ratio (B,) = [0.0, 1.0]: sample 0 all-student, sample 1 all-teacher."""
+    torch.manual_seed(42)
+    B = 2
+    student = torch.zeros(B, 4, 8, 8)
+    teacher = torch.ones(B, 4, 8, 8)
+    ratio = torch.tensor([0.0, 1.0])
+    out, mask = apply_per_token_mask(student, teacher, ratio, torch.device("cpu"))
+    # Sample 0: ratio=0.0 => all student (zeros)
+    assert not mask[0].any(), "sample 0 with ratio=0.0 must have no masked tokens"
+    assert torch.equal(out[0], student[0]), "sample 0 output must equal student"
+    # Sample 1: ratio=1.0 => all teacher (ones)
+    assert mask[1].all(), "sample 1 with ratio=1.0 must have all tokens masked"
+    assert torch.equal(out[1], teacher[1]), "sample 1 output must equal teacher"
+
+
+def test_tensor_ratio_scalar_same_as_float():
+    """0-dim tensor ratio should behave identically to float ratio."""
+    torch.manual_seed(7)
+    student = torch.zeros(4, 4, 8, 8)
+    teacher = torch.ones(4, 4, 8, 8)
+    ratio_float = 0.3
+    ratio_tensor = torch.tensor(0.3)
+
+    torch.manual_seed(7)
+    _, mask_float = apply_per_token_mask(student, teacher, ratio_float, torch.device("cpu"))
+    torch.manual_seed(7)
+    _, mask_tensor = apply_per_token_mask(student, teacher, ratio_tensor, torch.device("cpu"))
+    assert torch.equal(mask_float, mask_tensor), "0-dim tensor ratio must give same result as float"
+
+
+def test_statistical_marginal_property():
+    """Fix 1 marginal property: with R_M=0.25 and coin-flip, the overall fraction
+    of tokens assigned to the cleaner (teacher) level must be ~0.5 over many samples.
+
+    This is THE invariant paper Eq. 4 preserves: each token's marginal timestep
+    distribution equals p(t), independent of R_M.
+
+    We test the coin-flip helper directly using per-sample tensor ratios.
+    """
+    torch.manual_seed(12345)
+    R_M = 0.25
+    B = 512
+    N_h, N_w = 16, 16  # 256 tokens per sample (4D latents)
+    student = torch.zeros(B, 4, N_h, N_w)
+    teacher = torch.ones(B, 4, N_h, N_w)
+    device = torch.device("cpu")
+
+    # Simulate coin-flip: half of samples get R_M, half get 1 - R_M
+    coin = torch.rand(B) < 0.5
+    effective_ratio = torch.where(coin, torch.full((B,), R_M), torch.full((B,), 1.0 - R_M))
+    _, mask = apply_per_token_mask(student, teacher, effective_ratio, device)
+
+    overall_fraction = mask.float().mean().item()
+    assert abs(overall_fraction - 0.5) < 0.03, (
+        f"Marginal fraction of masked (teacher) tokens should be ~0.5, got {overall_fraction:.4f}. "
+        "Coin-flip Eq. 4 equivalence is broken."
+    )
+
+
+def test_per_sample_bimodal_fractions():
+    """Per-sample masked fractions must be bimodal: near R_M or near 1-R_M, NOT near 0.5.
+
+    This confirms the per-sample coin-flip structure (each sample has a SINGLE fraction
+    of R_M or 1-R_M), not per-token averaging. Uses large N for tight per-sample
+    estimates (N=4096 tokens => within ±0.1 of true fraction with high probability).
+    """
+    torch.manual_seed(99)
+    R_M = 0.25
+    B = 64
+    N_h, N_w = 64, 64  # 4096 tokens
+    student = torch.zeros(B, 4, N_h, N_w)
+    teacher = torch.ones(B, 4, N_h, N_w)
+    device = torch.device("cpu")
+
+    coin = torch.rand(B) < 0.5
+    effective_ratio = torch.where(coin, torch.full((B,), R_M), torch.full((B,), 1.0 - R_M))
+    _, mask = apply_per_token_mask(student, teacher, effective_ratio, device)
+
+    per_sample_frac = mask.float().mean(dim=1)  # (B,)
+    tol = 0.10
+    near_rm = (per_sample_frac - R_M).abs() < tol
+    near_inv = (per_sample_frac - (1.0 - R_M)).abs() < tol
+    all_bimodal = (near_rm | near_inv).all().item()
+    assert all_bimodal, (
+        f"Per-sample fractions must be near {R_M} or {1 - R_M} (±{tol}); "
+        f"offending values: {per_sample_frac[(~near_rm & ~near_inv)].tolist()}"
+    )

--- a/tests/test_self_flow_masking.py
+++ b/tests/test_self_flow_masking.py
@@ -1,0 +1,58 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import apply_per_token_mask
+
+
+def test_mask_ratio_zero_returns_student_unchanged():
+    student = torch.randn(2, 4, 8, 8)
+    teacher = torch.randn(2, 4, 8, 8)
+    out, mask = apply_per_token_mask(student, teacher, 0.0, torch.device("cpu"))
+    assert torch.equal(out, student)
+    assert mask.shape == (2, 64)
+    assert not mask.any()
+
+
+def test_mask_ratio_one_returns_teacher():
+    # ratio 1.0 is invalid for training (paper caps at 0.5) but pins the boundary
+    student = torch.zeros(2, 4, 8, 8)
+    teacher = torch.ones(2, 4, 8, 8)
+    out, mask = apply_per_token_mask(student, teacher, 1.0, torch.device("cpu"))
+    assert torch.equal(out, teacher)
+    assert mask.all()
+
+
+def test_masked_positions_take_teacher_values():
+    torch.manual_seed(0)
+    student = torch.zeros(2, 4, 8, 8)
+    teacher = torch.ones(2, 4, 8, 8)
+    out, mask = apply_per_token_mask(student, teacher, 0.25, torch.device("cpu"))
+    mask_spatial = mask.view(2, 1, 8, 8).expand_as(student)
+    assert torch.equal(out[mask_spatial], teacher[mask_spatial])
+    assert torch.equal(out[~mask_spatial], student[~mask_spatial])
+
+
+def test_mask_applies_across_all_channels():
+    torch.manual_seed(0)
+    student = torch.zeros(1, 4, 8, 8)
+    teacher = torch.ones(1, 4, 8, 8)
+    out, _ = apply_per_token_mask(student, teacher, 0.5, torch.device("cpu"))
+    # every (h, w) position is either all-teacher or all-student across channels
+    per_pos = out.sum(dim=1)  # (1, 8, 8)
+    assert ((per_pos == 0) | (per_pos == 4)).all()
+
+
+def test_5d_independent_draw_shape():
+    torch.manual_seed(0)
+    student = torch.zeros(1, 4, 2, 8, 8)
+    teacher = torch.ones(1, 4, 2, 8, 8)
+    out, mask = apply_per_token_mask(student, teacher, 0.25, torch.device("cpu"))
+    assert mask.shape == (1, 2 * 8 * 8)
+    assert out.shape == student.shape
+
+
+def test_approximate_ratio():
+    torch.manual_seed(0)
+    student = torch.zeros(8, 4, 32, 32)
+    teacher = torch.ones(8, 4, 32, 32)
+    _, mask = apply_per_token_mask(student, teacher, 0.25, torch.device("cpu"))
+    assert abs(mask.float().mean().item() - 0.25) < 0.03

--- a/tests/test_self_flow_process_batch.py
+++ b/tests/test_self_flow_process_batch.py
@@ -64,6 +64,13 @@ def test_process_batch_self_flow_smoke(tiny_model):
     assert "self_flow/mismatch_patch_count" in trainer._self_flow_logs, (
         "self_flow/mismatch_patch_count must be logged unconditionally (0 when no mismatch)"
     )
+    # Fix 1: cleaner_fraction_mean must be present (shows per-step coin outcome)
+    assert "self_flow/cleaner_fraction_mean" in trainer._self_flow_logs, (
+        "self_flow/cleaner_fraction_mean must be logged after Fix 1 (per-sample coin-flip)"
+    )
+    # actual_mask_ratio is now the mean of the per-sample effective ratio (near R_M or 1-R_M bimodal)
+    # — it hovers around 0.5 on average; no longer expected to be near args.mask_ratio exactly.
+    assert "self_flow/actual_mask_ratio" in trainer._self_flow_logs
 
     loss.backward()
     grads = [p.grad for p in trainer.rep_proj.parameters()]

--- a/tests/test_self_flow_process_batch.py
+++ b/tests/test_self_flow_process_batch.py
@@ -56,15 +56,111 @@ def test_process_batch_self_flow_smoke(tiny_model):
     assert "loss/gen" in metrics and "loss/rep" in metrics
     assert trainer._self_flow_logs  # state metrics populated for extra_step_logs
     assert "self_flow/ema_weight_drift" in trainer._self_flow_logs
+    # Mismatch metrics must always be present (even when 0) — gappy wandb series
+    # where 0.0 and absent are indistinguishable breaks monitoring.
+    assert "self_flow/mismatch_patch_frac" in trainer._self_flow_logs, (
+        "self_flow/mismatch_patch_frac must be logged unconditionally (0.0 when no mismatch)"
+    )
+    assert "self_flow/mismatch_patch_count" in trainer._self_flow_logs, (
+        "self_flow/mismatch_patch_count must be logged unconditionally (0 when no mismatch)"
+    )
 
     loss.backward()
     grads = [p.grad for p in trainer.rep_proj.parameters()]
     assert all(g is not None for g in grads)  # L_rep reached the projection head
 
 
+def test_process_batch_restores_student_weights_after_teacher_swap(tiny_model):
+    """After the teacher forward, process_batch must restore the student LoRA weights.
+
+    Catches a skipped or misordered ``load_state_dict(student_lora_state)`` restore.
+    We pre-load a distinct EMA state (5.0) so the post-call weight value is
+    unambiguous: if the student restore is skipped, net.lora_w will read 5.0, not 1.0.
+    """
+    torch.manual_seed(2)
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(
+        student_feature_layer=0,
+        teacher_feature_layer=2,
+        mask_ratio=0.25,
+        self_flow_gamma=0.8,
+        ema_decay=0.999,
+    )
+    acc = PreparingAccelerator()
+    trainer.handle_model_specific_args(args)
+    trainer.on_transformer_loaded(args, acc, tiny_model)
+    trainer.extra_trainable_params(args, acc, None, tiny_model, [])
+    net = StubNetwork()
+    trainer.on_train_start(args, acc, net, tiny_model, None)
+
+    # Override EMA state to a distinct sentinel so we can tell student from teacher
+    trainer.ema_lora_state["lora_w"] = torch.full((4,), 5.0)
+    # Record current student value (ones from StubNetwork.__init__)
+    expected_student_val = net.lora_w.detach().clone()
+
+    B, H, W = 2, 4, 4
+    latents = torch.randn(B, 4, H, W)
+    noise = torch.randn_like(latents)
+    batch = {
+        "ctx_vec": torch.randn(B, 3, 8),
+        "timesteps": None,
+    }
+    scheduler = make_noise_scheduler(args)
+
+    trainer.process_batch(
+        args,
+        acc,
+        tiny_model,
+        net,
+        batch,
+        latents,
+        noise,
+        scheduler,
+        torch.float32,
+        torch.float32,
+        None,
+        global_step=5,
+    )
+
+    # Student weights must be restored; if the restore is skipped, we'd see 5.0
+    assert torch.allclose(net.lora_w.detach(), expected_student_val), (
+        f"net.lora_w after process_batch should be {expected_student_val.tolist()} (student), "
+        f"got {net.lora_w.detach().tolist()} — teacher-swap restore likely skipped or misordered"
+    )
+
+
 def test_process_batch_vanilla_fallthrough(tiny_model):
+    """Base path works without any self-flow state; returns finite loss + empty metrics."""
+    torch.manual_seed(1)
     trainer = Flux2SelfFlowNetworkTrainer()
     args = make_args(self_flow=False)
-    # must not require any self-flow state; will exercise base process_batch
-    # (just verify no AttributeError on missing rep_proj/EMA before the super() call)
-    assert args.self_flow is False
+    # NOTE: with self_flow=False, on_transformer_loaded / on_train_start must NOT
+    # be called — the base path must not require any self-flow state.
+    acc = PreparingAccelerator()
+    net = StubNetwork()
+
+    B, H, W = 2, 4, 4
+    latents = torch.randn(B, 4, H, W)
+    noise = torch.randn_like(latents)
+    batch = {
+        "ctx_vec": torch.randn(B, 3, 8),
+        "timesteps": None,
+    }
+    scheduler = make_noise_scheduler(args)
+
+    loss, metrics = trainer.process_batch(
+        args,
+        acc,
+        tiny_model,
+        net,
+        batch,
+        latents,
+        noise,
+        scheduler,
+        torch.float32,
+        torch.float32,
+        None,
+        global_step=0,
+    )
+    assert loss.ndim == 0 and torch.isfinite(loss), f"expected finite scalar loss, got {loss}"
+    assert metrics == {}, f"base compute_loss should return empty dict, got {metrics}"

--- a/tests/test_self_flow_process_batch.py
+++ b/tests/test_self_flow_process_batch.py
@@ -1,0 +1,70 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import Flux2SelfFlowNetworkTrainer
+from musubi_tuner.modules.scheduling_flow_match_discrete import FlowMatchDiscreteScheduler
+
+from .test_self_flow_call_dit import make_args
+from .test_self_flow_lifecycle import PreparingAccelerator, StubNetwork
+
+
+def make_noise_scheduler(args):
+    """Build the same scheduler the trainer uses; location confirmed from trainer_base imports."""
+    return FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
+
+
+def test_process_batch_self_flow_smoke(tiny_model):
+    torch.manual_seed(0)
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(
+        student_feature_layer=0,
+        teacher_feature_layer=2,
+        mask_ratio=0.25,
+        self_flow_gamma=0.8,
+        ema_decay=0.999,
+    )
+    acc = PreparingAccelerator()
+    trainer.handle_model_specific_args(args)
+    trainer.on_transformer_loaded(args, acc, tiny_model)
+    trainer.extra_trainable_params(args, acc, None, tiny_model, [])
+    net = StubNetwork()
+    trainer.on_train_start(args, acc, net, tiny_model, None)
+
+    B, H, W = 2, 4, 4
+    latents = torch.randn(B, 4, H, W)
+    noise = torch.randn_like(latents)
+    batch = {
+        "ctx_vec": torch.randn(B, 3, 8),
+        "timesteps": None,
+    }
+    scheduler = make_noise_scheduler(args)
+
+    loss, metrics = trainer.process_batch(
+        args,
+        acc,
+        tiny_model,
+        net,
+        batch,
+        latents,
+        noise,
+        scheduler,
+        torch.float32,
+        torch.float32,
+        None,
+        global_step=10,
+    )
+    assert loss.ndim == 0 and torch.isfinite(loss)
+    assert "loss/gen" in metrics and "loss/rep" in metrics
+    assert trainer._self_flow_logs  # state metrics populated for extra_step_logs
+    assert "self_flow/ema_weight_drift" in trainer._self_flow_logs
+
+    loss.backward()
+    grads = [p.grad for p in trainer.rep_proj.parameters()]
+    assert all(g is not None for g in grads)  # L_rep reached the projection head
+
+
+def test_process_batch_vanilla_fallthrough(tiny_model):
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(self_flow=False)
+    # must not require any self-flow state; will exercise base process_batch
+    # (just verify no AttributeError on missing rep_proj/EMA before the super() call)
+    assert args.self_flow is False

--- a/tests/test_self_flow_save.py
+++ b/tests/test_self_flow_save.py
@@ -1,5 +1,3 @@
-import os
-
 import torch
 from safetensors.torch import load_file
 

--- a/tests/test_self_flow_save.py
+++ b/tests/test_self_flow_save.py
@@ -1,0 +1,58 @@
+import os
+
+import torch
+from safetensors.torch import load_file
+
+from musubi_tuner.flux_2_train_network_self_flow import Flux2SelfFlowNetworkTrainer
+
+from .test_self_flow_call_dit import FakeAccelerator, make_args
+
+
+class SavingStubNetwork(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lora_w = torch.nn.Parameter(torch.ones(4))
+
+    def save_weights(self, file, dtype, metadata):
+        from safetensors.torch import save_file
+
+        state = {k: v.detach().to(dtype) if dtype else v.detach() for k, v in self.state_dict().items()}
+        save_file(state, file, metadata={k: str(v) for k, v in (metadata or {}).items()})
+
+
+class PrintingAccelerator(FakeAccelerator):
+    def print(self, *a, **k):
+        pass
+
+
+def test_companion_files_written(tmp_path):
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(output_dir=str(tmp_path), huggingface_repo_id=None)
+    net = SavingStubNetwork()
+    trainer.rep_proj = torch.nn.Linear(4, 4)
+    trainer.ema_lora_state = {"lora_w": torch.full((4,), 2.0)}
+
+    trainer.on_post_save(
+        args,
+        PrintingAccelerator(),
+        net,
+        None,
+        ckpt_name="lora-000010.safetensors",
+        save_dtype=torch.float32,
+        metadata={},
+        force_sync_upload=False,
+    )
+
+    ema_path = tmp_path / "lora-000010-ema.safetensors"
+    proj_path = tmp_path / "lora-000010-proj.safetensors"
+    assert ema_path.exists() and proj_path.exists()
+    assert torch.equal(load_file(str(ema_path))["lora_w"], torch.full((4,), 2.0))
+    # student weights restored after the EMA swap-save
+    assert torch.equal(net.lora_w.detach(), torch.ones(4))
+
+
+def test_noop_without_self_flow(tmp_path):
+    trainer = Flux2SelfFlowNetworkTrainer()
+    args = make_args(self_flow=False, output_dir=str(tmp_path))
+    trainer.on_post_save(args, PrintingAccelerator(), SavingStubNetwork(), None, "x.safetensors", None, {}, False)
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_self_flow_timestep.py
+++ b/tests/test_self_flow_timestep.py
@@ -1,0 +1,39 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import (
+    assign_teacher_student_timesteps,
+    reconstruct_noisy_input,
+)
+
+
+def test_teacher_gets_min_student_gets_max():
+    t_a = torch.tensor([100.0, 900.0, 500.0])
+    t_b = torch.tensor([300.0, 200.0, 500.0])
+    teacher, student = assign_teacher_student_timesteps(t_a, t_b)
+    assert torch.equal(teacher, torch.tensor([100.0, 200.0, 500.0]))
+    assert torch.equal(student, torch.tensor([300.0, 900.0, 500.0]))
+
+
+def test_assign_preserves_dtype():
+    t_a = torch.tensor([100, 900], dtype=torch.long)
+    t_b = torch.tensor([300, 200], dtype=torch.long)
+    teacher, student = assign_teacher_student_timesteps(t_a, t_b)
+    assert teacher.dtype == torch.long and student.dtype == torch.long
+
+
+def test_reconstruct_noisy_input_4d():
+    latents = torch.zeros(2, 4, 8, 8)
+    noise = torch.ones(2, 4, 8, 8)
+    # timesteps in [1, 1001]; t=1 -> 0% noise, t=1001 -> 100% noise
+    timesteps = torch.tensor([1.0, 1001.0])
+    out = reconstruct_noisy_input(latents, noise, timesteps)
+    assert torch.allclose(out[0], torch.zeros(4, 8, 8))
+    assert torch.allclose(out[1], torch.ones(4, 8, 8))
+
+
+def test_reconstruct_noisy_input_5d():
+    latents = torch.zeros(1, 4, 2, 8, 8)
+    noise = torch.ones(1, 4, 2, 8, 8)
+    timesteps = torch.tensor([501.0])  # t=0.5
+    out = reconstruct_noisy_input(latents, noise, timesteps)
+    assert torch.allclose(out, torch.full_like(out, 0.5))

--- a/tests/test_self_flow_timestep_map.py
+++ b/tests/test_self_flow_timestep_map.py
@@ -1,0 +1,39 @@
+import torch
+
+from musubi_tuner.flux_2_train_network_self_flow import build_per_token_timestep_map
+
+
+def _setup():
+    teacher = torch.tensor([100.0, 200.0])
+    student = torch.tensor([800.0, 900.0])
+    mask = torch.tensor([[True, False, True, False], [False, False, True, True]])
+    return teacher, student, mask
+
+
+def test_masked_tokens_get_teacher_timestep():
+    teacher, student, mask = _setup()
+    per_token, mismatch = build_per_token_timestep_map(teacher, student, mask)
+    expected = torch.tensor(
+        [[100.0, 800.0, 100.0, 800.0], [900.0, 900.0, 200.0, 200.0]]
+    )
+    assert torch.equal(per_token, expected)
+    assert not mismatch.any()
+
+
+def test_full_mismatch_gives_student_everywhere():
+    teacher, student, mask = _setup()
+    per_token, mismatch = build_per_token_timestep_map(
+        teacher, student, mask, mismatch_prob=1.0
+    )
+    expected = student.unsqueeze(1).expand(2, 4)
+    assert torch.equal(per_token, expected)
+    assert torch.equal(mismatch, mask)
+
+
+def test_mismatch_only_hits_masked_tokens():
+    torch.manual_seed(0)
+    teacher, student, mask = _setup()
+    _, mismatch = build_per_token_timestep_map(
+        teacher, student, mask, mismatch_prob=0.5
+    )
+    assert not (mismatch & ~mask).any()

--- a/tests/test_self_flow_timestep_map.py
+++ b/tests/test_self_flow_timestep_map.py
@@ -13,18 +13,14 @@ def _setup():
 def test_masked_tokens_get_teacher_timestep():
     teacher, student, mask = _setup()
     per_token, mismatch = build_per_token_timestep_map(teacher, student, mask)
-    expected = torch.tensor(
-        [[100.0, 800.0, 100.0, 800.0], [900.0, 900.0, 200.0, 200.0]]
-    )
+    expected = torch.tensor([[100.0, 800.0, 100.0, 800.0], [900.0, 900.0, 200.0, 200.0]])
     assert torch.equal(per_token, expected)
     assert not mismatch.any()
 
 
 def test_full_mismatch_gives_student_everywhere():
     teacher, student, mask = _setup()
-    per_token, mismatch = build_per_token_timestep_map(
-        teacher, student, mask, mismatch_prob=1.0
-    )
+    per_token, mismatch = build_per_token_timestep_map(teacher, student, mask, mismatch_prob=1.0)
     expected = student.unsqueeze(1).expand(2, 4)
     assert torch.equal(per_token, expected)
     assert torch.equal(mismatch, mask)
@@ -33,7 +29,5 @@ def test_full_mismatch_gives_student_everywhere():
 def test_mismatch_only_hits_masked_tokens():
     torch.manual_seed(0)
     teacher, student, mask = _setup()
-    _, mismatch = build_per_token_timestep_map(
-        teacher, student, mask, mismatch_prob=0.5
-    )
+    _, mismatch = build_per_token_timestep_map(teacher, student, mask, mismatch_prob=0.5)
     assert not (mismatch & ~mask).any()


### PR DESCRIPTION
## Summary

Implements Self-Supervised Flow Matching (**Self-Flow**, [arXiv:2603.06507](https://arxiv.org/abs/2603.06507)) for FLUX.2 LoRA training by filling in the `flux_2_train_network_self_flow.py` skeleton merged earlier — with **zero modifications to `flux2_models.py` or any base trainer**. This supersedes the approach in #913, which required editing `Flux2.forward` and `hv_train_network.py` directly.

### How per-token timestep conditioning works without model changes

The dual-timestep schedule needs each image token conditioned on its own timestep. Instead of modifying `Flux2.forward`, the trainer installs forward hooks on the unmodified model:

- `time_in` (post-hook): recomputes the embedding from the staged per-token map τ (B, N_img) and returns a per-token vec (B, N_img, D)
- `guidance_in` (post-hook): unsqueezes to broadcast
- `double_stream_modulation_txt` (pre-hook): text tokens get the mean vec
- `single_stream_modulation` (pre-hook): concatenated global+per-token vec
- `final_layer`: no hook needed — `Modulation`/`LastLayer` already broadcast 3D vecs natively

Feature extraction for `L_rep` uses forward hooks on the chosen double/single blocks (the blocks self-checkpoint internally, so captured features stay differentiable under `--gradient_checkpointing`). When nothing is staged, every hook is a pass-through — the vanilla path is **bitwise identical** (test-enforced).

Everything else lands on the existing extension seams: `process_batch` (dual-timestep step), `extra_trainable_params` (projection head), `on_train_start`/`on_post_optimizer_step` (EMA teacher), `on_before/after_sample_images` (sample with EMA weights), `on_post_save` (`-ema` / `-proj` companion files).

### Paper-fidelity fix relative to #913

While porting, an audit against the paper found that #913 (and therefore the skeleton's documented design) deviates from **Eq. 4**: masked tokens always received the *cleaner* timestep (student forced to `max(t,s)`), which breaks the per-token marginal timestep distribution the paper explicitly credits for the method's effectiveness (§3.3: "maintaining the marginal timestep distribution per token"; the §4.4 always-cleaner ablation degrades to no-masking levels). This PR implements the paper-faithful scheme: a per-sample fair coin selects effective cleaner-token fraction `R_M` or `1−R_M`, which is provably distribution-equivalent to Eq. 4's unsorted assignment and restores the marginal `p(t)` for any `R_M`.

### Validation

- **68 CPU tests** (`tests/`), including: hooks-installed-but-unstaged is bitwise-identical to vanilla; heterogeneous per-token forward matches a verbatim reference port of #913's modified `Flux2.forward` (with and without guidance embedding); gradient flow through captured features under gradient checkpointing; statistical tests for the Eq. 4 marginal property.
- **GPU validation on FLUX.2 Klein 4B** (fp8_scaled + gradient checkpointing):
  - Vanilla pass-through: extension script without `--self_flow` matches `flux_2_train_network.py` to 4e-6 cumulative loss over 30 steps.
  - 500-step A/B vs a #913-lineage run (same seed/config): RNG consumption bitwise-identical (masks, timesteps), losses within 6e-4, final LoRA weight divergence statistically indistinguishable from the same-code rerun noise floor.
  - 500-step run of the corrected Eq. 4 scheme: trains healthily, identical `feat_cosine_sim` plateau (0.851).

### Notes for review

- `pyproject.toml` gains `[tool.pytest.ini_options] pythonpath = ["src"]` — this PR introduces the `tests/` suite, and that setting makes it runnable from a clean checkout (`pytest tests/`).
- First-pass scope (loud errors / documented): control images raise `NotImplementedError` with `--self_flow`; coupling-prob decay schedules are constant-only; patch-locality mask modes not included; `--num_timestep_buckets >= 2` is rejected (it would collapse both timestep draws). `--compile` warns (hooks graph-break).
- Internal extension point — no API stability guarantees (per the skeleton's policy).

### Usage

```bash
accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 \
  src/musubi_tuner/flux_2_train_network_self_flow.py \
  --dit flux-2-klein-base-4b.safetensors ... \
  --self_flow --self_flow_gamma 0.8 --mask_ratio 0.25 --ema_decay 0.999 \
  --student_feature_layer 8 --teacher_feature_layer 20
```

Each save writes `xxx.safetensors` (student), `xxx-ema.safetensors` (EMA teacher — recommended for inference, also used for sample images), and `xxx-proj.safetensors` (projection head, for resuming).

---

## 概要（日本語）

Self-Supervised Flow Matching（**Self-Flow**、[arXiv:2603.06507](https://arxiv.org/abs/2603.06507)）の FLUX.2 LoRA 学習対応を、既にマージされている `flux_2_train_network_self_flow.py` のスケルトンを実装する形で追加します。**`flux2_models.py` やベーストレーナーへの変更は一切ありません**。`Flux2.forward` 等の直接編集が必要だった #913 のアプローチを置き換えるものです。

### モデル変更なしでトークン毎のタイムステップ条件付けを実現する仕組み

未変更の Flux2 モデルに forward hook を登録します：

- `time_in`（post-hook）：ステージされたトークン毎マップ τ (B, N_img) から埋め込みを再計算し、(B, N_img, D) の vec を返す
- `guidance_in`（post-hook）：ブロードキャスト用に unsqueeze
- `double_stream_modulation_txt`（pre-hook）：テキストトークンには平均 vec を使用
- `single_stream_modulation`（pre-hook）：グローバル＋トークン毎 vec を結合
- `final_layer`：hook 不要（`Modulation` / `LastLayer` は 3D vec をネイティブにブロードキャスト）

`L_rep` 用の特徴抽出はブロックへの forward hook で行います（ブロックは内部で checkpoint するため、`--gradient_checkpointing` 使用時も勾配が流れます）。ステージされていない場合、すべての hook はパススルーであり、通常の推論・学習経路は**ビット単位で同一**です（テストで保証）。

その他はすべて既存の拡張シーム（`process_batch`、`extra_trainable_params`、`on_train_start`、`on_post_optimizer_step`、`on_before/after_sample_images`、`on_post_save`）上に実装しています。

### #913 からの論文忠実性の修正

移植時の論文監査で、#913 が **Eq. 4** から逸脱していることが判明しました：マスクされたトークンが常に*よりクリーンな*タイムステップを受け取る実装になっており、論文が有効性の根拠として明示する「トークン毎の周辺タイムステップ分布の保存」（§3.3）が崩れていました（§4.4 の always-cleaner アブレーションはマスキング無しと同等まで劣化）。本 PR ではサンプル毎の公平なコイン投げで実効クリーン率を `R_M` または `1−R_M` から選択する方式を実装しており、これは Eq. 4 の未ソート割り当てと分布同等であることが証明可能で、任意の `R_M` で周辺分布 `p(t)` を復元します。

### 検証

- **CPU テスト 68 件**：hook 登録済み・非ステージ時のバニラ経路とのビット単位一致、トークン毎 forward と #913 の変更版 `Flux2.forward` の逐語的移植（リファレンス）との一致（guidance embedding 有無両方）、gradient checkpointing 下での特徴の勾配伝播、Eq. 4 周辺分布の統計的テスト等。
- **GPU 検証（FLUX.2 Klein 4B、fp8_scaled + gradient checkpointing）**：
  - `--self_flow` 無しで `flux_2_train_network.py` と累積損失が 4e-6 以内で一致（30 ステップ）
  - 同一シード・設定での #913 系統との 500 ステップ A/B：RNG 消費（マスク・タイムステップ）がビット単位で一致、損失は 6e-4 以内、最終 LoRA 重みの乖離は同一コード再実行のノイズフロアと統計的に区別不能
  - 修正版 Eq. 4 方式の 500 ステップ実行：正常に学習、`feat_cosine_sim` の収束値も同一（0.851）

### レビューに関する補足

- `pyproject.toml` に `[tool.pytest.ini_options] pythonpath = ["src"]` を追加（本 PR で `tests/` を導入するため、クリーンなチェックアウトから `pytest tests/` を実行可能にします）
- 初期実装のスコープ：control 画像は `--self_flow` 時に `NotImplementedError`、coupling 減衰スケジュールは constant のみ、patch-locality マスクモードは未実装、`--num_timestep_buckets >= 2` はエラー（両ドローが同一になるため）。`--compile` は警告（hook によりグラフが分断されます）
- 内部拡張ポイントのため API 安定性の保証はありません（スケルトンのポリシーに準拠）

### 使い方

保存毎に `xxx.safetensors`（student）、`xxx-ema.safetensors`（EMA teacher — 推論にはこちらを推奨、サンプル画像生成にも使用）、`xxx-proj.safetensors`（projection head、再開用）が出力されます。

AI-assisted