### PR TITLE
Add custom loss function support

### DIFF
--- a/src/musubi_tuner/training/loss.py
+++ b/src/musubi_tuner/training/loss.py
@@ -21,11 +21,14 @@ import ast
 import functools
 import importlib
 import inspect
+import logging
 from typing import Any, Callable, Optional
 
 import torch
 
 from musubi_tuner.training.timesteps import compute_loss_weighting_for_sd3
+
+logger = logging.getLogger(__name__)
 
 
 def mse_loss(
@@ -79,6 +82,7 @@ def resolve_loss_fn(loss_fn: str, loss_fn_args: Optional[list[str]] = None) -> C
     ``functools.partial``.
     """
     kwargs = parse_loss_fn_args(loss_fn_args)
+    logger.info(f"use loss function {loss_fn} | {kwargs}")
 
     if "." not in loss_fn:
         try:

--- a/src/musubi_tuner/training/loss.py
+++ b/src/musubi_tuner/training/loss.py
@@ -11,8 +11,9 @@ The resolved callable has the exact signature of
 
 and returns either a bare scalar loss tensor or ``(loss, metrics_dict)``.
 Losses needing more than ``output.pred``/``output.target`` read from
-``output.extra`` (the base trainer stashes ``noisy_model_input``, ``latents``
-and ``noise`` there).
+``output.extra``; trainers that support such losses are responsible for
+stashing the required tensors there (e.g. a ``call_dit`` override stashing
+``noisy_model_input`` for x0 recovery).
 """
 
 import argparse

--- a/src/musubi_tuner/training/loss.py
+++ b/src/musubi_tuner/training/loss.py
@@ -6,10 +6,10 @@ supplies ``key=value`` construction arguments, mirroring ``--optimizer_args``.
 Values must be Python literals (strings must be quoted); non-literals raise at
 startup with a helpful error message.
 
-The resolved callable has the exact signature of
-``NetworkTrainer.compute_loss`` (minus ``self``)::
+The resolved callable is invoked with a single :class:`LossContext`::
 
-    loss_fn(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
+    loss_fn(ctx)  # ctx.args, ctx.output, ctx.timesteps, ctx.noise_scheduler,
+                  # ctx.dit_dtype, ctx.network_dtype, ctx.global_step
 
 and returns either a bare scalar loss tensor or ``(loss, metrics_dict)``.
 Losses needing more than ``output.pred``/``output.target`` read from
@@ -24,6 +24,7 @@ import functools
 import importlib
 import inspect
 import logging
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 import torch
@@ -33,18 +34,35 @@ from musubi_tuner.training.timesteps import compute_loss_weighting_for_sd3
 logger = logging.getLogger(__name__)
 
 
-def mse_loss(
-    args: argparse.Namespace,
-    output,
-    timesteps: torch.Tensor,
-    noise_scheduler,
-    dit_dtype: torch.dtype,
-    network_dtype: torch.dtype,
-    global_step: int,
-) -> tuple[torch.Tensor, dict[str, float]]:
+@dataclass
+class LossContext:
+    """Everything a pluggable ``--loss_fn`` callable receives, as one object.
+
+    Additive by design: new fields may be appended in future versions without
+    breaking existing third-party losses (unlike a positional signature).
+    ``output`` is the trainer's ``DiTOutput`` (``.pred`` / ``.target`` /
+    ``.extra``) — typed ``Any`` because ``trainer_base`` imports this module,
+    so importing ``DiTOutput`` here would be circular. ``output.extra`` is the
+    trainer→loss escape hatch for tensors only specific trainers provide
+    (e.g. ``noisy_model_input`` for x0 recovery); the fields here are values
+    every trainer can supply.
+    """
+
+    args: argparse.Namespace
+    output: Any
+    timesteps: torch.Tensor
+    noise_scheduler: Any
+    dit_dtype: torch.dtype
+    network_dtype: torch.dtype
+    global_step: int
+
+
+def mse_loss(ctx: LossContext) -> tuple[torch.Tensor, dict[str, float]]:
     """Default weighted MSE: SD3-style ``args.weighting_scheme``, then mean."""
-    weighting = compute_loss_weighting_for_sd3(args.weighting_scheme, noise_scheduler, timesteps, timesteps.device, dit_dtype)
-    loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
+    weighting = compute_loss_weighting_for_sd3(
+        ctx.args.weighting_scheme, ctx.noise_scheduler, ctx.timesteps, ctx.timesteps.device, ctx.dit_dtype
+    )
+    loss = torch.nn.functional.mse_loss(ctx.output.pred.to(ctx.network_dtype), ctx.output.target, reduction="none")
     if weighting is not None:
         loss = loss * weighting
     return loss.mean(), {}
@@ -82,7 +100,7 @@ def parse_loss_fn_args(loss_fn_args: Optional[list[str]]) -> dict[str, Any]:
 
 
 def resolve_loss_fn(loss_fn: str, loss_fn_args: Optional[list[str]] = None) -> Callable:
-    """Resolve ``--loss_fn`` to a callable with the ``compute_loss`` signature.
+    """Resolve ``--loss_fn`` to a callable invoked as ``loss_fn(ctx: LossContext)``.
 
     No dot: look up ``BUILTIN_LOSS_FNS``. Dotted path: import the module and
     fetch the attribute (same pattern as ``get_optimizer``). Classes are

--- a/src/musubi_tuner/training/loss.py
+++ b/src/musubi_tuner/training/loss.py
@@ -132,6 +132,10 @@ def resolve_loss_fn(loss_fn: str, loss_fn_args: Optional[list[str]] = None) -> C
     if inspect.isclass(fn):
         return fn(**kwargs)
     if kwargs:
+        try:
+            inspect.signature(fn).bind_partial(**kwargs)
+        except TypeError as e:
+            raise ValueError(f"--loss_fn_args do not match the parameters of --loss_fn {loss_fn!r}: {e}") from None
         return functools.partial(fn, **kwargs)
     return fn
 

--- a/src/musubi_tuner/training/loss.py
+++ b/src/musubi_tuner/training/loss.py
@@ -1,0 +1,113 @@
+"""Pluggable loss functions for network trainers.
+
+``--loss_fn`` selects the loss the same way ``--optimizer_type`` selects the
+optimizer: a built-in name (no dot) or a dotted import path. ``--loss_fn_args``
+supplies ``key=value`` construction arguments, mirroring ``--optimizer_args``.
+
+The resolved callable has the exact signature of
+``NetworkTrainer.compute_loss`` (minus ``self``)::
+
+    loss_fn(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
+
+and returns either a bare scalar loss tensor or ``(loss, metrics_dict)``.
+Losses needing more than ``output.pred``/``output.target`` read from
+``output.extra`` (the base trainer stashes ``noisy_model_input``, ``latents``
+and ``noise`` there).
+"""
+
+import argparse
+import ast
+import functools
+import importlib
+import inspect
+from typing import Any, Callable, Optional
+
+import torch
+
+from musubi_tuner.training.timesteps import compute_loss_weighting_for_sd3
+
+
+def mse_loss(
+    args: argparse.Namespace,
+    output,
+    timesteps: torch.Tensor,
+    noise_scheduler,
+    dit_dtype: torch.dtype,
+    network_dtype: torch.dtype,
+    global_step: int,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Default weighted MSE: SD3-style ``args.weighting_scheme``, then mean."""
+    weighting = compute_loss_weighting_for_sd3(args.weighting_scheme, noise_scheduler, timesteps, timesteps.device, dit_dtype)
+    loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
+    if weighting is not None:
+        loss = loss * weighting
+    return loss.mean(), {}
+
+
+BUILTIN_LOSS_FNS: dict[str, Callable] = {
+    "mse": mse_loss,
+}
+
+
+def parse_loss_fn_args(loss_fn_args: Optional[list[str]]) -> dict[str, Any]:
+    """Parse ``key=value`` strings; literal values via ast, else raw string.
+
+    Unlike ``optimizer_args``, non-literal values (``transform=swt``) are kept
+    as strings instead of raising, matching ``network_args`` ergonomics.
+    """
+    kwargs: dict[str, Any] = {}
+    if not loss_fn_args:
+        return kwargs
+    for arg in loss_fn_args:
+        if "=" not in arg:
+            raise ValueError(f"--loss_fn_args entry {arg!r} is not in key=value form")
+        key, value = arg.split("=", 1)
+        try:
+            kwargs[key] = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            kwargs[key] = value
+    return kwargs
+
+
+def resolve_loss_fn(loss_fn: str, loss_fn_args: Optional[list[str]] = None) -> Callable:
+    """Resolve ``--loss_fn`` to a callable with the ``compute_loss`` signature.
+
+    No dot: look up ``BUILTIN_LOSS_FNS``. Dotted path: import the module and
+    fetch the attribute (same pattern as ``get_optimizer``). Classes are
+    instantiated with the parsed kwargs; plain functions get them bound via
+    ``functools.partial``.
+    """
+    kwargs = parse_loss_fn_args(loss_fn_args)
+
+    if "." not in loss_fn:
+        try:
+            fn = BUILTIN_LOSS_FNS[loss_fn]
+        except KeyError:
+            raise ValueError(
+                f"unknown built-in --loss_fn {loss_fn!r}; built-ins: {sorted(BUILTIN_LOSS_FNS)}."
+                " Use a dotted import path (e.g. my_pkg.losses.MyLoss) for external losses."
+            ) from None
+    else:
+        module_path, _, attr_name = loss_fn.rpartition(".")
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as e:
+            raise ImportError(f"--loss_fn {loss_fn!r}: could not import module {module_path!r}: {e}") from e
+        try:
+            fn = getattr(module, attr_name)
+        except AttributeError:
+            raise ImportError(f"--loss_fn {loss_fn!r}: module {module_path!r} has no attribute {attr_name!r}") from None
+
+    if inspect.isclass(fn):
+        return fn(**kwargs)
+    if kwargs:
+        return functools.partial(fn, **kwargs)
+    return fn
+
+
+def normalize_loss_output(result) -> tuple[torch.Tensor, dict[str, float]]:
+    """Accept a bare loss tensor or ``(loss, metrics)``; return ``(loss, dict)``."""
+    if isinstance(result, tuple):
+        loss, metrics = result
+        return loss, dict(metrics)
+    return result, {}

--- a/src/musubi_tuner/training/loss.py
+++ b/src/musubi_tuner/training/loss.py
@@ -3,6 +3,8 @@
 ``--loss_fn`` selects the loss the same way ``--optimizer_type`` selects the
 optimizer: a built-in name (no dot) or a dotted import path. ``--loss_fn_args``
 supplies ``key=value`` construction arguments, mirroring ``--optimizer_args``.
+Values must be Python literals (strings must be quoted); non-literals raise at
+startup with a helpful error message.
 
 The resolved callable has the exact signature of
 ``NetworkTrainer.compute_loss`` (minus ``self``)::
@@ -54,10 +56,13 @@ BUILTIN_LOSS_FNS: dict[str, Callable] = {
 
 
 def parse_loss_fn_args(loss_fn_args: Optional[list[str]]) -> dict[str, Any]:
-    """Parse ``key=value`` strings; literal values via ast, else raw string.
+    """Parse ``key=value`` strings into kwargs via ``ast.literal_eval``.
 
-    Unlike ``optimizer_args``, non-literal values (``transform=swt``) are kept
-    as strings instead of raising, matching ``network_args`` ergonomics.
+    Values must be Python literals (numbers, bools, quoted strings,
+    dicts/lists/tuples), matching ``--optimizer_args`` semantics. Loss
+    functions are third-party code with unknown schemas, so a non-literal
+    value raises at startup with a quoting hint instead of silently falling
+    back to a raw string (which would mask typos like ``alpha=0.1.``).
     """
     kwargs: dict[str, Any] = {}
     if not loss_fn_args:
@@ -69,7 +74,10 @@ def parse_loss_fn_args(loss_fn_args: Optional[list[str]]) -> dict[str, Any]:
         try:
             kwargs[key] = ast.literal_eval(value)
         except (ValueError, SyntaxError):
-            kwargs[key] = value
+            raise ValueError(
+                f"--loss_fn_args entry {arg!r}: value {value!r} is not a Python literal."
+                f" If you meant a string, quote it: \"{key}='{value}'\""
+            ) from None
     return kwargs
 
 

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -329,6 +329,25 @@ def _add_optimizer_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_loss_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--loss_fn",
+        type=str,
+        default="mse",
+        help="Loss function to use: mse (default), or a dotted import path to a class or function"
+        " with the compute_loss signature, like 'wavelet_loss.musubi.WaveletPlusMSE'"
+        " / 損失関数: mse（デフォルト）、または compute_loss と同じシグネチャを持つクラス/関数へのドットパス",
+    )
+    parser.add_argument(
+        "--loss_fn_args",
+        type=str,
+        default=None,
+        nargs="*",
+        help='additional arguments for the loss function (like "alpha=0.1 transform=swt ...")'
+        ' / 損失関数の追加引数（例："alpha=0.1 transform=swt ..."）',
+    )
+
+
 def _add_lr_scheduler_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--lr_scheduler",
@@ -773,6 +792,7 @@ def setup_parser_common() -> argparse.ArgumentParser:
     _add_ddp_args(parser)
     _add_sampling_args(parser)
     _add_optimizer_args(parser)
+    _add_loss_args(parser)
     _add_lr_scheduler_args(parser)
     _add_memory_args(parser)
     _add_timestep_args(parser)

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -335,8 +335,8 @@ def _add_loss_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         default="mse",
         help="Loss function to use: mse (default), or a dotted import path to a class or function"
-        " with the compute_loss signature, like 'wavelet_loss.musubi.WaveletPlusMSE'"
-        " / 損失関数: mse（デフォルト）、または compute_loss と同じシグネチャを持つクラス/関数へのドットパス",
+        " invoked with a single LossContext, like 'wavelet_loss.musubi.WaveletPlusMSE'"
+        " / 損失関数: mse（デフォルト）、または LossContext を受け取るクラス/関数へのドットパス",
     )
     parser.add_argument(
         "--loss_fn_args",

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -344,8 +344,8 @@ def _add_loss_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         nargs="*",
         help="additional key=value arguments for the loss function; values must be Python literals,"
-        " strings need quotes (like \"alpha=0.1\" \"transform='swt'\" \"band_weights={'ll0': 1.0}\")"
-        " / 損失関数の追加引数（値はPythonリテラル。文字列は引用符が必要。例：\"alpha=0.1\" \"transform='swt'\"）",
+        ' strings need quotes (like "alpha=0.1" "transform=\'swt\'" "band_weights={\'ll0\': 1.0}")'
+        ' / 損失関数の追加引数（値はPythonリテラル。文字列は引用符が必要。例："alpha=0.1" "transform=\'swt\'"）',
     )
 
 

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -343,8 +343,9 @@ def _add_loss_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         default=None,
         nargs="*",
-        help='additional arguments for the loss function (like "alpha=0.1 transform=swt ...")'
-        ' / 損失関数の追加引数（例："alpha=0.1 transform=swt ..."）',
+        help="additional key=value arguments for the loss function; values must be Python literals,"
+        " strings need quotes (like \"alpha=0.1\" \"transform='swt'\" \"band_weights={'ll0': 1.0}\")"
+        " / 損失関数の追加引数（値はPythonリテラル。文字列は引用符が必要。例：\"alpha=0.1\" \"transform='swt'\"）",
     )
 
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1209,6 +1209,8 @@ class NetworkTrainer:
         (e.g. ``{"loss/gen": ..., "loss/rep": ...}``).
         """
         if self._resolved_loss_fn is None:
+            # defensive fallback for direct calls (unit tests); real runs resolve
+            # eagerly in _validate_args_and_init so bad --loss_fn fails at startup
             self._resolved_loss_fn = resolve_loss_fn(args.loss_fn, args.loss_fn_args)
         if isinstance(self._resolved_loss_fn, torch.nn.Module):
             # one-time device move for losses with buffers/submodules; no-op afterwards

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -57,6 +57,7 @@ from musubi_tuner.training.accelerator_setup import (
     collator_class,
     prepare_accelerator,
 )
+from musubi_tuner.training.loss import normalize_loss_output, resolve_loss_fn
 from musubi_tuner.training.sampling_prompts import should_sample_images
 from musubi_tuner.training.timesteps import (
     compute_density_for_timestep_sampling,
@@ -106,6 +107,7 @@ class NetworkTrainer:
         self.num_timestep_buckets: Optional[int] = None  # for get_bucketed_timestep()
         self.vae_frame_stride = 4  # all architectures require frames to be divisible by 4, except Qwen-Image-Layered
         self.default_discrete_flow_shift = 14.5  # default value for discrete flow shift for all models TODO may be None is better
+        self._resolved_loss_fn = None  # resolved --loss_fn callable, set at startup
 
     # TODO 他のスクリプトと共通化する
     def generate_step_logs(
@@ -1172,6 +1174,10 @@ class NetworkTrainer:
         )
 
         output = self.call_dit(args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype)
+        # standard extras for pluggable losses (x0 recovery, model-dynamics terms)
+        output.extra.setdefault("noisy_model_input", noisy_model_input)
+        output.extra.setdefault("latents", latents)
+        output.extra.setdefault("noise", noise)
         return self.compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
 
     def compute_loss(
@@ -1186,24 +1192,27 @@ class NetworkTrainer:
     ) -> tuple[torch.Tensor, dict[str, float]]:
         """Reduce a ``DiTOutput`` to a scalar loss + per-step metrics dict.
 
-        Default implementation: weighted MSE between ``output.pred`` and
-        ``output.target`` with the SD3-style ``args.weighting_scheme`` applied,
-        then ``.mean()``. Override to swap the loss formulation entirely
-        (e.g. Self-Flow's L_gen + gamma * L_rep) or to add auxiliary terms
-        (e.g. HiDream-O1's step-gated DINO perceptual loss). Subclasses are
-        responsible for whatever weighting/reduction they need — this hook owns
-        the full loss computation, not just the per-element MSE.
+        Default implementation: delegates to the callable resolved from
+        ``--loss_fn`` (default ``"mse"``: weighted MSE between ``output.pred``
+        and ``output.target`` with the SD3-style ``args.weighting_scheme``
+        applied, then ``.mean()``). Override to swap the loss formulation
+        entirely (e.g. Self-Flow's L_gen + gamma * L_rep) or to add auxiliary
+        terms (e.g. HiDream-O1's step-gated DINO perceptual loss). Subclasses
+        are responsible for whatever weighting/reduction they need — this hook
+        owns the full loss computation, not just the per-element MSE.
 
         ``global_step`` is provided for step-gated terms (e.g. computing an
         auxiliary loss only every N steps). ``loss_metrics`` defaults to empty;
         populate with named scalars for loss-decomposition logging
         (e.g. ``{"loss/gen": ..., "loss/rep": ...}``).
         """
-        weighting = compute_loss_weighting_for_sd3(args.weighting_scheme, noise_scheduler, timesteps, timesteps.device, dit_dtype)
-        loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
-        if weighting is not None:
-            loss = loss * weighting
-        return loss.mean(), {}
+        if self._resolved_loss_fn is None:
+            self._resolved_loss_fn = resolve_loss_fn(args.loss_fn, args.loss_fn_args)
+        if isinstance(self._resolved_loss_fn, torch.nn.Module):
+            # one-time device move for losses with buffers/submodules; no-op afterwards
+            self._resolved_loss_fn.to(output.pred.device)
+        result = self._resolved_loss_fn(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
+        return normalize_loss_output(result)
 
     def on_transformer_loaded(
         self,
@@ -1396,6 +1405,14 @@ class NetworkTrainer:
             network_dtype,
         )
 
+    def _resolve_loss_fn_from_args(self, args) -> None:
+        """Resolve ``args.loss_fn``/``args.loss_fn_args`` and cache on ``self``.
+
+        Called eagerly from ``_validate_args_and_init`` so a bad ``--loss_fn``
+        config fails fast at startup, before models load.
+        """
+        self._resolved_loss_fn = resolve_loss_fn(args.loss_fn, args.loss_fn_args)
+
     def _validate_args_and_init(self, args) -> bool:
         """Validate required args, configure CUDA flags, handle `--show_timesteps`.
 
@@ -1416,6 +1433,9 @@ class NetworkTrainer:
         if args.dit is None:
             raise ValueError("path to DiT model is required / DiTモデルのパスが必要です")
         assert not args.fp8_scaled or args.fp8_base, "fp8_scaled requires fp8_base / fp8_scaledはfp8_baseが必要です"
+
+        # resolve --loss_fn eagerly so bad config fails before models load
+        self._resolve_loss_fn_from_args(args)
 
         if args.sage_attn:
             raise ValueError(

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1176,10 +1176,6 @@ class NetworkTrainer:
         )
 
         output = self.call_dit(args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype)
-        # standard extras for pluggable losses (x0 recovery, model-dynamics terms)
-        output.extra.setdefault("noisy_model_input", noisy_model_input)
-        output.extra.setdefault("latents", latents)
-        output.extra.setdefault("noise", noise)
         return self.compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
 
     def compute_loss(

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -57,7 +57,7 @@ from musubi_tuner.training.accelerator_setup import (
     collator_class,
     prepare_accelerator,
 )
-from musubi_tuner.training.loss import normalize_loss_output, resolve_loss_fn
+from musubi_tuner.training.loss import LossContext, normalize_loss_output, resolve_loss_fn
 from musubi_tuner.training.sampling_prompts import should_sample_images
 from musubi_tuner.training.timesteps import (
     compute_density_for_timestep_sampling,
@@ -1191,10 +1191,11 @@ class NetworkTrainer:
         """Reduce a ``DiTOutput`` to a scalar loss + per-step metrics dict.
 
         Default implementation: delegates to the callable resolved from
-        ``--loss_fn`` (default ``"mse"``: weighted MSE between ``output.pred``
-        and ``output.target`` with the SD3-style ``args.weighting_scheme``
-        applied, then ``.mean()``). Override to swap the loss formulation
-        entirely (e.g. Self-Flow's L_gen + gamma * L_rep) or to add auxiliary
+        ``--loss_fn`` (invoked with a single ``LossContext`` carrying these
+        same parameters), default ``"mse"``: weighted MSE between
+        ``output.pred`` and ``output.target`` with the SD3-style
+        ``args.weighting_scheme`` applied, then ``.mean()``. Override to swap
+        the loss formulation entirely (e.g. Self-Flow's L_gen + gamma * L_rep) or to add auxiliary
         terms (e.g. HiDream-O1's step-gated DINO perceptual loss). Subclasses
         are responsible for whatever weighting/reduction they need — this hook
         owns the full loss computation, not just the per-element MSE.
@@ -1211,7 +1212,16 @@ class NetworkTrainer:
         if isinstance(self._resolved_loss_fn, torch.nn.Module):
             # one-time device move for losses with buffers/submodules; no-op afterwards
             self._resolved_loss_fn.to(output.pred.device)
-        result = self._resolved_loss_fn(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
+        ctx = LossContext(
+            args=args,
+            output=output,
+            timesteps=timesteps,
+            noise_scheduler=noise_scheduler,
+            dit_dtype=dit_dtype,
+            network_dtype=network_dtype,
+            global_step=global_step,
+        )
+        result = self._resolved_loss_fn(ctx)
         return normalize_loss_output(result)
 
     def on_transformer_loaded(

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1419,9 +1419,17 @@ class NetworkTrainer:
         """Resolve ``args.loss_fn``/``args.loss_fn_args`` and cache on ``self``.
 
         Called eagerly from ``_validate_args_and_init`` so a bad ``--loss_fn``
-        config fails fast at startup, before models load.
+        config fails fast at startup, before models load. Also warns if a
+        non-default ``--loss_fn`` was requested on a subclass that overrides
+        ``compute_loss``, since such overrides may never invoke the resolved plugin.
         """
         self._resolved_loss_fn = resolve_loss_fn(args.loss_fn, args.loss_fn_args)
+        if args.loss_fn != "mse" and type(self).compute_loss is not NetworkTrainer.compute_loss:
+            logger.warning(
+                f"--loss_fn {args.loss_fn!r} was requested, but {type(self).__name__} overrides compute_loss;"
+                " the custom loss is only used if that override routes through the default loss path"
+                " (e.g. via super().compute_loss)"
+            )
 
     def _validate_args_and_init(self, args) -> bool:
         """Validate required args, configure CUDA flags, handle `--show_timesteps`.

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -75,6 +75,8 @@ SS_METADATA_KEY_NETWORK_MODULE = "ss_network_module"
 SS_METADATA_KEY_NETWORK_DIM = "ss_network_dim"
 SS_METADATA_KEY_NETWORK_ALPHA = "ss_network_alpha"
 SS_METADATA_KEY_NETWORK_ARGS = "ss_network_args"
+SS_METADATA_KEY_LOSS_FN = "ss_loss_fn"
+SS_METADATA_KEY_LOSS_FN_ARGS = "ss_loss_fn_args"
 
 SS_METADATA_MINIMUM_KEYS = [
     SS_METADATA_KEY_BASE_MODEL_VERSION,
@@ -1913,6 +1915,10 @@ class NetworkTrainer:
         if args.network_args:
             # metadata["ss_network_args"] = json.dumps(net_kwargs)
             metadata[SS_METADATA_KEY_NETWORK_ARGS] = json.dumps(net_kwargs)
+
+        metadata[SS_METADATA_KEY_LOSS_FN] = args.loss_fn
+        if args.loss_fn_args:
+            metadata[SS_METADATA_KEY_LOSS_FN_ARGS] = json.dumps(args.loss_fn_args)
 
         # model name and hash
         # calculate hash takes time, so we omit it for now

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -151,3 +151,21 @@ def test_normalize_tuple():
     loss, metrics = normalize_loss_output((t, {"loss/aux": 0.5}))
     assert loss is t
     assert metrics == {"loss/aux": 0.5}
+
+
+# --- CLI args ---
+
+
+def test_parser_defaults_and_values():
+    from musubi_tuner.training.parser_common import setup_parser_common
+
+    parser = setup_parser_common()
+    args, _ = parser.parse_known_args([])
+    assert args.loss_fn == "mse"
+    assert args.loss_fn_args is None
+
+    args, _ = parser.parse_known_args(
+        ["--loss_fn", "wavelet_loss.musubi.WaveletPlusMSE", "--loss_fn_args", "alpha=0.1", "transform=swt"]
+    )
+    assert args.loss_fn == "wavelet_loss.musubi.WaveletPlusMSE"
+    assert args.loss_fn_args == ["alpha=0.1", "transform=swt"]

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -1,0 +1,153 @@
+"""Tests for the pluggable loss function resolver (training/loss.py)."""
+
+import sys
+import types
+from dataclasses import dataclass, field
+
+import pytest
+import torch
+
+from musubi_tuner.training.loss import (
+    BUILTIN_LOSS_FNS,
+    mse_loss,
+    normalize_loss_output,
+    parse_loss_fn_args,
+    resolve_loss_fn,
+)
+
+
+@dataclass
+class _FakeOutput:
+    pred: torch.Tensor
+    target: torch.Tensor
+    extra: dict = field(default_factory=dict)
+
+
+def _make_args(**overrides):
+    ns = types.SimpleNamespace(weighting_scheme="none", loss_fn="mse", loss_fn_args=None)
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+# --- parse_loss_fn_args ---
+
+
+def test_parse_none_and_empty():
+    assert parse_loss_fn_args(None) == {}
+    assert parse_loss_fn_args([]) == {}
+
+
+def test_parse_literal_values():
+    kwargs = parse_loss_fn_args(["weight=0.1", "level=2", "normalize=True"])
+    assert kwargs == {"weight": 0.1, "level": 2, "normalize": True}
+
+
+def test_parse_bare_string_falls_back():
+    # transform=swt: "swt" is not a Python literal -> kept as raw string
+    assert parse_loss_fn_args(["transform=swt"]) == {"transform": "swt"}
+
+
+def test_parse_value_containing_equals():
+    assert parse_loss_fn_args(["expr=a=b"]) == {"expr": "a=b"}
+
+
+def test_parse_missing_equals_raises():
+    with pytest.raises(ValueError, match="key=value"):
+        parse_loss_fn_args(["justakey"])
+
+
+# --- built-in mse ---
+
+
+def test_mse_matches_manual_computation():
+    torch.manual_seed(0)
+    pred = torch.randn(2, 4, 8)
+    target = torch.randn(2, 4, 8)
+    output = _FakeOutput(pred=pred, target=target)
+    timesteps = torch.tensor([100.0, 500.0])
+
+    loss, metrics = mse_loss(_make_args(), output, timesteps, None, torch.float32, torch.float32, 0)
+
+    expected = torch.nn.functional.mse_loss(pred, target)
+    assert torch.allclose(loss, expected)
+    assert metrics == {}
+
+
+# --- resolve_loss_fn ---
+
+
+def test_resolve_builtin_mse():
+    fn = resolve_loss_fn("mse")
+    assert fn is BUILTIN_LOSS_FNS["mse"]
+
+
+def test_resolve_unknown_builtin_lists_valid_names():
+    with pytest.raises(ValueError, match="mse"):
+        resolve_loss_fn("nope")
+
+
+def test_resolve_bad_import_path():
+    with pytest.raises(ImportError, match="no_such_module_xyz"):
+        resolve_loss_fn("no_such_module_xyz.Loss")
+
+
+def test_resolve_missing_attribute():
+    with pytest.raises(ImportError, match="no_such_attr"):
+        resolve_loss_fn("musubi_tuner.training.loss.no_such_attr")
+
+
+def test_resolve_dotted_function_binds_kwargs():
+    mod = types.ModuleType("fake_losses")
+
+    def fn_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step, scale=1.0):
+        return torch.nn.functional.mse_loss(output.pred, output.target) * scale
+
+    mod.fn_loss = fn_loss
+    sys.modules["fake_losses"] = mod
+    try:
+        fn = resolve_loss_fn("fake_losses.fn_loss", ["scale=2.0"])
+        output = _FakeOutput(pred=torch.ones(2, 2), target=torch.zeros(2, 2))
+        loss = fn(_make_args(), output, torch.tensor([1.0, 2.0]), None, torch.float32, torch.float32, 0)
+        assert torch.allclose(loss, torch.tensor(2.0))
+    finally:
+        del sys.modules["fake_losses"]
+
+
+def test_resolve_dotted_class_instantiates_with_kwargs():
+    mod = types.ModuleType("fake_losses_cls")
+
+    class ClassLoss(torch.nn.Module):
+        def __init__(self, scale=1.0):
+            super().__init__()
+            self.scale = scale
+
+        def forward(self, args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step):
+            loss = torch.nn.functional.mse_loss(output.pred, output.target) * self.scale
+            return loss, {"loss/scaled": float(loss)}
+
+    mod.ClassLoss = ClassLoss
+    sys.modules["fake_losses_cls"] = mod
+    try:
+        fn = resolve_loss_fn("fake_losses_cls.ClassLoss", ["scale=3.0"])
+        assert isinstance(fn, torch.nn.Module)
+        assert fn.scale == 3.0
+    finally:
+        del sys.modules["fake_losses_cls"]
+
+
+# --- normalize_loss_output ---
+
+
+def test_normalize_bare_tensor():
+    t = torch.tensor(1.5)
+    loss, metrics = normalize_loss_output(t)
+    assert loss is t
+    assert metrics == {}
+
+
+def test_normalize_tuple():
+    t = torch.tensor(1.5)
+    loss, metrics = normalize_loss_output((t, {"loss/aux": 0.5}))
+    assert loss is t
+    assert metrics == {"loss/aux": 0.5}

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -169,3 +169,132 @@ def test_parser_defaults_and_values():
     )
     assert args.loss_fn == "wavelet_loss.musubi.WaveletPlusMSE"
     assert args.loss_fn_args == ["alpha=0.1", "transform=swt"]
+
+
+# --- trainer integration ---
+
+
+def _make_trainer():
+    from musubi_tuner.training.trainer_base import NetworkTrainer
+
+    return NetworkTrainer()
+
+
+def test_default_compute_loss_matches_legacy_mse():
+    torch.manual_seed(0)
+    from musubi_tuner.training.trainer_base import DiTOutput
+
+    trainer = _make_trainer()
+    pred = torch.randn(2, 4, 8)
+    target = torch.randn(2, 4, 8)
+    args = _make_args()  # loss_fn="mse", weighting_scheme="none"
+    trainer._resolved_loss_fn = None  # simulate startup resolution not yet run
+    loss, metrics = trainer.compute_loss(
+        args, DiTOutput(pred=pred, target=target), torch.tensor([100.0, 500.0]), None, torch.float32, torch.float32, 0
+    )
+    assert torch.allclose(loss, torch.nn.functional.mse_loss(pred, target))
+    assert metrics == {}
+
+
+def test_compute_loss_uses_custom_function_and_normalizes_bare_tensor():
+    from musubi_tuner.training.trainer_base import DiTOutput
+
+    mod = types.ModuleType("fake_losses_trainer")
+
+    def bare_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step):
+        return torch.nn.functional.l1_loss(output.pred, output.target)  # bare tensor, no metrics
+
+    mod.bare_loss = bare_loss
+    sys.modules["fake_losses_trainer"] = mod
+    try:
+        trainer = _make_trainer()
+        args = _make_args(loss_fn="fake_losses_trainer.bare_loss")
+        pred, target = torch.ones(2, 2), torch.zeros(2, 2)
+        loss, metrics = trainer.compute_loss(
+            args, DiTOutput(pred=pred, target=target), torch.tensor([1.0, 2.0]), None, torch.float32, torch.float32, 0
+        )
+        assert torch.allclose(loss, torch.tensor(1.0))
+        assert metrics == {}
+    finally:
+        del sys.modules["fake_losses_trainer"]
+
+
+def test_compute_loss_resolves_once_and_caches():
+    trainer = _make_trainer()
+    from musubi_tuner.training.trainer_base import DiTOutput
+
+    calls = []
+    trainer._resolved_loss_fn = lambda *a: (calls.append(1) or torch.tensor(0.0), {})
+    trainer.compute_loss(
+        _make_args(), DiTOutput(pred=torch.zeros(1), target=torch.zeros(1)), torch.tensor([1.0]), None, torch.float32, torch.float32, 0
+    )
+    assert calls == [1]  # pre-set callable used, not re-resolved
+
+
+def test_process_batch_stashes_extra_inputs():
+    from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
+
+    captured = {}
+
+    class StubTrainer(NetworkTrainer):
+        def get_noisy_model_input_and_timesteps(self, args, noise, latents, timesteps, noise_scheduler, device, dtype):
+            return latents + noise, torch.tensor([500.0])
+
+        def call_dit(self, args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs):
+            return DiTOutput(pred=torch.zeros_like(latents), target=torch.zeros_like(latents))
+
+        def compute_loss(self, args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step):
+            captured.update(output.extra)
+            return torch.tensor(0.0), {}
+
+    class _FakeAccelerator:
+        device = torch.device("cpu")
+
+    latents = torch.ones(1, 4)
+    noise = torch.full((1, 4), 2.0)
+    StubTrainer().process_batch(
+        _make_args(), _FakeAccelerator(), None, None, {"timesteps": None}, latents, noise, None,
+        torch.float32, torch.float32, None, 0,
+    )
+    assert torch.equal(captured["latents"], latents)
+    assert torch.equal(captured["noise"], noise)
+    assert torch.equal(captured["noisy_model_input"], latents + noise)
+
+
+def test_validate_args_resolves_loss_fn_at_startup():
+    # NetworkTrainer.handle_model_specific_args (called later in
+    # _validate_args_and_init) is an abstract hook that unconditionally raises
+    # NotImplementedError on the base class -- there's no reasonable minimal
+    # args namespace that gets a bare NetworkTrainer instance all the way
+    # through _validate_args_and_init. Per the task note, resolution is
+    # factored into `_resolve_loss_fn_from_args`, called eagerly (before
+    # `handle_model_specific_args`) from `_validate_args_and_init`; test the
+    # helper directly, which is what actually performs the startup resolution.
+    trainer = _make_trainer()
+    args = _make_args(loss_fn="mse")
+    trainer._resolve_loss_fn_from_args(args)
+    assert trainer._resolved_loss_fn is BUILTIN_LOSS_FNS["mse"]
+
+    trainer2 = _make_trainer()
+    args.loss_fn = "nonexistent_module_xyz.Loss"
+    with pytest.raises(ImportError):
+        trainer2._resolve_loss_fn_from_args(args)
+
+    # confirm the real call site: _validate_args_and_init resolves before it
+    # reaches the abstract handle_model_specific_args hook (proves ordering,
+    # not just that the helper works in isolation).
+    trainer3 = _make_trainer()
+    args3 = _make_args(
+        loss_fn="mse",
+        cuda_allow_tf32=False,
+        cuda_cudnn_benchmark=False,
+        dataset_config="dummy.toml",
+        dit="dummy.safetensors",
+        fp8_scaled=False,
+        fp8_base=False,
+        sage_attn=False,
+        disable_numpy_memmap=False,
+    )
+    with pytest.raises(NotImplementedError, match="handle_model_specific_args"):
+        trainer3._validate_args_and_init(args3)
+    assert trainer3._resolved_loss_fn is BUILTIN_LOSS_FNS["mse"]

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -285,7 +285,13 @@ def test_compute_loss_resolves_once_and_caches():
     calls = []
     trainer._resolved_loss_fn = lambda *a: (calls.append(1) or torch.tensor(0.0), {})
     trainer.compute_loss(
-        _make_args(), DiTOutput(pred=torch.zeros(1), target=torch.zeros(1)), torch.tensor([1.0]), None, torch.float32, torch.float32, 0
+        _make_args(),
+        DiTOutput(pred=torch.zeros(1), target=torch.zeros(1)),
+        torch.tensor([1.0]),
+        None,
+        torch.float32,
+        torch.float32,
+        0,
     )
     assert calls == [1]  # pre-set callable used, not re-resolved
 
@@ -302,7 +308,9 @@ def test_process_batch_passes_call_dit_extras_to_loss():
         def get_noisy_model_input_and_timesteps(self, args, noise, latents, timesteps, noise_scheduler, device, dtype):
             return latents + noise, torch.tensor([500.0])
 
-        def call_dit(self, args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs):
+        def call_dit(
+            self, args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs
+        ):
             output = DiTOutput(pred=torch.zeros_like(latents), target=torch.zeros_like(latents))
             output.extra["noisy_model_input"] = noisy_model_input
             return output
@@ -317,8 +325,18 @@ def test_process_batch_passes_call_dit_extras_to_loss():
     latents = torch.ones(1, 4)
     noise = torch.full((1, 4), 2.0)
     StubTrainer().process_batch(
-        _make_args(), _FakeAccelerator(), None, None, {"timesteps": None}, latents, noise, None,
-        torch.float32, torch.float32, None, 0,
+        _make_args(),
+        _FakeAccelerator(),
+        None,
+        None,
+        {"timesteps": None},
+        latents,
+        noise,
+        None,
+        torch.float32,
+        torch.float32,
+        None,
+        0,
     )
     assert set(captured) == {"noisy_model_input"}  # only what the trainer stashed
     assert torch.equal(captured["noisy_model_input"], latents + noise)

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -43,13 +43,27 @@ def test_parse_literal_values():
     assert kwargs == {"weight": 0.1, "level": 2, "normalize": True}
 
 
-def test_parse_bare_string_falls_back():
-    # transform=swt: "swt" is not a Python literal -> kept as raw string
-    assert parse_loss_fn_args(["transform=swt"]) == {"transform": "swt"}
+def test_parse_bare_string_raises_with_quoting_hint():
+    # transform=swt: "swt" is not a Python literal -> hard error at startup,
+    # message shows exactly how to quote it (optimizer_args semantics)
+    with pytest.raises(ValueError, match=r"transform='swt'"):
+        parse_loss_fn_args(["transform=swt"])
 
 
-def test_parse_value_containing_equals():
-    assert parse_loss_fn_args(["expr=a=b"]) == {"expr": "a=b"}
+def test_parse_quoted_string_value():
+    assert parse_loss_fn_args(["transform='swt'"]) == {"transform": "swt"}
+
+
+def test_parse_dict_value():
+    kwargs = parse_loss_fn_args(["band_weights={'ll0': 1.0, 'lh2': 0.2}"])
+    assert kwargs == {"band_weights": {"ll0": 1.0, "lh2": 0.2}}
+
+
+def test_parse_numeric_typo_raises():
+    # the whole point of strict parsing: a typo'd float must fail loudly,
+    # not silently become the string "0.1."
+    with pytest.raises(ValueError, match="not a Python literal"):
+        parse_loss_fn_args(["alpha=0.1."])
 
 
 def test_parse_missing_equals_raises():
@@ -165,10 +179,10 @@ def test_parser_defaults_and_values():
     assert args.loss_fn_args is None
 
     args, _ = parser.parse_known_args(
-        ["--loss_fn", "wavelet_loss.musubi.WaveletPlusMSE", "--loss_fn_args", "alpha=0.1", "transform=swt"]
+        ["--loss_fn", "wavelet_loss.musubi.WaveletPlusMSE", "--loss_fn_args", "alpha=0.1", "transform='swt'"]
     )
     assert args.loss_fn == "wavelet_loss.musubi.WaveletPlusMSE"
-    assert args.loss_fn_args == ["alpha=0.1", "transform=swt"]
+    assert args.loss_fn_args == ["alpha=0.1", "transform='swt'"]
 
 
 # --- trainer integration ---

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -231,7 +231,10 @@ def test_compute_loss_resolves_once_and_caches():
     assert calls == [1]  # pre-set callable used, not re-resolved
 
 
-def test_process_batch_stashes_extra_inputs():
+def test_process_batch_passes_call_dit_extras_to_loss():
+    # Trainers that support extra-input losses (wavelet x0 recovery, DiNO/PO)
+    # stash tensors into output.extra themselves (e.g. in call_dit); the base
+    # process_batch must hand that dict through to compute_loss untouched.
     from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
 
     captured = {}
@@ -241,7 +244,9 @@ def test_process_batch_stashes_extra_inputs():
             return latents + noise, torch.tensor([500.0])
 
         def call_dit(self, args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype, **kwargs):
-            return DiTOutput(pred=torch.zeros_like(latents), target=torch.zeros_like(latents))
+            output = DiTOutput(pred=torch.zeros_like(latents), target=torch.zeros_like(latents))
+            output.extra["noisy_model_input"] = noisy_model_input
+            return output
 
         def compute_loss(self, args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step):
             captured.update(output.extra)
@@ -256,8 +261,7 @@ def test_process_batch_stashes_extra_inputs():
         _make_args(), _FakeAccelerator(), None, None, {"timesteps": None}, latents, noise, None,
         torch.float32, torch.float32, None, 0,
     )
-    assert torch.equal(captured["latents"], latents)
-    assert torch.equal(captured["noise"], noise)
+    assert set(captured) == {"noisy_model_input"}  # only what the trainer stashed
     assert torch.equal(captured["noisy_model_input"], latents + noise)
 
 

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -9,6 +9,7 @@ import torch
 
 from musubi_tuner.training.loss import (
     BUILTIN_LOSS_FNS,
+    LossContext,
     mse_loss,
     normalize_loss_output,
     parse_loss_fn_args,
@@ -28,6 +29,18 @@ def _make_args(**overrides):
     for k, v in overrides.items():
         setattr(ns, k, v)
     return ns
+
+
+def _make_ctx(output, args=None, timesteps=None):
+    return LossContext(
+        args=args if args is not None else _make_args(),
+        output=output,
+        timesteps=timesteps if timesteps is not None else torch.tensor([100.0, 500.0]),
+        noise_scheduler=None,
+        dit_dtype=torch.float32,
+        network_dtype=torch.float32,
+        global_step=0,
+    )
 
 
 # --- parse_loss_fn_args ---
@@ -78,10 +91,9 @@ def test_mse_matches_manual_computation():
     torch.manual_seed(0)
     pred = torch.randn(2, 4, 8)
     target = torch.randn(2, 4, 8)
-    output = _FakeOutput(pred=pred, target=target)
-    timesteps = torch.tensor([100.0, 500.0])
+    ctx = _make_ctx(_FakeOutput(pred=pred, target=target))
 
-    loss, metrics = mse_loss(_make_args(), output, timesteps, None, torch.float32, torch.float32, 0)
+    loss, metrics = mse_loss(ctx)
 
     expected = torch.nn.functional.mse_loss(pred, target)
     assert torch.allclose(loss, expected)
@@ -114,15 +126,15 @@ def test_resolve_missing_attribute():
 def test_resolve_dotted_function_binds_kwargs():
     mod = types.ModuleType("fake_losses")
 
-    def fn_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step, scale=1.0):
-        return torch.nn.functional.mse_loss(output.pred, output.target) * scale
+    def fn_loss(ctx, scale=1.0):
+        return torch.nn.functional.mse_loss(ctx.output.pred, ctx.output.target) * scale
 
     mod.fn_loss = fn_loss
     sys.modules["fake_losses"] = mod
     try:
         fn = resolve_loss_fn("fake_losses.fn_loss", ["scale=2.0"])
         output = _FakeOutput(pred=torch.ones(2, 2), target=torch.zeros(2, 2))
-        loss = fn(_make_args(), output, torch.tensor([1.0, 2.0]), None, torch.float32, torch.float32, 0)
+        loss = fn(_make_ctx(output, timesteps=torch.tensor([1.0, 2.0])))
         assert torch.allclose(loss, torch.tensor(2.0))
     finally:
         del sys.modules["fake_losses"]
@@ -136,8 +148,8 @@ def test_resolve_dotted_class_instantiates_with_kwargs():
             super().__init__()
             self.scale = scale
 
-        def forward(self, args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step):
-            loss = torch.nn.functional.mse_loss(output.pred, output.target) * self.scale
+        def forward(self, ctx):
+            loss = torch.nn.functional.mse_loss(ctx.output.pred, ctx.output.target) * self.scale
             return loss, {"loss/scaled": float(loss)}
 
     mod.ClassLoss = ClassLoss
@@ -215,8 +227,8 @@ def test_compute_loss_uses_custom_function_and_normalizes_bare_tensor():
 
     mod = types.ModuleType("fake_losses_trainer")
 
-    def bare_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step):
-        return torch.nn.functional.l1_loss(output.pred, output.target)  # bare tensor, no metrics
+    def bare_loss(ctx):
+        return torch.nn.functional.l1_loss(ctx.output.pred, ctx.output.target)  # bare tensor, no metrics
 
     mod.bare_loss = bare_loss
     sys.modules["fake_losses_trainer"] = mod
@@ -316,3 +328,29 @@ def test_validate_args_resolves_loss_fn_at_startup():
     with pytest.raises(NotImplementedError, match="handle_model_specific_args"):
         trainer3._validate_args_and_init(args3)
     assert trainer3._resolved_loss_fn is BUILTIN_LOSS_FNS["mse"]
+
+
+def test_trainer_builds_loss_context():
+    from musubi_tuner.training.trainer_base import DiTOutput
+
+    trainer = _make_trainer()
+    seen = {}
+
+    def capture(ctx):
+        assert isinstance(ctx, LossContext)
+        seen.update(vars(ctx))
+        return torch.tensor(0.0)
+
+    trainer._resolved_loss_fn = capture
+    args = _make_args()
+    output = DiTOutput(pred=torch.zeros(1), target=torch.zeros(1))
+    ts = torch.tensor([42.0])
+    trainer.compute_loss(args, output, ts, "sched", torch.float16, torch.bfloat16, 7)
+
+    assert seen["args"] is args
+    assert seen["output"] is output
+    assert seen["timesteps"] is ts
+    assert seen["noise_scheduler"] == "sched"
+    assert seen["dit_dtype"] is torch.float16
+    assert seen["network_dtype"] is torch.bfloat16
+    assert seen["global_step"] == 7

--- a/tests/test_loss_fn.py
+++ b/tests/test_loss_fn.py
@@ -1,5 +1,6 @@
 """Tests for the pluggable loss function resolver (training/loss.py)."""
 
+import logging
 import sys
 import types
 from dataclasses import dataclass, field
@@ -138,6 +139,38 @@ def test_resolve_dotted_function_binds_kwargs():
         assert torch.allclose(loss, torch.tensor(2.0))
     finally:
         del sys.modules["fake_losses"]
+
+
+def test_resolve_dotted_function_rejects_mismatched_kwargs():
+    mod = types.ModuleType("fake_losses_bad_kwargs")
+
+    def fn_loss(ctx, scale=1.0):
+        return torch.nn.functional.mse_loss(ctx.output.pred, ctx.output.target) * scale
+
+    mod.fn_loss = fn_loss
+    sys.modules["fake_losses_bad_kwargs"] = mod
+    try:
+        with pytest.raises(ValueError, match="fake_losses_bad_kwargs.fn_loss"):
+            resolve_loss_fn("fake_losses_bad_kwargs.fn_loss", ["scael=2.0"])
+    finally:
+        del sys.modules["fake_losses_bad_kwargs"]
+
+
+def test_resolve_dotted_function_accepts_matching_kwargs():
+    mod = types.ModuleType("fake_losses_good_kwargs")
+
+    def fn_loss(ctx, scale=1.0):
+        return torch.nn.functional.mse_loss(ctx.output.pred, ctx.output.target) * scale
+
+    mod.fn_loss = fn_loss
+    sys.modules["fake_losses_good_kwargs"] = mod
+    try:
+        fn = resolve_loss_fn("fake_losses_good_kwargs.fn_loss", ["scale=2.0"])
+        output = _FakeOutput(pred=torch.ones(2, 2), target=torch.zeros(2, 2))
+        loss = fn(_make_ctx(output, timesteps=torch.tensor([1.0, 2.0])))
+        assert torch.allclose(loss, torch.tensor(2.0))
+    finally:
+        del sys.modules["fake_losses_good_kwargs"]
 
 
 def test_resolve_dotted_class_instantiates_with_kwargs():
@@ -354,3 +387,42 @@ def test_trainer_builds_loss_context():
     assert seen["dit_dtype"] is torch.float16
     assert seen["network_dtype"] is torch.bfloat16
     assert seen["global_step"] == 7
+
+
+def test_resolve_loss_fn_warns_when_compute_loss_overridden_and_non_default_loss_fn(caplog):
+    from musubi_tuner.training.trainer_base import NetworkTrainer
+
+    class OverridingTrainer(NetworkTrainer):
+        def compute_loss(self, args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step):
+            return torch.tensor(0.0), {}
+
+    mod = types.ModuleType("fake_losses_warn_check")
+
+    def fn_loss(ctx):
+        return torch.nn.functional.mse_loss(ctx.output.pred, ctx.output.target)
+
+    mod.fn_loss = fn_loss
+    sys.modules["fake_losses_warn_check"] = mod
+    try:
+        # default "mse" loss_fn on an overriding trainer -> no warning
+        trainer_mse = OverridingTrainer()
+        with caplog.at_level(logging.WARNING):
+            caplog.clear()
+            trainer_mse._resolve_loss_fn_from_args(_make_args(loss_fn="mse"))
+        assert not any("overrides compute_loss" in r.message for r in caplog.records)
+
+        # non-default loss_fn on an overriding trainer -> warning
+        trainer_custom = OverridingTrainer()
+        with caplog.at_level(logging.WARNING):
+            caplog.clear()
+            trainer_custom._resolve_loss_fn_from_args(_make_args(loss_fn="fake_losses_warn_check.fn_loss"))
+        assert any("overrides compute_loss" in r.message for r in caplog.records)
+
+        # non-default loss_fn on a plain NetworkTrainer (no override) -> no warning
+        trainer_plain = NetworkTrainer()
+        with caplog.at_level(logging.WARNING):
+            caplog.clear()
+            trainer_plain._resolve_loss_fn_from_args(_make_args(loss_fn="fake_losses_warn_check.fn_loss"))
+        assert not any("overrides compute_loss" in r.message for r in caplog.records)
+    finally:
+        del sys.modules["fake_losses_warn_check"]


### PR DESCRIPTION
This allows us to inject our own custom loss function in. Takes the same signature as compute_loss. 

Would want some feedback on this approach as it feels a bit opinionated towards a ctx object with the information from the compute_loss function. This approach makes it easier to add new options without breaking previous versions and a cleaner interface but it's more abstract from just passing the parameters over.

This idea is credit to @recris who suggested with the wavelet loss implementation in #987. 

Related #987 