### PR TITLE
Ideogram4 followup 2

### DIFF
--- a/docs/ideogram4.md
+++ b/docs/ideogram4.md
@@ -1,30 +1,87 @@
-# Ideogram 4 FP8
+# Ideogram 4
 
-This adapter supports the Comfy-Org single-file component layout for Ideogram 4 FP8.
-The model license is non-commercial; read and accept the relevant terms before downloading or using the weights.
+## Overview / 概要
 
-Ideogram 4 is distributed only in quantized form (FP8 and NVFP4); there are no official BF16/FP16 DiT weights.
-The DiT is therefore always loaded from a pre-quantized FP8 checkpoint — for both inference and LoRA training — and
-kept in FP8 as the frozen base. The FP8 weights are dequantized on the fly to the compute dtype, and any LoRA modules
-run in the compute dtype, so this is the normal (and only) operating mode rather than an optional memory optimization.
+This document describes how to train and run inference for Ideogram 4 within the Musubi Tuner framework. Ideogram 4 is a text-to-image model. Its main components are:
 
-## Download
+- **DiT**: a 34-layer single-stream transformer.
+- **Text Encoder**: Qwen3-VL 8B. Hidden states from multiple layers are concatenated into a 53,248-channel conditioning sequence.
+- **VAE**: the Flux2 KL-VAE.
+- **Asymmetric CFG**: inference uses a separate conditional DiT and unconditional DiT.
 
-Download the component files yourself from https://huggingface.co/Comfy-Org/Ideogram-4 and pass local paths to the scripts.
-The scripts do not accept `--repo_id` and do not download Comfy-Org weights for you.
+This adapter targets the Comfy-Org single-file component layout. The model license is non-commercial; read and accept the relevant terms before downloading or using the weights.
+
+Ideogram 4 is distributed only in quantized form (FP8 and NVFP4); there are no official BF16/FP16 DiT weights. The DiT is therefore always loaded from a pre-quantized FP8 checkpoint — for both inference and LoRA training — and kept in FP8 as the frozen base. The FP8 weights are dequantized on the fly to the compute dtype, and any LoRA modules run in the compute dtype, so this is the normal (and only) operating mode rather than an optional memory optimization.
+
+Many options are shared with other architectures and can be found via `--help`. Refer to the [HunyuanVideo documentation](./hunyuan_video.md) as needed. This feature is experimental.
+
+<details>
+<summary>日本語</summary>
+
+このドキュメントは、Musubi Tunerフレームワーク内でのIdeogram 4の学習・推論方法について説明します。Ideogram 4はテキストから画像を生成するモデルです。主な構成要素は次の通りです。
+
+- **DiT**: 34層のsingle-stream transformer。
+- **Text Encoder**: Qwen3-VL 8B。複数レイヤーの隠れ状態を連結し、53,248チャンネルの条件付けシーケンスを作ります。
+- **VAE**: Flux2 KL-VAE。
+- **非対称CFG**: 推論ではconditional DiTとunconditional DiTを別々に使用します。
+
+このアダプターはComfy-Orgの単一ファイル形式を対象としています。モデルのライセンスは非商用です。重みをダウンロード・使用する前に、関連する規約を読んで同意してください。
+
+Ideogram 4は量子化された形式（FP8およびNVFP4）でのみ配布されており、公式のBF16/FP16 DiT重みは存在しません。そのためDiTは、推論・LoRA学習のどちらでも常に事前量子化されたFP8チェックポイントから読み込まれ、凍結したベースとしてFP8のまま保持されます。FP8重みはオンザフライでcompute dtypeに逆量子化され、LoRAモジュールもcompute dtypeで動作します。つまりこれはオプションのメモリ最適化ではなく、通常の（そして唯一の）動作モードです。
+
+多くのオプションは他のアーキテクチャと共通で、`--help`で確認できます。必要に応じて[HunyuanVideoのドキュメント](./hunyuan_video.md)も参照してください。この機能は実験的なものです。
+
+</details>
+
+## Download the model / モデルのダウンロード
+
+Download the component files yourself from https://huggingface.co/Comfy-Org/Ideogram-4 and pass local paths to the scripts. The scripts do not accept `--repo_id` and do not download Comfy-Org weights for you.
 
 Required files:
 
-- `diffusion_models/ideogram4_fp8_scaled.safetensors`
-- `diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors`
-- `text_encoders/qwen3vl_8b_fp8_scaled.safetensors`
-- `vae/flux2-vae.safetensors`
+- `diffusion_models/ideogram4_fp8_scaled.safetensors` — conditional DiT
+- `diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors` — unconditional DiT (for inference / asymmetric CFG)
+- `text_encoders/qwen3vl_8b_fp8_scaled.safetensors` — Qwen3-VL text encoder
+- `vae/flux2-vae.safetensors` — Flux2 VAE
 
-Tokenizer and text-encoder config are downloaded automatically from `Qwen/Qwen3-VL-8B-Instruct`; there are no tokenizer/config CLI arguments.
+The tokenizer is downloaded automatically from `Qwen/Qwen3-VL-8B-Instruct`; the text-encoder config is bundled in this repository. There are no tokenizer/config CLI arguments.
 
-## Cache
+<details>
+<summary>日本語</summary>
 
-Latent cache:
+コンポーネントファイルは https://huggingface.co/Comfy-Org/Ideogram-4 から自分でダウンロードし、ローカルパスをスクリプトに渡してください。スクリプトは`--repo_id`を受け付けず、Comfy-Orgの重みを自動でダウンロードすることはありません。
+
+必要なファイル:
+
+- `diffusion_models/ideogram4_fp8_scaled.safetensors` — conditional DiT
+- `diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors` — unconditional DiT（推論／非対称CFG用）
+- `text_encoders/qwen3vl_8b_fp8_scaled.safetensors` — Qwen3-VL text encoder
+- `vae/flux2-vae.safetensors` — Flux2 VAE
+
+トークナイザーは`Qwen/Qwen3-VL-8B-Instruct`から自動でダウンロードされます。text encoderのconfigはこのリポジトリ内に同梱されています。トークナイザー/config用のCLI引数はありません。
+
+</details>
+
+## Caption format / キャプション形式
+
+Ideogram 4 was trained with structured JSON captions (top-level keys such as `high_level_description`, `style_description`, `compositional_deconstruction`). A built-in verifier can check this structure.
+
+- **Latent / text caching**: plain text captions are accepted by default. Add `--validate_caption_structure` to verify official structured JSON captions, and combine it with `--warn_on_caption_issues` to warn instead of failing.
+- **Inference**: the prompt is always verified against the structured JSON format. Plain text or malformed JSON raises an error unless you pass `--warn_on_caption_issues`, which downgrades the failure to a warning.
+
+<details>
+<summary>日本語</summary>
+
+Ideogram 4は構造化されたJSONキャプション（`high_level_description`、`style_description`、`compositional_deconstruction`などのトップレベルキー）で学習されています。組み込みのverifierでこの構造を検証できます。
+
+- **latent／textキャッシュ時**: プレーンテキストのキャプションは既定で受け付けられます。`--validate_caption_structure`を付けると公式の構造化JSONキャプションを検証し、`--warn_on_caption_issues`と併用すると失敗の代わりに警告にできます。
+- **推論時**: プロンプトは常に構造化JSON形式として検証されます。プレーンテキストや不正なJSONはエラーになりますが、`--warn_on_caption_issues`を付けると失敗が警告に降格されます。
+
+</details>
+
+## Pre-caching / 事前キャッシング
+
+### Latent Pre-caching / latentの事前キャッシング
 
 ```powershell
 python src/musubi_tuner/ideogram4_cache_latents.py `
@@ -33,12 +90,20 @@ python src/musubi_tuner/ideogram4_cache_latents.py `
   --vae_dtype bfloat16
 ```
 
-The latent cache stores the raw patchified VAE encoder mean in `(patch_i, patch_j, latent_channel)`
-order. Training applies the Ideogram 4 latent shift/scale once, matching the official pipeline.
-Rebuild older Ideogram 4 latent caches created by builds that applied the VAE BatchNorm inside
-`AutoEncoder.encode()` or used the older `(latent_channel, patch_i, patch_j)` patch order.
+- Uses `ideogram4_cache_latents.py`. The dataset should be an image dataset.
+- `--vae_dtype` sets the VAE compute dtype (default `bfloat16`).
+- The latent cache stores the raw patchified VAE encoder mean in `(patch_i, patch_j, latent_channel)` order. Training applies the Ideogram 4 latent shift/scale once, matching the official pipeline.
 
-Text cache:
+<details>
+<summary>日本語</summary>
+
+- `ideogram4_cache_latents.py`を使用します。データセットは画像データセットである必要があります。
+- `--vae_dtype`はVAEのcompute dtypeを指定します（既定は`bfloat16`）。
+- latentキャッシュは、patchify済みのVAE encoder meanを`(patch_i, patch_j, latent_channel)`の順で保存します。学習時にIdeogram 4のlatent shift/scaleを一度だけ適用し、公式パイプラインと一致させます。
+
+</details>
+
+### Text Encoder Output Pre-caching / テキストエンコーダー出力の事前キャッシング
 
 ```powershell
 python src/musubi_tuner/ideogram4_cache_text_encoder_outputs.py `
@@ -47,55 +112,31 @@ python src/musubi_tuner/ideogram4_cache_text_encoder_outputs.py `
   --text_cache_dtype bf16
 ```
 
-Plain text captions are accepted by default. Add `--validate_caption_structure` to check official structured JSON
-captions before caching; combine it with `--warn_on_caption_issues` to warn instead of failing.
+- Uses `ideogram4_cache_text_encoder_outputs.py`. Requires `--text_encoder`.
+- See [Caption format](#caption-format--キャプション形式) for `--validate_caption_structure` / `--warn_on_caption_issues`.
+- The text cache is large because each token stores 53,248 channels. Approximate BF16 cost:
+  - 128 tokens: 13.6 MB/image, 13.6 GB/1k images
+  - 256 tokens: 27.3 MB/image, 27.3 GB/1k images
+  - 512 tokens: 54.5 MB/image, 54.5 GB/1k images
+  - 2048 tokens: 218.1 MB/image, 218.1 GB/1k images
+- `--text_cache_dtype fp8_e4m3fn` halves the disk cost but is an explicit quality/precision tradeoff.
 
-Text cache size is large because each token stores 53,248 channels. Approximate BF16 cost:
+<details>
+<summary>日本語</summary>
 
-- 128 tokens: 13.6 MB/image, 13.6 GB/1k images
-- 256 tokens: 27.3 MB/image, 27.3 GB/1k images
-- 512 tokens: 54.5 MB/image, 54.5 GB/1k images
-- 2048 tokens: 218.1 MB/image, 218.1 GB/1k images
+- `ideogram4_cache_text_encoder_outputs.py`を使用します。`--text_encoder`が必要です。
+- `--validate_caption_structure`／`--warn_on_caption_issues`については[キャプション形式](#caption-format--キャプション形式)を参照してください。
+- 各トークンが53,248チャンネルを保存するため、テキストキャッシュは大きくなります。BF16でのおおよそのサイズは英語版を参照してください。
+- `--text_cache_dtype fp8_e4m3fn`を指定するとディスク使用量は半分になりますが、明確な品質/精度のトレードオフがあります。
 
-`--text_cache_dtype fp8_e4m3fn` halves the disk cost but is an explicit quality/precision tradeoff.
+</details>
 
-## Generate
+## Training / 学習
 
-```powershell
-python src/musubi_tuner/ideogram4_generate_image.py `
-  --dit path\to\ideogram4_fp8_scaled.safetensors `
-  --unconditional_dit path\to\ideogram4_unconditional_fp8_scaled.safetensors `
-  --text_encoder path\to\qwen3vl_8b_fp8_scaled.safetensors `
-  --vae path\to\flux2-vae.safetensors `
-  --prompt "A structured JSON or plain text prompt" `
-  --image_size 1024 1024 `
-  --sampler_preset V4_DEFAULT_20 `
-  --initial_sigma 1.004 `
-  --save_path outputs\ideogram4.png
-```
-
-Sampler presets:
-
-- `V4_QUALITY_48`: 45 main steps at guidance 7, then 3 polish steps at guidance 3
-- `V4_DEFAULT_20`: 18 main steps at guidance 7, then 2 polish steps at guidance 3
-- `V4_TURBO_12`: 11 main steps at guidance 7, then 1 polish step at guidance 3
-
-Ideogram 4 v1 uses the official asymmetric CFG path. `negative_prompt` is ignored.
-`--initial_sigma` overrides the first denoising sigma and defaults to `1.004`.
-
-To apply trained LoRA weights, add `--lora_weight path\to\lora.safetensors` (repeatable) with optional
-`--lora_multiplier` (one value per weight, default `1.0`). The LoRA is attached to the conditional DiT as a
-forward hook rather than merged into the weights, because the FP8 base cannot have LoRA merged back into it.
-This means generation results may differ from tools that merge LoRA into the weights (e.g. ComfyUI).
-
-`--attn_mode` selects the attention backend (`torch`/`sdpa` (default), `flash`, `sageattn`, `xformers`); add
-`--split_attn` to process each sample's attention separately. `flash`/`sageattn`/`xformers` require the
-respective package to be installed and can be faster, but the numerics differ slightly from `torch`.
-
-## Train LoRA
+Training uses a dedicated script `ideogram4_train_network.py`.
 
 ```powershell
-python src/musubi_tuner/ideogram4_train_network.py `
+accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 src/musubi_tuner/ideogram4_train_network.py `
   --dataset_config path\to\dataset.toml `
   --dit path\to\ideogram4_fp8_scaled.safetensors `
   --network_module networks.lora_ideogram4 `
@@ -105,10 +146,61 @@ python src/musubi_tuner/ideogram4_train_network.py `
   --sdpa
 ```
 
+- Uses `ideogram4_train_network.py` and **requires** `--network_module networks.lora_ideogram4`.
+- LoRA v1 trains only the conditional transformer. It targets `attention.qkv`, `attention.o`, and `feed_forward.w1/w2/w3` inside `Ideogram4TransformerBlock`.
+- Merging LoRA back into the FP8 base weights is not supported.
+- `--dit_dtype` sets the DiT compute dtype (default `bfloat16`).
+- Ideogram 4 uses a plain MSE flow-matching loss; `--weighting_scheme` other than `none` is rejected.
+- `--log_loss_stats` logs prediction/target diagnostics during training.
+- Attention backends use the shared flags: `--sdpa` (default), `--flash_attn`, `--xformers`, with `--split_attn`. SageAttention is not supported because the head dimension (256) is outside its int8/fp8 kernels.
+
+<details>
+<summary>日本語</summary>
+
+学習は専用のスクリプト`ideogram4_train_network.py`を使用します。コマンド例は英語版を参照してください。
+
+- `ideogram4_train_network.py`を使用し、`--network_module networks.lora_ideogram4`の指定が**必要**です。
+- LoRA v1はconditional transformerのみを学習します。対象は`Ideogram4TransformerBlock`内の`attention.qkv`、`attention.o`、`feed_forward.w1/w2/w3`です。
+- LoRAをFP8ベース重みにマージし直すことはサポートされていません。
+- `--dit_dtype`はDiTのcompute dtypeを指定します（既定は`bfloat16`）。
+- Ideogram 4は単純なMSEのflow-matching lossを使用します。`none`以外の`--weighting_scheme`はエラーになります。
+- `--log_loss_stats`は学習中にprediction/targetの診断情報をログ出力します。
+- attentionのバックエンドは共通フラグ（`--sdpa`（既定）、`--flash_attn`、`--xformers`、`--split_attn`）を使用します。SageAttentionはhead次元（256）がint8/fp8カーネルの対応外のため使用できません。
+
+</details>
+
+### Timestep sampling / タイムステップサンプリング
+
+Ideogram 4 training defaults to `--timestep_sampling ideogram4_shift`, a resolution-aware logit-normal timestep sampler aligned with the official pipeline. You normally do not need to change it.
+
+<details>
+<summary>日本語</summary>
+
+Ideogram 4の学習は既定で`--timestep_sampling ideogram4_shift`を使用します。これは公式パイプラインに合わせた、解像度依存のlogit-normalタイムステップサンプラーです。通常は変更する必要はありません。
+
+</details>
+
+### Memory Optimization / メモリ最適化
+
+- `--blocks_to_swap` offloads some DiT blocks to CPU. The maximum is 33.
+- `--gradient_checkpointing` (and `--gradient_checkpointing_cpu_offload`) reduce VRAM usage. See the [HunyuanVideo documentation](./hunyuan_video.md#memory-optimization) for details.
+- The DiT base is already FP8 (see [Overview](#overview--概要)), so no separate `--fp8_base` flag is needed for it.
+
+<details>
+<summary>日本語</summary>
+
+- `--blocks_to_swap`は一部のDiTブロックをCPUにオフロードします。最大値は33です。
+- `--gradient_checkpointing`（および`--gradient_checkpointing_cpu_offload`）でVRAM使用量を削減できます。詳細は[HunyuanVideoドキュメント](./hunyuan_video.md#memory-optimization)を参照してください。
+- DiTベースは既にFP8です（[概要](#overview--概要)参照）。そのため別途`--fp8_base`フラグは不要です。
+
+</details>
+
+### Sampling during training / 学習中のサンプル生成
+
 Sampling during training requires the remaining local components:
 
 ```powershell
-python src/musubi_tuner/ideogram4_train_network.py `
+accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 src/musubi_tuner/ideogram4_train_network.py `
   --dataset_config path\to\dataset.toml `
   --dit path\to\ideogram4_fp8_scaled.safetensors `
   --text_encoder path\to\qwen3vl_8b_fp8_scaled.safetensors `
@@ -122,10 +214,77 @@ python src/musubi_tuner/ideogram4_train_network.py `
   --sdpa
 ```
 
-LoRA v1 trains only the conditional transformer. It targets `attention.qkv`, `attention.o`, and `feed_forward.w1/w2/w3` inside `Ideogram4TransformerBlock`, including official `Fp8Linear` layers. Merging LoRA back into FP8 base weights is not supported.
-Sampling during LoRA training defaults to single-DiT CFG for the same reason: the LoRA adapter is attached only to the
-conditional DiT. If you pass `--unconditional_dit`, it is ignored for training samples unless you also pass
-`--use_unconditional_dit_for_lora_sampling` to opt into the official asymmetric CFG path.
+- `--text_encoder` and `--vae` are only needed when sampling.
+- `--sampler_preset` selects the step schedule (see [Inference](#inference--推論) for the preset list); `--initial_sigma` overrides the first denoising sigma (default `1.004`).
+- Sampling during LoRA training defaults to single-DiT CFG, because the LoRA adapter is attached only to the conditional DiT. If you pass `--unconditional_dit`, it is ignored for training samples unless you also pass `--use_unconditional_dit_for_lora_sampling` to opt into the official asymmetric CFG path.
 
-Ideogram 4 training defaults to `--timestep_sampling ideogram4_shift`, a resolution-aware logit-normal timestep
-sampler aligned with the official pipeline.
+<details>
+<summary>日本語</summary>
+
+学習中のサンプル生成には、残りのローカルコンポーネントが必要です。コマンド例は英語版を参照してください。
+
+- `--text_encoder`と`--vae`はサンプル生成時のみ必要です。
+- `--sampler_preset`はステップスケジュールを選択します（プリセット一覧は[推論](#inference--推論)を参照）。`--initial_sigma`は最初のデノイジングsigmaを上書きします（既定は`1.004`）。
+- LoRAアダプターはconditional DiTのみに付与されるため、LoRA学習中のサンプル生成は既定でsingle-DiT CFGになります。`--unconditional_dit`を渡しても、`--use_unconditional_dit_for_lora_sampling`を併用して公式の非対称CFGパスを明示的に有効化しない限り、学習サンプルでは無視されます。
+
+</details>
+
+## Inference / 推論
+
+Inference uses a dedicated script `ideogram4_generate_image.py`.
+
+```powershell
+python src/musubi_tuner/ideogram4_generate_image.py `
+  --dit path\to\ideogram4_fp8_scaled.safetensors `
+  --unconditional_dit path\to\ideogram4_unconditional_fp8_scaled.safetensors `
+  --text_encoder path\to\qwen3vl_8b_fp8_scaled.safetensors `
+  --vae path\to\flux2-vae.safetensors `
+  --prompt "A structured JSON prompt" `
+  --image_size 1024 1024 `
+  --sampler_preset V4_DEFAULT_20 `
+  --initial_sigma 1.004 `
+  --save_path outputs\ideogram4.png
+```
+
+Sampler presets (`--sampler_preset`):
+
+- `V4_QUALITY_48`: 45 main steps at guidance 7, then 3 polish steps at guidance 3
+- `V4_DEFAULT_20`: 18 main steps at guidance 7, then 2 polish steps at guidance 3
+- `V4_TURBO_12`: 11 main steps at guidance 7, then 1 polish step at guidance 3
+
+Notes:
+
+- Ideogram 4 v1 uses the official asymmetric CFG path with the conditional and unconditional DiTs. `--negative_prompt` is ignored.
+- `--initial_sigma` overrides the first denoising sigma (default `1.004`).
+- `--dtype` sets the compute dtype for the models (default `bfloat16`).
+- `--prompt` is verified as structured JSON; see [Caption format](#caption-format--キャプション形式).
+- `--disable_numpy_memmap` disables numpy memmap while loading safetensors (higher RAM, sometimes faster loading).
+
+### LoRA / LoRA
+
+To apply trained LoRA weights, add `--lora_weight path\to\lora.safetensors` (repeatable) with optional `--lora_multiplier` (one value per weight, default `1.0`), and optional `--include_patterns` / `--exclude_patterns` (one regex per weight). The LoRA is attached to the conditional DiT as a forward hook rather than merged into the weights, because the FP8 base cannot have LoRA merged back into it. This means generation results may differ from tools that merge LoRA into the weights (e.g. ComfyUI).
+
+### Attention / Attention
+
+`--attn_mode` selects the attention backend (`torch`/`sdpa` (default), `flash`, `sageattn`, `xformers`); add `--split_attn` to process each sample's attention separately. `flash`/`sageattn`/`xformers` require the respective package to be installed and can be faster, but the numerics differ slightly from `torch`. (`sageattn` does not support the head dimension of 256 and will fail.)
+
+<details>
+<summary>日本語</summary>
+
+推論は専用のスクリプト`ideogram4_generate_image.py`を使用します。コマンド例とサンプラープリセット一覧は英語版を参照してください。
+
+- Ideogram 4 v1はconditional/unconditional DiTを用いた公式の非対称CFGパスを使用します。`--negative_prompt`は無視されます。
+- `--initial_sigma`は最初のデノイジングsigmaを上書きします（既定は`1.004`）。
+- `--dtype`はモデルのcompute dtypeを指定します（既定は`bfloat16`）。
+- `--prompt`は構造化JSONとして検証されます。[キャプション形式](#caption-format--キャプション形式)を参照してください。
+- `--disable_numpy_memmap`はsafetensors読み込み時のnumpy memmapを無効化します（RAM使用量は増えますが、読み込みが速くなる場合があります）。
+
+#### LoRA
+
+学習済みLoRA重みを適用するには、`--lora_weight path\to\lora.safetensors`（繰り返し指定可）を追加し、必要に応じて`--lora_multiplier`（重みごとに1値、既定`1.0`）、`--include_patterns`／`--exclude_patterns`（重みごとに1つのregex）を指定します。FP8ベースにはLoRAをマージし直せないため、LoRAは重みへのマージではなくconditional DiTへのforward hookとして付与されます。このため、LoRAを重みにマージするツール（例: ComfyUI）とは生成結果が異なる場合があります。
+
+#### Attention
+
+`--attn_mode`でattentionのバックエンドを選択します（`torch`/`sdpa`（既定）、`flash`、`sageattn`、`xformers`）。`--split_attn`を追加すると各サンプルのattentionを個別に処理します。`flash`/`sageattn`/`xformers`はそれぞれのパッケージのインストールが必要で、高速化が期待できますが、数値は`torch`とわずかに異なります。（`sageattn`はhead次元256に対応しておらず失敗します。）
+
+</details>

--- a/src/musubi_tuner/ideogram4/ideogram4_quantized_loading.py
+++ b/src/musubi_tuner/ideogram4/ideogram4_quantized_loading.py
@@ -31,9 +31,6 @@ _BNB_SIBLING_SUFFIXES = (
     ".nested_quant_map",
 )
 
-# Largest magnitude representable by the e4m3 float8 format. Per-row weight
-# scales map each row's max abs value onto this so we use the full range.
-FP8_E4M3_MAX = 448.0
 FP8_SCALE_SUFFIX = ".weight_scale"
 COMFY_FP8_MARKER_SUFFIX = ".comfy_quant"
 # Marker written into the text encoder's config.json so the loader knows to take
@@ -154,23 +151,6 @@ def load_bnb4bit_state_dict(
 # matmul runs, so this needs no FP8 tensor-core hardware and works on any device
 # that can store float8 (CPU included). The win is ~2x smaller Linear weights.
 # ---------------------------------------------------------------------------
-
-
-def quantize_weight_to_fp8(
-    weight: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Quantize a 2-D Linear weight to e4m3 float8 with per-row scales.
-
-    Returns ``(weight_fp8, scale)`` where ``weight_fp8`` has shape ``(out, in)``
-    in ``float8_e4m3fn`` and ``scale`` has shape ``(out,)`` in float32 such that
-    ``weight ≈ weight_fp8.to(dtype) * scale[:, None]``.
-    """
-    fp8_dtype = require_fp8_dtype()
-    w = weight.detach().to(torch.float32)
-    amax = w.abs().amax(dim=1, keepdim=True).clamp(min=1e-12)
-    scale = amax / FP8_E4M3_MAX
-    q = (w / scale).clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX).to(fp8_dtype)
-    return q, scale.squeeze(1).to(torch.float32)
 
 
 def is_fp8_state_dict(state_dict: dict[str, torch.Tensor]) -> bool:

--- a/src/musubi_tuner/ideogram4/ideogram4_utils.py
+++ b/src/musubi_tuner/ideogram4/ideogram4_utils.py
@@ -527,19 +527,6 @@ def build_negative_image_inputs(
     }
 
 
-def build_unconditional_sequence_inputs(
-    text_features: list[torch.Tensor],
-    height: int,
-    width: int,
-    *,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> dict[str, torch.Tensor | int]:
-    inputs = build_sequence_inputs_from_features(text_features, height, width, device=device)
-    inputs["llm_features"] = inputs["llm_features"].to(device=device, dtype=dtype)
-    return inputs
-
-
 def patchify_vae_latents(latents: torch.Tensor) -> torch.Tensor:
     if latents.ndim != 4:
         raise ValueError(f"expected VAE latents as B,C,H,W, got {tuple(latents.shape)}")
@@ -663,13 +650,10 @@ def generate_images(
             unconditional_text_features = [torch.zeros_like(features) for features in text_features]
         if len(unconditional_text_features) != len(text_features):
             raise ValueError("unconditional_text_features must have the same batch size as text_features")
-        negative_inputs = build_unconditional_sequence_inputs(
-            unconditional_text_features,
-            height,
-            width,
-            device=device,
-            dtype=cond_features.dtype,
-        )
+        negative_inputs = build_sequence_inputs_from_features(unconditional_text_features, height, width, device=device)
+        # Match the negative llm_features dtype to cond_features (float32), mirroring the
+        # build_negative_image_inputs branch so both CFG paths feed the DiT the same dtype.
+        negative_inputs["llm_features"] = negative_inputs["llm_features"].to(device=device, dtype=cond_features.dtype)
         neg_max_text_tokens = int(negative_inputs["max_text_tokens"])
         neg_text_z_padding = torch.zeros(batch_size, neg_max_text_tokens, latent_dim, dtype=torch.float32, device=device)
     else:

--- a/src/musubi_tuner/ideogram4/ideogram4_utils.py
+++ b/src/musubi_tuner/ideogram4/ideogram4_utils.py
@@ -568,16 +568,14 @@ def unflatten_token_grid(tokens: torch.Tensor, grid_h: int, grid_w: int) -> torc
 
 
 def normalize_token_grid(token_grid: torch.Tensor) -> torch.Tensor:
-    shift, scale = get_latent_norm()
-    shift = shift.to(device=token_grid.device, dtype=token_grid.dtype).view(1, -1, 1, 1)
-    scale = scale.to(device=token_grid.device, dtype=token_grid.dtype).view(1, -1, 1, 1)
+    shift, scale = get_latent_norm(device=token_grid.device, dtype=token_grid.dtype)
+    shift = shift.view(1, -1, 1, 1)
+    scale = scale.view(1, -1, 1, 1)
     return (token_grid - shift) / scale
 
 
 def denormalize_tokens(tokens: torch.Tensor) -> torch.Tensor:
-    shift, scale = get_latent_norm()
-    shift = shift.to(device=tokens.device, dtype=tokens.dtype)
-    scale = scale.to(device=tokens.device, dtype=tokens.dtype)
+    shift, scale = get_latent_norm(device=tokens.device, dtype=tokens.dtype)
     if tokens.ndim == 4:
         shift = shift.view(1, -1, 1, 1)
         scale = scale.view(1, -1, 1, 1)

--- a/src/musubi_tuner/ideogram4/latent_norm.py
+++ b/src/musubi_tuner/ideogram4/latent_norm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
 
 LATENT_SHIFT: tuple[float, ...] = (
@@ -265,8 +267,11 @@ LATENT_SCALE: tuple[float, ...] = (
 )
 
 
-def get_latent_norm() -> tuple[torch.Tensor, torch.Tensor]:
-    shift = torch.tensor(LATENT_SHIFT, dtype=torch.float32)
-    scale = torch.tensor(LATENT_SCALE, dtype=torch.float32)
+def get_latent_norm(
+    device: Optional[torch.device] = None,
+    dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    shift = torch.tensor(LATENT_SHIFT, dtype=dtype, device=device)
+    scale = torch.tensor(LATENT_SCALE, dtype=dtype, device=device)
     assert shift.shape == (128,) and scale.shape == (128,)
     return shift, scale

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -409,7 +409,6 @@ def create_network(
     neuron_dropout: Optional[float] = None,
     module_class: Type[object] = None,
     module_kwargs: Optional[Dict[str, Any]] = None,
-    linear_module_class_names: Optional[tuple[str, ...]] = None,
     **kwargs,
 ):
     """architecture independent network creation"""
@@ -470,7 +469,6 @@ def create_network(
         conv_alpha=conv_alpha,
         module_class=module_class,
         module_kwargs=module_kwargs,
-        linear_module_class_names=linear_module_class_names,
         exclude_patterns=exclude_patterns,
         include_patterns=include_patterns,
         verbose=verbose,
@@ -509,7 +507,6 @@ class LoRANetwork(torch.nn.Module):
         module_kwargs: Optional[Dict[str, Any]] = None,
         modules_dim: Optional[Dict[str, int]] = None,
         modules_alpha: Optional[Dict[str, int]] = None,
-        linear_module_class_names: Optional[tuple[str, ...]] = None,
         exclude_patterns: Optional[List[str]] = None,
         include_patterns: Optional[List[str]] = None,
         verbose: Optional[bool] = False,
@@ -527,7 +524,6 @@ class LoRANetwork(torch.nn.Module):
         self.target_replace_modules = target_replace_modules
         self.prefix = prefix
         self.module_kwargs = module_kwargs or {}
-        self.linear_module_class_names = linear_module_class_names or ("Linear",)
 
         self.loraplus_lr_ratio = None
         # self.loraplus_unet_lr_ratio = None
@@ -585,7 +581,7 @@ class LoRANetwork(torch.nn.Module):
                         module = root_module  # search all modules
 
                     for child_name, child_module in module.named_modules():
-                        is_linear = child_module.__class__.__name__ in self.linear_module_class_names
+                        is_linear = child_module.__class__.__name__ == "Linear"
                         is_conv2d = child_module.__class__.__name__ == "Conv2d"
                         is_conv3d = child_module.__class__.__name__ == "Conv3d"
                         is_conv2d_1x1 = is_conv2d and child_module.kernel_size == (1, 1)
@@ -981,7 +977,6 @@ def create_network_from_weights(
     for_inference: bool = False,
     module_class: Optional[Type[object]] = None,
     module_kwargs: Optional[Dict[str, Any]] = None,
-    linear_module_class_names: Optional[tuple[str, ...]] = None,
     **kwargs,
 ) -> LoRANetwork:
     # get dim/alpha mapping
@@ -1012,6 +1007,5 @@ def create_network_from_weights(
         modules_alpha=modules_alpha,
         module_class=module_class,
         module_kwargs=module_kwargs,
-        linear_module_class_names=linear_module_class_names,
     )
     return network

--- a/src/musubi_tuner/networks/lora_ideogram4.py
+++ b/src/musubi_tuner/networks/lora_ideogram4.py
@@ -10,18 +10,6 @@ import musubi_tuner.networks.lora as lora
 
 
 IDEOGRAM4_TARGET_REPLACE_MODULES = ["Ideogram4TransformerBlock"]
-IDEOGRAM4_TARGET_INCLUDE_PATTERNS = [
-    r".*attention\.(qkv|o)",
-    r".*feed_forward\.w[123]",
-]
-
-
-def _parse_patterns(value):
-    if value is None:
-        return []
-    if isinstance(value, str):
-        return ast.literal_eval(value)
-    return value
 
 
 def create_arch_network(
@@ -34,14 +22,17 @@ def create_arch_network(
     neuron_dropout: Optional[float] = None,
     **kwargs,
 ):
-    exclude_patterns = _parse_patterns(kwargs.get("exclude_patterns", None))
-    include_patterns = _parse_patterns(kwargs.get("include_patterns", None))
+    # add default exclude patterns
+    exclude_patterns = kwargs.get("exclude_patterns", None)
+    if exclude_patterns is None:
+        exclude_patterns = []
+    else:
+        exclude_patterns = ast.literal_eval(exclude_patterns)
 
-    exclude_patterns.append(r".*")
-    include_patterns.extend(IDEOGRAM4_TARGET_INCLUDE_PATTERNS)
+    # exclude adaln_modulation (per-block modulation): keep attention.{qkv,o} and feed_forward.w{1,2,3}
+    exclude_patterns.append(r".*adaln_modulation.*")
 
     kwargs["exclude_patterns"] = exclude_patterns
-    kwargs["include_patterns"] = include_patterns
 
     network = lora.create_network(
         IDEOGRAM4_TARGET_REPLACE_MODULES,

--- a/src/musubi_tuner/networks/lora_ideogram4.py
+++ b/src/musubi_tuner/networks/lora_ideogram4.py
@@ -14,7 +14,6 @@ IDEOGRAM4_TARGET_INCLUDE_PATTERNS = [
     r".*attention\.(qkv|o)",
     r".*feed_forward\.w[123]",
 ]
-IDEOGRAM4_LINEAR_CLASS_NAMES = ("Linear",)
 
 
 def _parse_patterns(value):
@@ -54,7 +53,6 @@ def create_arch_network(
         text_encoders,
         unet,
         neuron_dropout=neuron_dropout,
-        linear_module_class_names=IDEOGRAM4_LINEAR_CLASS_NAMES,
         **kwargs,
     )
     if len(network.unet_loras) == 0:
@@ -77,6 +75,5 @@ def create_arch_network_from_weights(
         text_encoders,
         unet,
         for_inference,
-        linear_module_class_names=IDEOGRAM4_LINEAR_CLASS_NAMES,
         **kwargs,
     )

--- a/tests/test_ideogram4_fp8_loading.py
+++ b/tests/test_ideogram4_fp8_loading.py
@@ -17,11 +17,22 @@ from musubi_tuner.ideogram4 import ideogram4_utils
 from musubi_tuner.ideogram4.ideogram4_quantized_loading import (
     COMFY_FP8_MARKER_SUFFIX,
     FP8_SCALE_SUFFIX,
-    quantize_weight_to_fp8,
 )
 from musubi_tuner.modules.fp8_optimization_utils import apply_fp8_monkey_patch
 from musubi_tuner.utils import safetensors_utils
 from musubi_tuner.utils.lora_utils import load_safetensors_with_lora_and_fp8
+
+# e4m3 max; quantize a 2-D Linear weight to float8 with per-row scales, mirroring the
+# layout a ComfyUI FP8 exporter produces (weight_fp8.to(dtype) * scale[:, None] ≈ weight).
+_FP8_E4M3_MAX = 448.0
+
+
+def _quantize_weight_to_fp8(weight):
+    w = weight.detach().to(torch.float32)
+    amax = w.abs().amax(dim=1, keepdim=True).clamp(min=1e-12)
+    scale = amax / _FP8_E4M3_MAX
+    q = (w / scale).clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    return q, scale.squeeze(1).to(torch.float32)
 
 
 def _write_comfy_fp8_checkpoint(path, *, out_features=8, in_features=16):
@@ -32,7 +43,7 @@ def _write_comfy_fp8_checkpoint(path, *, out_features=8, in_features=16):
     """
     torch.manual_seed(0)
     ref_weight = torch.randn(out_features, in_features, dtype=torch.float32)
-    weight_fp8, scale = quantize_weight_to_fp8(ref_weight)  # scale: [out]
+    weight_fp8, scale = _quantize_weight_to_fp8(ref_weight)  # scale: [out]
 
     other_weight = torch.randn(out_features, in_features, dtype=torch.bfloat16)
 

--- a/tests/test_ideogram4_synthetic.py
+++ b/tests/test_ideogram4_synthetic.py
@@ -134,10 +134,10 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
         self.assertEqual(selector.reso_steps, 16)
         self.assertEqual(selector.get_bucket_resolution((1024, 1024)), (1024, 1024))
 
-    def test_qwen3_vl_metadata_loads_from_public_qwen_repo(self):
+    def test_text_encoder_uses_vendored_config_without_trust_remote_code(self):
         calls = {}
         original_tokenizer = ideogram4_utils.AutoTokenizer
-        original_config = ideogram4_utils.AutoConfig
+        original_config = ideogram4_utils.Qwen3VLConfig
         original_model = ideogram4_utils.AutoModel
         original_validate = ideogram4_utils.validate_local_safetensors
         original_load_state_dict = ideogram4_utils._load_state_dict
@@ -151,7 +151,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         class FakeConfig:
             @staticmethod
-            def from_pretrained(*args, **kwargs):
+            def from_dict(*args, **kwargs):
                 calls["config"] = (args, kwargs)
                 return object()
 
@@ -171,8 +171,8 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         class FakeAutoModel:
             @staticmethod
-            def from_config(config, trust_remote_code=True):
-                calls["model"] = (config, trust_remote_code)
+            def from_config(*args, **kwargs):
+                calls["model"] = (args, kwargs)
                 return FakeModel()
 
         class NoOpContext:
@@ -184,7 +184,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         try:
             ideogram4_utils.AutoTokenizer = FakeTokenizer
-            ideogram4_utils.AutoConfig = FakeConfig
+            ideogram4_utils.Qwen3VLConfig = FakeConfig
             ideogram4_utils.AutoModel = FakeAutoModel
             ideogram4_utils.validate_local_safetensors = lambda path: {}
             ideogram4_utils._load_state_dict = lambda path, device="cpu", disable_mmap=False: {}
@@ -198,18 +198,21 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
             )
         finally:
             ideogram4_utils.AutoTokenizer = original_tokenizer
-            ideogram4_utils.AutoConfig = original_config
+            ideogram4_utils.Qwen3VLConfig = original_config
             ideogram4_utils.AutoModel = original_model
             ideogram4_utils.validate_local_safetensors = original_validate
             ideogram4_utils._load_state_dict = original_load_state_dict
             ideogram4_utils.init_empty_weights = original_init_empty_weights
 
-        self.assertEqual(calls["tokenizer"][0], ("Qwen/Qwen3-VL-8B-Instruct",))
+        # Tokenizer is the only artifact fetched by repo id; Qwen3-VL is natively supported so no
+        # trust_remote_code (and no subfolder).
+        self.assertEqual(calls["tokenizer"][0], (ideogram4_utils.QWEN3_VL_8B_INSTRUCT_REPO_ID,))
         self.assertNotIn("subfolder", calls["tokenizer"][1])
-        self.assertTrue(calls["tokenizer"][1]["trust_remote_code"])
-        self.assertEqual(calls["config"][0], ("Qwen/Qwen3-VL-8B-Instruct",))
-        self.assertNotIn("subfolder", calls["config"][1])
-        self.assertTrue(calls["config"][1]["trust_remote_code"])
+        self.assertNotIn("trust_remote_code", calls["tokenizer"][1])
+        # The text-encoder config is built from the vendored dict, never fetched from the Hub.
+        self.assertEqual(calls["config"][0], (ideogram4_utils.QWEN3_VL_8B_INSTRUCT_CONFIG,))
+        # AutoModel is instantiated from that config without trust_remote_code.
+        self.assertNotIn("trust_remote_code", calls["model"][1])
 
     def test_text_encoder_state_dict_remaps_qwen3_vl_model_prefixes(self):
         state = {
@@ -238,7 +241,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
         self.assertTrue(torch.equal(normalized["language_model.norm.weight"], state["language_model.norm.weight"]))
 
     def test_text_encoder_loader_materializes_missing_meta_tensors(self):
-        original_config = ideogram4_utils.AutoConfig
+        original_config = ideogram4_utils.Qwen3VLConfig
         original_model = ideogram4_utils.AutoModel
         original_validate = ideogram4_utils.validate_local_safetensors
         original_load_state_dict = ideogram4_utils._load_state_dict
@@ -246,7 +249,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         class FakeConfig:
             @staticmethod
-            def from_pretrained(*args, **kwargs):
+            def from_dict(*args, **kwargs):
                 return object()
 
         class FakeModel(nn.Module):
@@ -261,7 +264,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         class FakeAutoModel:
             @staticmethod
-            def from_config(config, trust_remote_code=True):
+            def from_config(config):
                 return FakeModel()
 
         class NoOpContext:
@@ -272,7 +275,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
                 return False
 
         try:
-            ideogram4_utils.AutoConfig = FakeConfig
+            ideogram4_utils.Qwen3VLConfig = FakeConfig
             ideogram4_utils.AutoModel = FakeAutoModel
             ideogram4_utils.validate_local_safetensors = lambda path: {}
             ideogram4_utils._load_state_dict = lambda path, device="cpu", disable_mmap=False: {
@@ -287,7 +290,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
                 dtype=torch.float32,
             )
         finally:
-            ideogram4_utils.AutoConfig = original_config
+            ideogram4_utils.Qwen3VLConfig = original_config
             ideogram4_utils.AutoModel = original_model
             ideogram4_utils.validate_local_safetensors = original_validate
             ideogram4_utils._load_state_dict = original_load_state_dict
@@ -665,7 +668,10 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
         self.assertEqual(args.lora_weight, ["a.safetensors", "b.safetensors"])
         self.assertEqual(args.lora_multiplier, [0.8, 1.0])
 
-    def test_process_batch_uses_common_timestep_sampler_with_normalized_model_latents(self):
+    def test_scale_shift_latents_normalizes_and_compute_loss_reports_metrics(self):
+        # process_batch is now the shared base trainer's; Ideogram 4 only overrides the
+        # scale_shift_latents (latent normalization) and compute_loss (mean MSE + diagnostics)
+        # hooks, so verify those directly instead of the old monolithic process_batch.
         original_image_video = sys.modules.get("musubi_tuner.dataset.image_video_dataset")
         original_sampling = sys.modules.get("musubi_tuner.training.sampling_prompts")
         original_trainer = sys.modules.get("musubi_tuner.training.trainer_base")
@@ -702,46 +708,25 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
             ideogram4_train_network = importlib.import_module("musubi_tuner.ideogram4_train_network")
 
             trainer = ideogram4_train_network.Ideogram4NetworkTrainer()
-            captured = {}
 
-            def fake_get_timesteps(args, noise, latents, timesteps, noise_scheduler, device, dtype):
-                captured["sampler_args"] = args
-                captured["sampler_timesteps"] = timesteps
-                captured["sampler_noise_scheduler"] = noise_scheduler
-                captured["sampler_device"] = device
-                captured["sampler_dtype"] = dtype
-                t = torch.full((latents.shape[0],), 0.25, device=device, dtype=dtype)
-                noisy_model_input = (1.0 - t.view(-1, 1, 1, 1)) * latents + t.view(-1, 1, 1, 1) * noise
-                return noisy_model_input, t * 1000.0 + 1.0
+            # scale_shift_latents transforms raw VAE latents into the model's normalized token-grid space.
+            latents = torch.linspace(-1.0, 1.0, 128 * 2 * 3, dtype=torch.float32).reshape(1, 128, 2, 3)
+            normalized = trainer.scale_shift_latents(latents)
+            self.assertTrue(torch.allclose(normalized, ideogram4_utils.normalize_token_grid(latents)))
 
-            def fake_call(args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype):
-                captured["latents"] = latents.detach().clone()
-                captured["noise"] = noise.detach().clone()
-                captured["noisy_model_input"] = noisy_model_input.detach().clone()
-                captured["timesteps"] = timesteps.detach().clone()
-                target = latents - noise
-                return DiTOutput(pred=target, target=target)
-
-            trainer.get_noisy_model_input_and_timesteps = fake_get_timesteps
-            trainer.call_dit = fake_call
-
-            latents = torch.linspace(-1.0, 1.0, 128 * 32 * 40, dtype=torch.float32).reshape(1, 128, 32, 40)
-            args = SimpleNamespace(timestep_sampling="uniform", log_loss_stats=True)
-            noise_scheduler = object()
-            batch_timesteps = [0.25]
-            loss, metrics = trainer.process_batch(
+            # compute_loss: plain mean MSE in velocity space; with pred == target loss is zero and the
+            # log_loss_stats diagnostics fall out (cosine == 1, timestep mean preserved).
+            target = torch.linspace(-1.0, 1.0, 4 * 2 * 2, dtype=torch.float32).reshape(1, 4, 2, 2)
+            output = DiTOutput(pred=target.clone(), target=target.clone())
+            args = SimpleNamespace(log_loss_stats=True)
+            loss, metrics = trainer.compute_loss(
                 args,
-                SimpleNamespace(device=torch.device("cpu")),
-                transformer=None,
-                network=None,
-                batch={"i4_llm_features": [torch.zeros(1, 8)], "timesteps": batch_timesteps},
-                latents=latents,
-                noise=torch.empty_like(latents),
-                noise_scheduler=noise_scheduler,
-                dit_dtype=torch.float32,
-                network_dtype=torch.float32,
-                vae=None,
-                global_step=0,
+                output,
+                torch.full((1,), 251.0),
+                object(),  # noise_scheduler (unused)
+                torch.float32,
+                torch.float32,
+                0,
             )
         finally:
             if original_module is not None:
@@ -761,16 +746,6 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
             else:
                 sys.modules.pop("musubi_tuner.training.trainer_base", None)
 
-        self.assertIs(captured["sampler_args"], args)
-        self.assertIs(captured["sampler_timesteps"], batch_timesteps)
-        self.assertIs(captured["sampler_noise_scheduler"], noise_scheduler)
-        self.assertEqual(captured["sampler_device"], torch.device("cpu"))
-        self.assertEqual(captured["sampler_dtype"], torch.float32)
-        expected_latents = ideogram4_utils.normalize_token_grid(latents)
-        self.assertTrue(torch.allclose(captured["latents"], expected_latents))
-        expected_noisy = 0.75 * expected_latents + 0.25 * captured["noise"]
-        self.assertTrue(torch.allclose(captured["noisy_model_input"], expected_noisy))
-        self.assertTrue(torch.equal(captured["timesteps"], torch.full((1,), 251.0)))
         self.assertEqual(float(loss.item()), 0.0)
         self.assertGreater(metrics["loss/zero_pred"], 0.0)
         self.assertGreater(metrics["loss/flipped_pred"], 0.0)


### PR DESCRIPTION
This pull request significantly expands and refines the documentation for Ideogram 4 in the Musubi Tuner framework, providing comprehensive bilingual (English/Japanese) instructions for all key workflows: model setup, caption formatting, pre-caching, training, and inference. It also makes several minor code cleanups and improvements to utility functions, particularly around dtype handling and code clarity.

**Documentation improvements:**

* The `docs/ideogram4.md` file is fully rewritten and greatly expanded, now covering all major aspects of using Ideogram 4, including: model/component requirements, caption structure and validation, latent/text pre-caching, LoRA training and memory optimization, and inference. All sections are provided in both English and Japanese, and new details are included for CLI arguments, workflow caveats, and integration notes. [[1]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL1-R84) [[2]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL36-R106) [[3]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL50-R139) [[4]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eR149-R203) [[5]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL125-R290)

**Codebase maintenance and improvements:**

* Removes unused quantization code and constants from `ideogram4_quantized_loading.py`, such as the `quantize_weight_to_fp8` function and the `FP8_E4M3_MAX` constant, as these are no longer needed. [[1]](diffhunk://#diff-5973e944e62101fd07c93e250ddb3a14bb4780efde61084576f5afa5cafee63dL34-L36) [[2]](diffhunk://#diff-5973e944e62101fd07c93e250ddb3a14bb4780efde61084576f5afa5cafee63dL159-L175)
* Cleans up utility functions in `ideogram4_utils.py`:
  - Removes the redundant `build_unconditional_sequence_inputs` function, consolidating logic to use the existing `build_sequence_inputs_from_features`. [[1]](diffhunk://#diff-725ef54d5e3e276214bc3f545399b95bf789c9573bc5a73660400c12423ecf74L530-L542) [[2]](diffhunk://#diff-725ef54d5e3e276214bc3f545399b95bf789c9573bc5a73660400c12423ecf74L666-R654)
  - Refactors normalization/denormalization to pass device/dtype directly to `get_latent_norm`, improving clarity and efficiency.

These changes make the documentation much more accessible and actionable for both English and Japanese users, while the code cleanups help reduce redundancy and potential confusion in the utilities.

**References:**
- Documentation: [[1]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL1-R84) [[2]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL36-R106) [[3]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL50-R139) [[4]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eR149-R203) [[5]](diffhunk://#diff-58b63f0d51f1a53c792df91c2a874836558133c9e5389fb5feaa90c2b650186eL125-R290)
- Quantization code cleanup: [[1]](diffhunk://#diff-5973e944e62101fd07c93e250ddb3a14bb4780efde61084576f5afa5cafee63dL34-L36) [[2]](diffhunk://#diff-5973e944e62101fd07c93e250ddb3a14bb4780efde61084576f5afa5cafee63dL159-L175)
- Utility function cleanup: [[1]](diffhunk://#diff-725ef54d5e3e276214bc3f545399b95bf789c9573bc5a73660400c12423ecf74L530-L542) [[2]](diffhunk://#diff-725ef54d5e3e276214bc3f545399b95bf789c9573bc5a73660400c12423ecf74L584-R578) [[3]](diffhunk://#diff-725ef54d5e3e276214bc3f545399b95bf789c9573bc5a73660400c12423ecf74L666-R654)