### PR TITLE
Add cu132 optional dependency extra for PyTorch with CUDA 13.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ cu130 = [
     "torch>=2.9.1",
     "torchvision>=0.24.1",
 ]
+cu132 = [
+    "torch>=2.12.0",
+    "torchvision>=0.27.0",
+]
 gui = [
     "gradio>=4.0.0, <6.0.0",
 ]
@@ -52,6 +56,7 @@ conflicts = [
     { extra = "cu124" },
     { extra = "cu128" },
     { extra = "cu130" },
+    { extra = "cu132" },
   ],
 ]
 
@@ -73,11 +78,13 @@ torch = [
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
   { index = "pytorch-cu130", extra = "cu130" },
+  { index = "pytorch-cu132", extra = "cu132" },
 ]
 torchvision = [
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
   { index = "pytorch-cu130", extra = "cu130" },
+  { index = "pytorch-cu132", extra = "cu132" },
 ]
 
 [[tool.uv.index]]
@@ -93,6 +100,11 @@ explicit = true
 [[tool.uv.index]]
 name = "pytorch-cu130"
 url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu132"
+url = "https://download.pytorch.org/whl/cu132"
 explicit = true
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

Adds a `cu132` optional dependency extra for installing PyTorch built against CUDA 13.2, following the existing `cu124`/`cu128`/`cu130` pattern:

- `[project.optional-dependencies]` group with `torch>=2.12.0` and `torchvision>=0.27.0` (the versions published on the cu132 index)
- entry in the `[tool.uv]` conflicts list
- `[tool.uv.sources]` index mappings for torch/torchvision
- `pytorch-cu132` index (`https://download.pytorch.org/whl/cu132`, explicit)

## Verification

- `uv lock` resolves cleanly (176 packages) with the new extra/conflict in place
- Confirmed `torch-2.12.0+cu132`/`2.12.1+cu132` and `torchvision-0.27.0+cu132`/`0.27.1+cu132` exist on the index

AI-assisted