### PR TITLE
feat: add --log_grad_metrics for pre-clip gradient norm logging

### DIFF
--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -253,6 +253,13 @@ def _add_logging_args(parser: argparse.ArgumentParser) -> None:
         help="specify WandB API key to log in before starting training (optional). / WandB APIキーを指定して学習開始前にログインする（オプション）",
     )
     parser.add_argument("--log_config", action="store_true", help="log training configuration / 学習設定をログに出力する")
+    parser.add_argument(
+        "--log_grad_metrics",
+        action="store_true",
+        help="log gradient norm metrics (grad/norm, grad/mean_norm, grad/max, pre-clipping) to the tracker."
+        " Adds a small per-step GPU sync overhead"
+        " / 勾配ノルムのメトリクス（grad/norm, grad/mean_norm, grad/max、クリッピング前）をトラッカーに出力する。ステップごとにわずかなGPU同期のオーバーヘッドが発生する",
+    )
 
 
 def _add_ddp_args(parser: argparse.ArgumentParser) -> None:

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -160,6 +160,26 @@ class NetworkTrainer:
 
         return logs
 
+    def collect_grad_metrics(self, params) -> dict:
+        """Collect gradient diagnostics for logging.
+
+        Returns grad/norm (total L2, pre-clip), grad/mean_norm (mean of per-parameter
+        L2 norms) and grad/max (max absolute element).
+        Returns empty dict if no parameters have gradients.
+        """
+        grads = [p.grad.detach() for p in params if p.grad is not None]
+        if not grads:
+            return {}
+        per_norm = torch.stack([g.norm() for g in grads])
+        total_norm = per_norm.norm()
+        mean_norm = per_norm.mean()
+        max_grad = torch.stack([g.abs().max() for g in grads]).max()
+        return {
+            "grad/norm": total_norm.item(),
+            "grad/mean_norm": mean_norm.item(),
+            "grad/max": max_grad.item(),
+        }
+
     def get_optimizer(self, args, trainable_params: list[torch.nn.Parameter]) -> tuple[str, str, torch.optim.Optimizer]:
         # adamw, adamw8bit, adafactor
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -2073,6 +2073,7 @@ class NetworkTrainer:
                         global_step,
                     )
 
+                    grad_metrics = {}
                     accelerator.backward(loss)
                     if accelerator.sync_gradients:
                         # self.all_reduce_network(accelerator, network)  # sync DDP grad manually
@@ -2081,6 +2082,9 @@ class NetworkTrainer:
                             for param in network.parameters():
                                 if param.grad is not None:
                                     param.grad = accelerator.reduce(param.grad, reduction="mean")
+
+                        if args.log_grad_metrics and len(accelerator.trackers) > 0:
+                            grad_metrics = self.collect_grad_metrics(network.parameters())
 
                         if args.max_grad_norm != 0.0:
                             params_to_clip = accelerator.unwrap_model(network).get_trainable_params()
@@ -2145,6 +2149,7 @@ class NetworkTrainer:
                         args, current_loss, avr_loss, lr_scheduler, lr_descriptions, optimizer, keys_scaled, mean_norm, maximum_norm
                     )
                     logs.update(loss_metrics)
+                    logs.update(grad_metrics)
                     logs.update(self.extra_step_logs(args, logs))
                     accelerator.log(logs, step=global_step)
 

--- a/tests/test_grad_metrics.py
+++ b/tests/test_grad_metrics.py
@@ -82,3 +82,14 @@ def test_skips_params_without_grad(trainer):
     metrics = trainer.collect_grad_metrics([p_with, p_without])
     assert metrics["grad/norm"] == pytest.approx(5.0)
     assert metrics["grad/max"] == pytest.approx(4.0)
+
+
+def test_log_grad_metrics_flag_default_off():
+    """--log_grad_metrics exists in the common parser and defaults to False."""
+    from musubi_tuner.training.parser_common import setup_parser_common
+
+    parser = setup_parser_common()
+    args, _ = parser.parse_known_args([])
+    assert args.log_grad_metrics is False
+    args, _ = parser.parse_known_args(["--log_grad_metrics"])
+    assert args.log_grad_metrics is True

--- a/tests/test_grad_metrics.py
+++ b/tests/test_grad_metrics.py
@@ -1,0 +1,84 @@
+"""Tests for gradient metrics collection (grad/norm, grad/mean_norm, grad/max)."""
+
+import torch
+import torch.nn as nn
+import pytest
+
+from musubi_tuner.training.trainer_base import NetworkTrainer
+
+
+@pytest.fixture
+def trainer():
+    return NetworkTrainer()
+
+
+def _params_with_grads(values: list[list[float]]) -> list[nn.Parameter]:
+    """Create parameters with fixed gradient values for testing."""
+    params = []
+    for vals in values:
+        p = nn.Parameter(torch.zeros(len(vals)))
+        p.grad = torch.tensor(vals)
+        params.append(p)
+    return params
+
+
+def test_grad_norm_single_param(trainer):
+    """L2 norm of a single parameter's gradient is computed correctly."""
+    # grads = [3, 4] → norm = 5
+    params = _params_with_grads([[3.0, 4.0]])
+    metrics = trainer.collect_grad_metrics(params)
+    assert metrics["grad/norm"] == pytest.approx(5.0)
+
+
+def test_grad_norm_multiple_params(trainer):
+    """Total L2 norm across multiple parameters matches torch.nn.utils.clip_grad_norm_."""
+    params = _params_with_grads([[1.0, 0.0], [0.0, 1.0]])
+    metrics = trainer.collect_grad_metrics(params)
+    # norm of [1,0,0,1] = sqrt(2)
+    assert metrics["grad/norm"] == pytest.approx(2.0**0.5, rel=1e-5)
+
+
+def test_grad_max_single_param(trainer):
+    """Max absolute gradient value is the largest element."""
+    params = _params_with_grads([[-5.0, 2.0, 1.0]])
+    metrics = trainer.collect_grad_metrics(params)
+    assert metrics["grad/max"] == pytest.approx(5.0)
+
+
+def test_grad_max_across_params(trainer):
+    """Max absolute gradient value is found across all parameters."""
+    params = _params_with_grads([[1.0, 2.0], [3.0, -9.0]])
+    metrics = trainer.collect_grad_metrics(params)
+    assert metrics["grad/max"] == pytest.approx(9.0)
+
+
+def test_empty_metrics_when_no_grads(trainer):
+    """Returns empty dict when no parameters have gradients."""
+    params = [nn.Parameter(torch.zeros(4))]  # grad is None
+    metrics = trainer.collect_grad_metrics(params)
+    assert metrics == {}
+
+
+def test_grad_mean_norm_single_param(trainer):
+    """Mean norm with one param equals its own norm."""
+    params = _params_with_grads([[3.0, 4.0]])
+    metrics = trainer.collect_grad_metrics(params)
+    assert metrics["grad/mean_norm"] == pytest.approx(5.0)
+
+
+def test_grad_mean_norm_multiple_params(trainer):
+    """Mean norm is the average of per-parameter norms, not the total norm."""
+    # param0 norm = 5, param1 norm = 5, mean = 5
+    params = _params_with_grads([[3.0, 4.0], [4.0, 3.0]])
+    metrics = trainer.collect_grad_metrics(params)
+    assert metrics["grad/mean_norm"] == pytest.approx(5.0)
+
+
+def test_skips_params_without_grad(trainer):
+    """Parameters without .grad set are excluded from the computation."""
+    p_with = nn.Parameter(torch.zeros(2))
+    p_with.grad = torch.tensor([3.0, 4.0])
+    p_without = nn.Parameter(torch.zeros(2))  # no grad
+    metrics = trainer.collect_grad_metrics([p_with, p_without])
+    assert metrics["grad/norm"] == pytest.approx(5.0)
+    assert metrics["grad/max"] == pytest.approx(4.0)


### PR DESCRIPTION
## Summary

Adds an opt-in `--log_grad_metrics` flag that logs gradient diagnostics to the tracker (TensorBoard/WandB) each optimizer step, for all `*_train_network.py` trainers via `NetworkTrainer`:

- `grad/norm` — total L2 norm across all network gradients (**pre-clipping**, so it shows what `--max_grad_norm` is actually fighting)
- `grad/mean_norm` — mean of per-parameter L2 norms
- `grad/max` — max absolute gradient element

Useful for spotting gradient explosions/vanishing and for choosing a sensible `--max_grad_norm` value.

## Implementation notes

- Computed after `accelerator.backward()` and the manual DDP grad reduce, before `accelerator.clip_grad_norm_`, so the logged norm is the true pre-clip value.
- Metrics are emitted only on gradient-sync steps (i.e. actual optimizer updates, gradient-accumulation aware); accumulation micro-steps log nothing.
- Default **off**: the `.item()` calls force a GPU sync per step, so the flag is opt-in and additionally gated on an active tracker (`len(accelerator.trackers) > 0`). With the flag off there is no behavior or performance change.
- No per-trainer changes — everything lives in `training/trainer_base.py` and `training/parser_common.py`.

## Tests

`tests/test_grad_metrics.py`: 9 pure-CPU tests covering the norm math (single/multi-param total norm, mean-vs-total distinction, max element, params without grads, empty case) and the parser flag default.

```
uv run pytest tests/  # 85 passed
```