### PR TITLE
Add Intel Arc (XPU) support: Wan 2.1/2.2 and Flux 2 LoRA training

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,25 @@
+# Agent Notes — musubi-tuner XPU fork
+
+This is a fork of kohya-ss/musubi-tuner ported to **Intel Arc Pro B70 (XPU)**. There is no
+NVIDIA GPU on this machine. The port is complete and validated — see `b70_support_plan.md`
+for the current state, design decisions, and verification steps.
+
+## Rules
+
+1. **Stay on the active branch** (`port/upstream-v0.3.4`, or `main` once fast-forwarded).
+   Local training scripts outside this repo run against whatever is checked out here.
+2. **Don't upgrade `torch`, `transformers`, or `bitsandbytes`** without an explicit decision —
+   the XPU stack is version-sensitive (transformers pinned at 4.56.1; Ideogram4/Krea2 need newer, we don't use them).
+3. **Keep `torch.cuda.*` primitives out of shared code paths.** Device-specific transfer logic
+   belongs behind the copier seam in `modules/custom_offloading_utils.py` (`_InOrderCopier` is the XPU shim).
+4. **No mid-autograd `torch.xpu.synchronize()`** and no XPU sync from worker threads — both
+   crash the driver (`UR_RESULT_ERROR_DEVICE_LOST` / deadlock). See the design table in `b70_support_plan.md`.
+5. **In-training sampling stays disabled on XPU** (produces noise). Evaluate in ComfyUI.
+6. Before any long training run: pytest (ideogram4 tests excluded) + a 3-step smoke run.
+   Both commands are in `b70_support_plan.md`.
+
+## Quick facts
+
+- venv: `./venv` (Python 3.13, torch 2.11.0+xpu); invoke with `PYTHONPATH=src`
+- Preferred LoRA training path: `--blocks_to_swap N --block_swap_h2d_only` (~22% faster than classic swap)
+- Reference recipe: `examples/train_lora_flux2_xpu_h2d.sh` + `examples/flux2_dataset_config.example.toml`

--- a/b70_support_plan.md
+++ b/b70_support_plan.md
@@ -1,0 +1,55 @@
+# Intel Arc B70 XPU Port — Current State
+
+Status doc for the XPU port of musubi-tuner (fork of kohya-ss/musubi-tuner).
+Not a plan — the port is done and validated. Last updated: 2026-07-08.
+
+## Environment
+
+- **GPU:** Intel Arc Pro B70 (Xe2/Battlemage, 32GB VRAM, PCI ID `e223`), requires compute-runtime v26.14+
+- **PyTorch:** 2.11.0+xpu (wheels from `https://download.pytorch.org/whl/xpu`), Python 3.13 venv at `./venv`
+- **Branch:** `port/upstream-v0.3.4` = upstream v0.3.4 + the XPU commits (pre-rebase history: `main-pre-rebase`)
+
+## What works (validated)
+
+- **Flux2 dev LoRA training end-to-end**: 540-step dim64/alpha64 bf16 run with
+  `--blocks_to_swap 40 --block_swap_h2d_only`, output LoRA validated in ComfyUI against a
+  known-good reference (2026-07-07). Recipe: `examples/train_lora_flux2_xpu_h2d.sh`.
+- **Caching** (latents + text encoder) on XPU; `--device_map_auto` splits the Mistral-3 TE across GPU+CPU.
+- **Wan 2.1/2.2 LoRA training** (validated earlier: 2×1000-step I2V run).
+- **adamw8bit** (bitsandbytes 0.49.2 XPU kernels).
+
+## XPU design decisions (why the code looks the way it does)
+
+| Area | Decision | Reason |
+|---|---|---|
+| Classic block swap | Synchronous on the calling thread (`_SyncFuture`, no ThreadPool) | `torch.xpu.synchronize()` is not thread-safe; SYCL context is bound to the main thread |
+| Swap copies | `non_blocking=True` + one trailing sync (`swap_weight_devices_no_cuda`) | Pipelines to ~10.6 GB/s vs ~3.3 blocking; per-tensor sync mid-autograd triggers `UR_RESULT_ERROR_DEVICE_LOST` |
+| **H2D-only swap** (`--block_swap_h2d_only`) | `LoRAStreamOffloader` + `_InOrderCopier`: flat H2D copies on the default in-order queue, no events | Frozen-base LoRA never needs the D2H half; in-order queue provides the ordering CUDA needs events for. **36 s/it vs 47 s/it classic** on the Flux2 dim64 recipe → use this for LoRA training |
+| Trainer loop | `torch.xpu.synchronize()` every 50 steps | Prevents driver command-queue buildup / hangs on long runs |
+| Pinned memory | Not used on XPU (forced off in `LoRAStreamOffloader`) | Measured slower than pageable `non_blocking` on this stack |
+| Flux2 `Modulation`/`LastLayer` | fp32 upcasts removed | Matches the numerics of the validated LoRAs; restoring them is an untested A/B |
+| Wan time embedding | bf16 autocast on XPU (fp32 path misbehaves) | Plus bf16 `e` accepted in `WanAttentionBlock`/`Head` |
+| Device detection | `xpu` preferred over `cuda` in caching scripts and defaults | Single-GPU XPU box |
+
+## Known limitations
+
+- **In-training sampling on XPU produces noise** — keep it disabled; evaluate checkpoints in ComfyUI.
+- **`transformers` pinned at 4.56.1** — upstream's Ideogram4/Krea2 code (and their tests) need newer.
+  Do not upgrade casually; the XPU stack is sensitive. Excluded tests: `tests/test_ideogram4_*`.
+- No copy/compute overlap in `_InOrderCopier` (single in-order queue). A `torch.xpu.Stream`
+  copier is the known next optimization if more speed is needed.
+
+## Verifying changes
+
+```bash
+source venv/bin/activate
+PYTHONPATH=src python -m pytest tests/ -q --ignore=tests/test_ideogram4_synthetic.py \
+  --ignore=tests/test_ideogram4_autoencoder.py --ignore=tests/test_ideogram4_fp8_loading.py \
+  --ignore=tests/test_ideogram4_lora_sampling.py --ignore=tests/test_ideogram4_te_fp8_loading.py \
+  --ignore=tests/test_ideogram4_timesteps.py
+```
+
+Then a 3-step smoke of the Flux2 recipe (`--max_train_steps 3`, see
+`examples/train_lora_flux2_xpu_h2d.sh`) before any long run: expect the block swap line
+`double blocks: 6, single blocks: 46` at `--blocks_to_swap 40`, finite loss, a saved
+checkpoint, and ~36 s/it (h2d) / ~47 s/it (classic) at 1024px on the B70.

--- a/examples/flux2_dataset_config.example.toml
+++ b/examples/flux2_dataset_config.example.toml
@@ -1,0 +1,18 @@
+# Flux2 LoRA dataset config — working example (validated on Intel Arc B70, XPU)
+# Images + same-named .txt caption files in image_directory; images without a
+# .txt caption are skipped by the trainer.
+
+[general]
+resolution = [
+    1024,
+    1024,
+]
+caption_extension = ".txt"
+batch_size = 1
+enable_bucket = true
+bucket_no_upscale = true
+
+[[datasets]]
+image_directory = "/path/to/dataset"
+cache_directory = "/path/to/dataset/cache"
+num_repeats = 1

--- a/examples/train_lora_flux2_xpu_h2d.sh
+++ b/examples/train_lora_flux2_xpu_h2d.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# ============================================================================
+# Flux2 dev LoRA training on Intel Arc (XPU) with H2D-only block swap
+# ----------------------------------------------------------------------------
+# Validated end-to-end on an Arc Pro B70 (32GB): 540 steps at ~36 s/it (1024px,
+# bucketed), output LoRA confirmed working in ComfyUI. The classic swap path
+# (drop --block_swap_h2d_only) runs the same recipe at ~47 s/it.
+#
+# Recipe: dim 64 / alpha 64 (scale 1.0), LR 5e-5 constant, AdamW8bit,
+# timestep_sampling flux2_shift, discrete_flow_shift 1.0, weighting none,
+# mixed bf16, gradient checkpointing + cpu offload, blocks_to_swap 40.
+#
+# In-training sampling is intentionally OFF (broken on XPU — produces noise);
+# evaluate checkpoints in ComfyUI instead.
+#
+# Usage: ./train_lora_flux2_xpu_h2d.sh /path/to/dataset_config.toml [--training-only]
+#   (see flux2_dataset_config.example.toml; --training-only skips re-caching)
+# ============================================================================
+
+set -e
+
+DATASET_CONFIG="${1:?usage: $0 /path/to/dataset_config.toml [--training-only]}"
+TRAINING_ONLY=false
+[ "$2" = "--training-only" ] && TRAINING_ONLY=true
+
+# Adjust these to your setup
+MUSUBI_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MODEL_DIR="/path/to/FLUX.2-dev"
+VAE="${MODEL_DIR}/ae.safetensors"
+DIT="${MODEL_DIR}/flux2-dev.safetensors"
+TEXT_ENCODER="${MODEL_DIR}/text_encoder/model-00001-of-00010.safetensors"
+OUTPUT_DIR="${OUTPUT_DIR:-./output/flux2-lora-xpu}"
+OUTPUT_NAME="${OUTPUT_NAME:-flux2-lora-xpu}"
+MODEL_VERSION="dev"
+
+[ ! -f "$DATASET_CONFIG" ] && echo "Error: $DATASET_CONFIG not found" && exit 1
+[ ! -f "$VAE" ] && echo "Error: VAE not found at $VAE" && exit 1
+[ ! -f "$DIT" ] && echo "Error: DIT not found at $DIT" && exit 1
+
+mkdir -p "$OUTPUT_DIR" "$OUTPUT_DIR/logs"
+source "$MUSUBI_DIR/venv/bin/activate"
+cd "$MUSUBI_DIR"
+export PYTHONPATH="$PWD/src"
+
+if [ "$TRAINING_ONLY" = false ]; then
+    echo "[1/3] Caching latents..."
+    python src/musubi_tuner/flux_2_cache_latents.py \
+        --dataset_config "$DATASET_CONFIG" \
+        --vae "$VAE" \
+        --model_version "$MODEL_VERSION" \
+        --batch_size 1
+
+    echo "[2/3] Caching text encoder outputs..."
+    python src/musubi_tuner/flux_2_cache_text_encoder_outputs.py \
+        --dataset_config "$DATASET_CONFIG" \
+        --text_encoder "$TEXT_ENCODER" \
+        --model_version "$MODEL_VERSION" \
+        --batch_size 4
+fi
+
+echo "[3/3] Training LoRA (dim64/alpha64, LR5e-5, H2D-only block swap; sampling disabled)..."
+PYTHONPATH=src accelerate launch \
+    --num_cpu_threads_per_process 1 \
+    --mixed_precision bf16 \
+    src/musubi_tuner/flux_2_train_network.py \
+    --dit "$DIT" \
+    --vae "$VAE" \
+    --text_encoder "$TEXT_ENCODER" \
+    --dataset_config "$DATASET_CONFIG" \
+    --model_version "$MODEL_VERSION" \
+    --sdpa \
+    --mixed_precision bf16 \
+    --timestep_sampling flux2_shift \
+    --discrete_flow_shift 1.0 \
+    --weighting_scheme none \
+    --optimizer_type adamw8bit \
+    --learning_rate 5e-5 \
+    --lr_scheduler constant \
+    --gradient_checkpointing \
+    --gradient_checkpointing_cpu_offload \
+    --max_data_loader_n_workers 0 \
+    --network_module networks.lora_flux_2 \
+    --network_dim 64 \
+    --network_alpha 64 \
+    --max_train_epochs 20 \
+    --save_every_n_epochs 4 \
+    --seed 42 \
+    --output_dir "$OUTPUT_DIR" \
+    --output_name "$OUTPUT_NAME" \
+    --logging_dir "$OUTPUT_DIR/logs" \
+    --blocks_to_swap 40 \
+    --block_swap_h2d_only \
+    --img_in_txt_in_offloading
+
+echo "Done. Checkpoints in ${OUTPUT_DIR}/ — evaluate in ComfyUI (in-training sampling is disabled on XPU)."

--- a/src/musubi_tuner/cache_latents.py
+++ b/src/musubi_tuner/cache_latents.py
@@ -334,7 +334,7 @@ def main():
 
     args = parser.parse_args()
 
-    device = args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "cpu"
+    device = args.device if args.device is not None else "xpu" if torch.xpu.is_available() else "cuda" if torch.cuda.is_available() else "cpu"
     device = torch.device(device)
 
     # Load dataset config
@@ -381,7 +381,7 @@ def setup_parser_common() -> argparse.ArgumentParser:
     parser.add_argument("--dataset_config", type=str, required=True, help="path to dataset config .toml file")
     parser.add_argument("--vae", type=str, required=False, default=None, help="path to vae checkpoint")
     parser.add_argument("--vae_dtype", type=str, default=None, help="data type for VAE, default depends on model, e.g., float16")
-    parser.add_argument("--device", type=str, default=None, help="device to use, default is cuda if available")
+    parser.add_argument("--device", type=str, default=None, help="device to use, default is xpu if available, else cuda if available, else cpu")
     parser.add_argument(
         "--batch_size", type=int, default=None, help="batch size, override dataset config if dataset batch size > this"
     )

--- a/src/musubi_tuner/flux_2/flux2_models.py
+++ b/src/musubi_tuner/flux_2/flux2_models.py
@@ -509,25 +509,13 @@ class Flux2(nn.Module):
             double_blocks_to_swap = num_blocks
             single_blocks_to_swap = 0
         else:
-            swap_ratio = self.num_single_blocks / self.num_double_blocks
-            double_blocks_to_swap = int(round(num_blocks / (1.0 + swap_ratio / 2.0)))
-            single_blocks_to_swap = int(round(double_blocks_to_swap * swap_ratio))
-
-            # adjust if we exceed available blocks
-            if self.num_double_blocks * 2 < self.num_single_blocks:
-                while double_blocks_to_swap >= 1 and double_blocks_to_swap > self.num_double_blocks - 2:
-                    double_blocks_to_swap -= 1
-                    single_blocks_to_swap += 2
-            else:
-                while single_blocks_to_swap >= 2 and single_blocks_to_swap > self.num_single_blocks - 2:
-                    single_blocks_to_swap -= 2
-                    double_blocks_to_swap += 1
-
-            if double_blocks_to_swap == 0 and single_blocks_to_swap == 0:
-                if self.num_single_blocks >= self.num_double_blocks:
-                    single_blocks_to_swap = 1
-                else:
-                    double_blocks_to_swap = 1
+            # Clamp double swap to max, overflow remaining budget into single swap.
+            # The *2+1 accounts for single blocks being ~half the size of double blocks.
+            # This is needed for Flux2's 8:48 double:single ratio where the old proportional
+            # formula overflows single_blocks for large swap counts.
+            double_blocks_to_swap = min(num_blocks // 2, self.num_double_blocks - 2)
+            remaining_budget = num_blocks - double_blocks_to_swap
+            single_blocks_to_swap = min(remaining_budget * 2 + 1, self.num_single_blocks - 2)
 
         assert double_blocks_to_swap <= self.num_double_blocks - 2 and single_blocks_to_swap <= self.num_single_blocks - 2, (
             f"Cannot swap more than {self.num_double_blocks - 2} double blocks and {self.num_single_blocks - 2} single blocks. "
@@ -669,12 +657,9 @@ class Modulation(nn.Module):
         self.lin = nn.Linear(dim, self.multiplier * dim, bias=not disable_bias)
 
     def forward(self, vec: torch.Tensor):
-        org_dtype = vec.dtype
-        vec = vec.to(torch.float32)  # for numerical stability
         out = self.lin(nn.functional.silu(vec))
         if out.ndim == 2:
             out = out[:, None, :]
-        out = out.to(org_dtype)
         out = out.chunk(self.multiplier, dim=-1)
         return out[:3], out[3:] if self.is_double else None
 
@@ -687,17 +672,14 @@ class LastLayer(nn.Module):
         self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(hidden_size, 2 * hidden_size, bias=False))
 
     def forward(self, x: torch.Tensor, vec: torch.Tensor) -> torch.Tensor:
-        org_dtype = x.dtype
-        vec = vec.to(torch.float32)  # for numerical stability
         mod = self.adaLN_modulation(vec)
         shift, scale = mod.chunk(2, dim=-1)
         if shift.ndim == 2:
             shift = shift[:, None, :]
             scale = scale[:, None, :]
-        x = x.to(torch.float32)  # for numerical stability
         x = (1 + scale) * self.norm_final(x) + shift
         x = self.linear(x)
-        return x.to(org_dtype)
+        return x
 
 
 class SingleStreamBlock(nn.Module):

--- a/src/musubi_tuner/flux_2/flux2_utils.py
+++ b/src/musubi_tuner/flux_2/flux2_utils.py
@@ -488,6 +488,13 @@ def load_flow_model(
             for key in sd.keys():
                 sd[key] = sd[key].to(loading_device)
 
+    # Strip ComfyUI fp8 scale keys (input_scale/weight_scale) that are not part of the model
+    scale_keys = [k for k in sd.keys() if k.endswith(("input_scale", "weight_scale"))]
+    if scale_keys:
+        logger.info(f"Stripping {len(scale_keys)} fp8 scale keys from state dict")
+        for k in scale_keys:
+            del sd[k]
+
     info = model.load_state_dict(sd, strict=True, assign=True)
     logger.info(f"Loaded Flux 2: {info}")
 

--- a/src/musubi_tuner/flux_2/flux2_utils.py
+++ b/src/musubi_tuner/flux_2/flux2_utils.py
@@ -524,8 +524,22 @@ class Mistral3Embedder(nn.Module):
         device: Union[str, torch.device],
         disable_mmap: bool = False,
         state_dict: Optional[dict] = None,
+        device_map_auto: bool = False,
     ) -> tuple[AutoProcessor, Mistral3ForConditionalGeneration]:
         super().__init__()
+
+        if device_map_auto:
+            import os
+
+            model_dir = os.path.dirname(ckpt_path) if os.path.isfile(ckpt_path) else ckpt_path
+            logger.info(f"Loading Mistral 3 with device_map=auto (GPU+CPU split) from {model_dir}")
+            self.mistral3 = Mistral3ForConditionalGeneration.from_pretrained(
+                model_dir,
+                device_map="auto",
+                dtype=torch.bfloat16,
+            )
+            self.tokenizer = AutoProcessor.from_pretrained(M3_TOKENIZER_ID, use_fast=False)
+            return
 
         M3_CONFIG_JSON = """
 {
@@ -812,9 +826,10 @@ def load_text_embedder(
     device: Union[str, torch.device],
     disable_mmap: bool = False,
     state_dict: Optional[dict] = None,
+    device_map_auto: bool = False,
 ) -> Union[Mistral3Embedder, Qwen3Embedder]:
     if model_version_info.qwen_variant is None:
-        return Mistral3Embedder(ckpt_path, dtype, device, disable_mmap, state_dict)
+        return Mistral3Embedder(ckpt_path, dtype, device, disable_mmap, state_dict, device_map_auto=device_map_auto)
 
     variant = model_version_info.qwen_variant
     is_8b = variant == "8B"

--- a/src/musubi_tuner/flux_2_cache_latents.py
+++ b/src/musubi_tuner/flux_2_cache_latents.py
@@ -89,7 +89,7 @@ def main():
         logger.info("Disabling cuDNN PyTorch backend.")
         torch.backends.cudnn.enabled = False
 
-    device = args.device if hasattr(args, "device") and args.device else ("cuda" if torch.cuda.is_available() else "cpu")
+    device = args.device if hasattr(args, "device") and args.device else ("xpu" if torch.xpu.is_available() else "cuda" if torch.cuda.is_available() else "cpu")
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/flux_2_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/flux_2_cache_text_encoder_outputs.py
@@ -53,7 +53,8 @@ def main():
     # Load Mistral 3 or Qwen-3 text encoder
     m3_dtype = torch.float8_e4m3fn if args.fp8_text_encoder else torch.bfloat16
     text_embedder = flux2_utils.load_text_embedder(
-        model_version_info, args.text_encoder, dtype=m3_dtype, device=device, disable_mmap=True
+        model_version_info, args.text_encoder, dtype=m3_dtype, device=device, disable_mmap=True,
+        device_map_auto=args.device_map_auto,
     )
 
     # Encode with Mistral 3 or Qwen-3 text encoder
@@ -83,6 +84,10 @@ def main():
 def flux_2_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("--text_encoder", type=str, default=None, required=True, help="text encoder (mistral 3) checkpoint path")
     parser.add_argument("--fp8_text_encoder", action="store_true", help="use fp8 for Text Encoder model")
+    parser.add_argument(
+        "--device_map_auto", action="store_true",
+        help="split Mistral 3 text encoder across GPU+CPU via device_map=auto (reduces VRAM usage)",
+    )
     flux2_utils.add_model_version_args(parser)
     return parser
 

--- a/src/musubi_tuner/flux_2_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/flux_2_cache_text_encoder_outputs.py
@@ -35,7 +35,7 @@ def main():
     args = parser.parse_args()
     model_version_info = flux2_utils.FLUX2_MODEL_INFO[args.model_version]
 
-    device = args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "cpu"
+    device = args.device if args.device is not None else "xpu" if torch.xpu.is_available() else "cuda" if torch.cuda.is_available() else "cpu"
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/flux_2_train_network.py
+++ b/src/musubi_tuner/flux_2_train_network.py
@@ -56,7 +56,8 @@ class Flux2NetworkTrainer(NetworkTrainer):
         # Load Text Encoder (Mistral 3 or Qwen-3)
         te_dtype = torch.float8_e4m3fn if args.fp8_text_encoder else torch.bfloat16
         text_embedder = flux2_utils.load_text_embedder(
-            self.model_version_info, args.text_encoder, dtype=te_dtype, device=device, disable_mmap=True
+            self.model_version_info, args.text_encoder, dtype=te_dtype, device=device, disable_mmap=True,
+            device_map_auto=True,
         )
 
         # Encode with Text Encoder (Mistral 3 or Qwen-3)

--- a/src/musubi_tuner/modules/custom_offloading_utils.py
+++ b/src/musubi_tuner/modules/custom_offloading_utils.py
@@ -771,6 +771,41 @@ class _StagedCopier:
             pool.shutdown(wait=False)
 
 
+class _InOrderCopier:
+    """
+    Transfer engine for ``LoRAStreamOffloader`` on devices without ``torch.cuda`` streams (e.g. Intel XPU).
+
+    Enqueues the flat H2D copy with ``non_blocking=True`` on the device's default (in-order) queue and
+    returns no events: in-order execution already guarantees that (a) the copy runs after all previously
+    enqueued compute -- a ring slot is never overwritten while compute still uses it, so ``gate_event``
+    is unnecessary -- and (b) compute enqueued after the copy sees the loaded weights, so wait-events are
+    unnecessary. Pageable ``non_blocking`` H2D copies pipeline well on XPU (measured ~10.6 GB/s on Arc
+    B70, see ``swap_weight_devices_no_cuda``); pinned staging measured slower on this stack, so none is
+    used. No true copy/compute overlap (single queue), but the D2H half of the classic swap is gone and
+    the host never blocks on the transfer.
+    """
+
+    def __init__(self, device: torch.device, debug: bool = False):
+        self.device = device
+        self.debug = debug
+
+    def submit(self, key, dst_flat: torch.Tensor, src_flat: torch.Tensor, gate_event=None):
+        # gate_event is always None on non-CUDA devices (no cross-stream hazard on an in-order queue)
+        dst_flat.copy_(src_flat, non_blocking=True)
+
+    def wait(self, key):
+        return None  # in-order queue: compute enqueued after the copy sees the loaded weights
+
+    def pop_xfer_timing(self, key):
+        return None
+
+    def sync(self):
+        _synchronize_device(self.device)
+
+    def reset(self):
+        _synchronize_device(self.device)  # drain in-flight copies before ring state is rebuilt
+
+
 class LoRAStreamOffloader:
     """
     H2D-only offloader for training where the base weights are frozen (e.g. LoRA / LoHa / LoKr).
@@ -834,7 +869,14 @@ class LoRAStreamOffloader:
         self.debug = debug
         self.debug_interval = int(os.getenv("MUSUBI_TUNER_OFFLOADER_DEBUG_INTERVAL", "10"))  # steps between prints
 
-        assert device.type == "cuda", "LoRAStreamOffloader currently supports CUDA only"
+        assert device.type in ("cuda", "xpu"), "LoRAStreamOffloader supports CUDA and XPU only"
+        self.cuda_available = device.type == "cuda"
+        if not self.cuda_available and use_pinned_memory:
+            # XPU: pinned host memory measured slower than pageable non_blocking on this stack, and the
+            # CUDA-stream _DirectCopier cannot run there anyway -- force the pageable in-order path.
+            print(f"LoRAStreamOffloader[{block_type}]: ignoring use_pinned_memory on {device.type} (pageable in-order copier)")
+            use_pinned_memory = False
+            self.use_pinned_memory = False
 
         # ---- streaming placement: S evenly spaced block indices (midpoint formula -> distinct for S <= N) ----
         stream_idx = sorted({((2 * i + 1) * num_blocks) // (2 * blocks_to_swap) for i in range(blocks_to_swap)})
@@ -855,7 +897,10 @@ class LoRAStreamOffloader:
         # ---- transfer engine: owns the copy stream and all H2D primitives ----
         # pinned masters -> direct async H2D; pageable masters -> stage through a worker thread + pinned pool
         # (low "shared GPU memory" footprint, e.g. on Windows). Both expose the same submit/wait interface.
-        if use_pinned_memory:
+        # non-CUDA (XPU): in-order default-queue copier, no streams/events needed.
+        if not self.cuda_available:
+            self.copier = _InOrderCopier(device, debug=self.debug)
+        elif use_pinned_memory:
             self.copier = _DirectCopier(device, debug=self.debug)
         else:
             self.copier = _StagedCopier(device, num_staging=self.B, debug=self.debug)
@@ -908,6 +953,15 @@ class LoRAStreamOffloader:
     def _bind(self, block_idx: int, params: list[nn.Parameter]):
         for m, p in zip(self._modules(block_idx), params):
             m.weight = p
+
+    def _record_free_event(self):
+        """Event marking that compute is done with a ring slot (gates its next overwrite).
+
+        On non-CUDA devices returns None: the in-order queue already orders the next H2D copy after all
+        previously enqueued compute, so no gate is needed (and ``_InOrderCopier`` ignores gate_event)."""
+        if not self.cuda_available:
+            return None
+        return torch.cuda.current_stream().record_event()
 
     @staticmethod
     def _compute_layout(weights: list[torch.Tensor]) -> tuple[list[int], int]:
@@ -1081,7 +1135,7 @@ class LoRAStreamOffloader:
         if self.S == 0 or not self.is_stream[block_idx]:
             return
         j = self.rank[block_idx]
-        self.free_event[j % self.B] = torch.cuda.current_stream().record_event()
+        self.free_event[j % self.B] = self._record_free_event()
         if j + self.B < self.S:
             self._load(j + self.B, (j + self.B) % self.B, "fwd")  # same slot as rank j; evicts rank j
         elif self.forward_only and j == self.S - 1 and self.S > self.B:
@@ -1102,7 +1156,7 @@ class LoRAStreamOffloader:
             if prefetch:
                 # consumed block_index in backward: free its slot and prefetch B streaming-slots behind
                 j = self.rank[block_index]
-                self.free_event[j % self.B] = torch.cuda.current_stream().record_event()
+                self.free_event[j % self.B] = self._record_free_event()
                 if j - self.B >= 0:
                     self._load(j - self.B, (j - self.B) % self.B, "bwd")  # same slot as rank j; evicts rank j
             if wait_prev:
@@ -1125,7 +1179,7 @@ class LoRAStreamOffloader:
         # finalize the events accumulated for the step that just ended, then print every debug_interval steps
         if not any(self._cur[c]["waits"] or self._cur[c]["loads"] for c in ("fwd", "bwd")):
             return  # very first forward: nothing finished yet
-        torch.cuda.synchronize()  # ensure timing events are complete (debug only)
+        _synchronize_device(self.device)  # ensure timing events are complete (debug only)
         for ctx in ("fwd", "bwd"):
             c, r = self._cur[ctx], self._roll[ctx]
             r["stall_ms"] += sum(a.elapsed_time(b) for a, b in c["stall_ev"])

--- a/src/musubi_tuner/modules/custom_offloading_utils.py
+++ b/src/musubi_tuner/modules/custom_offloading_utils.py
@@ -25,6 +25,21 @@ def _clean_memory_on_device(device: torch.device):
         torch.mps.empty_cache()
 
 
+class _SyncFuture:
+    """A Future-like object that wraps an already-completed result.
+
+    Used on XPU/non-CUDA devices where block swaps are performed synchronously
+    on the calling thread. This avoids the ThreadPoolExecutor deadlock that
+    occurs when torch.xpu.synchronize() is called from a worker thread.
+    """
+
+    def __init__(self, result):
+        self._result = result
+
+    def result(self, timeout=None):
+        return self._result
+
+
 def _synchronize_device(device: torch.device):
     if device.type == "cuda":
         torch.cuda.synchronize()
@@ -35,8 +50,13 @@ def _synchronize_device(device: torch.device):
 
 
 def swap_weight_devices_no_cuda(device: torch.device, layer_to_cpu: nn.Module, layer_to_cuda: nn.Module):
-    """
-    not tested
+    """Swap weights between two layers without CUDA streams.
+
+    On XPU/non-CUDA devices, transfers are inherently synchronous so we avoid
+    the redundant torch.xpu.synchronize() calls that the original code made
+    between the two halves of the swap.  Those per-swap synchronize calls can
+    trigger UR_RESULT_ERROR_DEVICE_LOST on Intel Arc GPUs when invoked during
+    an active autograd pass.
     """
     assert layer_to_cpu.__class__ == layer_to_cuda.__class__
 
@@ -45,17 +65,23 @@ def swap_weight_devices_no_cuda(device: torch.device, layer_to_cpu: nn.Module, l
         if hasattr(module_to_cpu, "weight") and module_to_cpu.weight is not None:
             weight_swap_jobs.append((module_to_cpu, module_to_cuda, module_to_cpu.weight.data, module_to_cuda.weight.data))
 
-    # device to cpu
-    for module_to_cpu, module_to_cuda, cuda_data_view, cpu_data_view in weight_swap_jobs:
-        module_to_cpu.weight.data = cuda_data_view.data.to("cpu", non_blocking=True)
-
-    _synchronize_device(device)
-
-    # cpu to device
-    for module_to_cpu, module_to_cuda, cuda_data_view, cpu_data_view in weight_swap_jobs:
-        cuda_data_view.copy_(module_to_cuda.weight.data, non_blocking=True)
-        module_to_cuda.weight.data = cuda_data_view
-
+    # Move each block to its target device. On non-CUDA devices these
+    # operations are synchronous, so no inter-copy barrier is required.
+    # IMPORTANT: each block keeps ITS OWN weights; only the device changes.
+    # Do NOT cross-assign the two blocks' weights (that scrambles parameters
+    # between blocks and silently corrupts training/inference).
+    for module_to_cpu, module_to_cuda, cpu_data, cuda_data in weight_swap_jobs:
+        # cpu_data  = module_to_cpu's weights  (currently on device, going to CPU)
+        # cuda_data = module_to_cuda's weights (currently on CPU,   going to device)
+        module_to_cpu.weight.data = cpu_data.to(device="cpu", non_blocking=True)
+        module_to_cuda.weight.data = cuda_data.to(device=device, non_blocking=True)
+    # One synchronize AFTER queuing all transfers. On XPU the non_blocking copies
+    # pipeline, so a single trailing sync drains them ~3x faster than blocking
+    # copies (which synchronize per tensor: ~3.3 -> ~10.6 GB/s on Arc B70).
+    # The sync is required: this synchronous path's contract is "all transfers
+    # complete before the function returns". A single synchronize on the calling
+    # (main) thread is safe -- this is NOT the per-swap mid-autograd synchronize
+    # from worker threads that triggered UR_RESULT_ERROR_DEVICE_LOST.
     _synchronize_device(device)
 
 
@@ -63,6 +89,8 @@ def weighs_to_device(layer: nn.Module, device: torch.device):
     for module in layer.modules():
         if hasattr(module, "weight") and module.weight is not None and module.__class__.__name__.endswith("Linear"):
             module.weight.data = module.weight.data.to(device, non_blocking=device.type != "cpu")
+            # fp8 scale_weight is kept CUDA-resident permanently (swap_weight_devices_cuda only swaps .weight).
+            # Moving scale_weight to CPU here would leave it stranded after async weight swaps during forward.
 
 
 @dataclass
@@ -181,6 +209,7 @@ class Offloader:
         self.thread_pool = ThreadPoolExecutor(max_workers=1)
         self.futures = {}
         self.cuda_available = device.type == "cuda"
+        self.xpu_available = device.type == "xpu"
         self.stream = torch.cuda.Stream(device=device) if self.cuda_available else None
 
         # Staging buffers for cuda offloading without large pinned memory. These are pinned memory buffers to speed up the transfer between CPU and GPU
@@ -382,11 +411,34 @@ class Offloader:
         return sync_event
 
     def _submit_move_blocks(self, blocks, block_idx_to_cpu, block_idx_to_cuda):
+        block_to_cpu = blocks[block_idx_to_cpu]
+        block_to_cuda = blocks[block_idx_to_cuda]
+
+        # XPU/non-CUDA: perform synchronously on calling thread to avoid
+        # ThreadPoolExecutor deadlock (torch.xpu.synchronize is not
+        # thread-safe and the SYCL context is bound to the main thread).
+        if self.xpu_available or not self.cuda_available:
+            if self.debug:
+                start_time = time.perf_counter()
+                print(
+                    f"[{self.block_type}] Move block {block_idx_to_cpu} to CPU and block {block_idx_to_cuda} to device (synchronous)"
+                )
+
+            swap_weight_devices_no_cuda(self.device, block_to_cpu, block_to_cuda)
+
+            if self.debug:
+                print(
+                    f"[{self.block_type}] Moved blocks {block_idx_to_cpu} to CPU and {block_idx_to_cuda} to device in {time.perf_counter() - start_time:.2f}s (synchronous)"
+                )
+
+            self.futures[block_idx_to_cuda] = _SyncFuture((block_idx_to_cpu, block_idx_to_cuda, None))
+            return
+
         def move_blocks(bidx_to_cpu, block_to_cpu, bidx_to_cuda, block_to_cuda):
             if self.debug:
                 start_time = time.perf_counter()
                 print(
-                    f"[{self.block_type}] Move block {bidx_to_cpu} to CPU and block {bidx_to_cuda} to {'CUDA' if self.cuda_available else 'device'}"
+                    f"[{self.block_type}] Move block {bidx_to_cpu} to CPU and block {bidx_to_cuda} to CUDA"
                 )
 
             dev = self.device.index if self.device.index is not None else torch.cuda.current_device()
@@ -396,12 +448,9 @@ class Offloader:
 
             if self.debug:
                 print(
-                    f"[{self.block_type}] Moved blocks {bidx_to_cpu} to CPU and {bidx_to_cuda} to {'CUDA' if self.cuda_available else 'device'} in {time.perf_counter() - start_time:.2f}s"
+                    f"[{self.block_type}] Moved blocks {bidx_to_cpu} to CPU and {bidx_to_cuda} to CUDA in {time.perf_counter() - start_time:.2f}s"
                 )
             return bidx_to_cpu, bidx_to_cuda, sync_event
-
-        block_to_cpu = blocks[block_idx_to_cpu]
-        block_to_cuda = blocks[block_idx_to_cuda]
 
         self.futures[block_idx_to_cuda] = self.thread_pool.submit(
             move_blocks, block_idx_to_cpu, block_to_cpu, block_idx_to_cuda, block_to_cuda
@@ -423,6 +472,11 @@ class Offloader:
         if self.cuda_available and sync_event is not None:
             # this does not wait CPU side, so the log below should be immediate when pinned memory is used
             torch.cuda.current_stream().wait_event(sync_event)
+
+        # On XPU, swaps are already synchronous (no thread pool), so no
+        # additional synchronisation is needed.  Calling torch.xpu.synchronize()
+        # here during an active autograd pass can trigger UR_RESULT_ERROR_DEVICE_LOST
+        # on Intel Arc GPUs.
 
         if self.debug:
             print(f"[{self.block_type}] Waited for block {block_idx}: {time.perf_counter() - start_time:.2f}s")

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -20,6 +20,53 @@ logging.basicConfig(level=logging.INFO)
 HUNYUAN_TARGET_REPLACE_MODULES = ["MMDoubleStreamBlock", "MMSingleStreamBlock"]
 
 
+class FusedLoRAAdd(torch.autograd.Function):
+    """Fused LoRA addition: computes org_forwarded + scale * lx @ lora_up_weight.T
+    without materializing the full [seq_len, out_dim] intermediate from lora_up.
+
+    Memory: saves one [seq_len, out_dim] tensor vs the unfused path. For backward,
+    only the tiny [seq_len, rank] tensor lx is saved (not the large lora_up output).
+
+    Dtype contract (matches the unfused path + _match_org_dtype): all three matmul
+    operands run in lx's dtype -- callers must pass org_forwarded already cast to
+    lx.dtype (the delta dtype) and round the result back via _match_org_dtype, so
+    the sum happens in the (possibly higher-precision) delta dtype and is rounded
+    exactly once, identical to `org_forwarded + lx * multiplier * scale`.
+    """
+
+    @staticmethod
+    def forward(ctx, org_forwarded, lx, lora_up_weight, scale):
+        shape = org_forwarded.shape
+        # cast weight to activation dtype for mixed precision (weights fp32, activations bf16)
+        up_w = lora_up_weight.to(lx.dtype)
+        result = torch.addmm(
+            org_forwarded.reshape(-1, shape[-1]),
+            lx.reshape(-1, lx.shape[-1]),
+            up_w.t(),
+            beta=1.0,
+            alpha=scale,
+        ).reshape(shape)
+        ctx.save_for_backward(lx, lora_up_weight)
+        ctx.scale = scale
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        lx, lora_up_weight = ctx.saved_tensors
+        scale = ctx.scale
+        go_2d = grad_output.reshape(-1, grad_output.shape[-1])
+        lx_2d = lx.reshape(-1, lx.shape[-1])
+        # grad for org_forwarded: identity pass-through
+        grad_org = grad_output
+        # grad for lx: [N, rank] -- tiny
+        # cast weight to match grad dtype (mixed precision: weights fp32, activations bf16)
+        up_w = lora_up_weight.to(go_2d.dtype)
+        grad_lx = torch.mm(go_2d, up_w).mul_(scale).reshape_as(lx)
+        # grad for lora_up_weight: [out_dim, rank] -- tiny (compute in weight dtype for optimizer)
+        grad_up = torch.mm(go_2d.t(), lx_2d).mul_(scale).to(lora_up_weight.dtype)
+        return grad_org, grad_lx, grad_up, None
+
+
 class LoRAModule(torch.nn.Module):
     """
     replaces forward method of the original Linear, instead of replacing the original Linear module.
@@ -167,6 +214,16 @@ class LoRAModule(torch.nn.Module):
             else:
                 scale = self.scale
 
+            # Fused path (Linear, 2D/3D): org + scale * lx @ up.T in one addmm, avoiding
+            # materialization of the full [seq, out_dim] lora_up output. org_forwarded is
+            # cast to the delta dtype first and the sum rounded once via _match_org_dtype,
+            # which is numerically identical to the unfused add-then-round below.
+            if lx.dim() <= 3:
+                org_c = org_forwarded if org_forwarded.dtype == lx.dtype else org_forwarded.to(lx.dtype)
+                fused = FusedLoRAAdd.apply(org_c, lx, self.lora_up.weight, self.multiplier * scale)
+                return self._match_org_dtype(fused, org_forwarded)
+
+            # Conv2d/Conv3d fallback (4D/5D tensors): standard path
             lx = self.lora_up(lx)
 
             # Add in the (possibly higher-precision) delta dtype, then round the sum once.
@@ -344,8 +401,13 @@ class LoRAInfModule(LoRAModule):
         lora_input = self._lora_input(x)
         if self.split_dims is None:
             lx = self.lora_down(lora_input)
-            lx = self.lora_up(lx)
             org_forwarded = self.org_forward(x)
+            # Fused path (Linear, 2D/3D): see LoRAModule.forward for the dtype contract.
+            if lx.dim() <= 3:
+                org_c = org_forwarded if org_forwarded.dtype == lx.dtype else org_forwarded.to(lx.dtype)
+                fused = FusedLoRAAdd.apply(org_c, lx, self.lora_up.weight, self.multiplier * self.scale)
+                return self._match_org_dtype(fused, org_forwarded)
+            lx = self.lora_up(lx)
             # Add in the (possibly higher-precision) delta dtype, then round the sum once.
             return self._match_org_dtype(org_forwarded + lx * self.multiplier * self.scale, org_forwarded)
         else:

--- a/src/musubi_tuner/training/accelerator_setup.py
+++ b/src/musubi_tuner/training/accelerator_setup.py
@@ -82,13 +82,13 @@ def prepare_accelerator(args: argparse.Namespace) -> Accelerator:
     kwargs_handlers = [
         (
             InitProcessGroupKwargs(
-                backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
+                backend="gloo" if os.name == "nt" or not (torch.cuda.is_available() or torch.xpu.is_available()) else "nccl",
                 init_method=(
                     "env://?use_libuv=False" if os.name == "nt" and Version(torch.__version__) >= Version("2.4.0") else None
                 ),
                 timeout=timedelta(minutes=args.ddp_timeout) if args.ddp_timeout else None,
             )
-            if torch.cuda.device_count() > 1
+            if max(torch.cuda.device_count(), torch.xpu.device_count()) > 1
             else None
         ),
         (

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -837,8 +837,12 @@ class NetworkTrainer:
         # save random state to restore later
         rng_state = torch.get_rng_state()
         cuda_rng_state = None
+        xpu_rng_state = None
         try:
-            cuda_rng_state = torch.cuda.get_rng_state() if torch.cuda.is_available() else None
+            if torch.cuda.is_available():
+                cuda_rng_state = torch.cuda.get_rng_state()
+            elif torch.xpu.is_available():
+                xpu_rng_state = torch.xpu.get_rng_state()
         except Exception:
             pass
 
@@ -868,6 +872,8 @@ class NetworkTrainer:
         torch.set_rng_state(rng_state)
         if cuda_rng_state is not None:
             torch.cuda.set_rng_state(cuda_rng_state)
+        elif xpu_rng_state is not None:
+            torch.xpu.set_rng_state(xpu_rng_state)
 
         transformer.switch_block_swap_for_training()
         clean_memory_on_device(accelerator.device)
@@ -913,12 +919,18 @@ class NetworkTrainer:
         device = accelerator.device
         if seed is not None:
             torch.manual_seed(seed)
-            torch.cuda.manual_seed(seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed(seed)
+            elif torch.xpu.is_available():
+                torch.xpu.manual_seed(seed)
             generator = torch.Generator(device=device).manual_seed(seed)
         else:
             # True random sample image generation
             torch.seed()
-            torch.cuda.seed()
+            if torch.cuda.is_available():
+                torch.cuda.seed()
+            elif torch.xpu.is_available():
+                torch.xpu.seed()
             generator = torch.Generator(device=device).manual_seed(torch.initial_seed())
 
         logger.info(f"prompt: {prompt}")
@@ -2127,6 +2139,10 @@ class NetworkTrainer:
                     logs.update(loss_metrics)
                     logs.update(self.extra_step_logs(args, logs))
                     accelerator.log(logs, step=global_step)
+
+                # Periodic XPU synchronization to prevent driver queue buildup / deadlocks
+                if accelerator.device.type == "xpu" and global_step > 0 and global_step % 50 == 0:
+                    torch.xpu.synchronize()
 
                 if global_step >= args.max_train_steps:
                     break

--- a/src/musubi_tuner/utils/device_utils.py
+++ b/src/musubi_tuner/utils/device_utils.py
@@ -9,6 +9,8 @@ def clean_memory_on_device(device: Optional[Union[str, torch.device]]):
         device = torch.device(device)
     if device.type == "cuda":
         torch.cuda.empty_cache()
+    elif device.type == "xpu":
+        torch.xpu.empty_cache()
     elif device.type == "cpu":
         pass
     elif device.type == "mps":  # not tested

--- a/src/musubi_tuner/wan/modules/model.py
+++ b/src/musubi_tuner/wan/modules/model.py
@@ -410,7 +410,12 @@ class WanAttentionBlock(nn.Module):
             freqs(Tensor): Rope freqs, shape [1024, C / num_heads / 2]
         """
         org_dtype = x.dtype
-        assert e.dtype == torch.float32
+        # temporary-for-testing: XPU compatibility - allow bf16 e (from Wan2.2 time embedding on XPU)
+        if hasattr(torch.xpu, 'is_available') and torch.xpu.is_available():
+            if e.dtype != torch.float32:
+                e = e.to(torch.float32)
+        else:
+            assert e.dtype == torch.float32
         if self.model_version == "2.1":
             e = self.modulation.to(torch.float32) + e
             e = e.chunk(6, dim=1)
@@ -491,7 +496,11 @@ class Head(nn.Module):
             x(Tensor): Shape [B, L, C]
             e(Tensor): Shape [B, C] for 2.1, [B, L, 6, C] for 2.2
         """
-        assert e.dtype == torch.float32
+        # temporary-for-testing: XPU compatibility - allow bf16 e (from Wan2.2 time embedding on XPU)
+        if hasattr(torch.xpu, 'is_available') and torch.xpu.is_available() and e.dtype != torch.float32:
+            e = e.to(torch.float32)
+        else:
+            assert e.dtype == torch.float32
         if self.model_version == "2.1":
             e = (self.modulation.to(torch.float32) + e.unsqueeze(1)).chunk(2, dim=1)
             # x = self.head(self.norm(x) * (1 + e[1]) + e[0])
@@ -845,28 +854,45 @@ class WanModel(nn.Module):  # ModelMixin, ConfigMixin):
         x = torch.cat([torch.cat([u, u.new_zeros(1, seq_len - u.size(1), u.size(2))], dim=1) for u in x])
 
         # time embeddings
-        # with amp.autocast(dtype=torch.float32):
-        with torch.amp.autocast(device_type=device.type, dtype=torch.float32):
-            if self.model_version == "2.1" or self.force_v2_1_time_embedding:  # For Wan2.1
-                e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).float())
-                e0 = self.time_projection(e).unflatten(1, (6, self.dim))
-                # e0: torch.Size([1, 6, 5120]), e: torch.Size([1, 5120]), t: torch.Size([1])
-
-                if self.model_version != "2.1":  # Reshape to be compatible with 2.2 blocks
-                    e0 = e0.unsqueeze(1)
-                    e = e.unsqueeze(1)
-                    t = t.unsqueeze(1).expand(-1, seq_len)
-            else:  # For Wan2.2
-                if t.dim() == 1:
-                    # t = t.expand(t.size(0), seq_len) # this should be a bug in the original code
-                    t = t.unsqueeze(1).expand(-1, seq_len)
-                bt = t.size(0)
-                t = t.flatten()
-                e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).unflatten(0, (bt, seq_len)).float())
-                e0 = self.time_projection(e).unflatten(2, (6, self.dim))
-                # e0: torch.Size([1, 14040, 6, 5120]), e: torch.Size([1, 14040, 5120]), t: torch.Size([14040])
-
-        assert e.dtype == torch.float32 and e0.dtype == torch.float32
+        # Use enabled=False to run in current dtype without autocast
+        # This avoids dtype mismatch issues with XPU
+        if device.type == "xpu" and hasattr(torch.xpu, 'is_available') and torch.xpu.is_available():
+            # For XPU, use bfloat16 autocast since float32 is not properly supported
+            with torch.amp.autocast(device_type=device.type, dtype=torch.bfloat16):
+                if self.model_version == "2.1" or self.force_v2_1_time_embedding:
+                    e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).float())
+                    e0 = self.time_projection(e).unflatten(1, (6, self.dim))
+                    if self.model_version != "2.1":
+                        e0 = e0.unsqueeze(1)
+                        e = e.unsqueeze(1)
+                        t = t.unsqueeze(1).expand(-1, seq_len)
+                else:
+                    if t.dim() == 1:
+                        t = t.unsqueeze(1).expand(-1, seq_len)
+                    bt = t.size(0)
+                    t = t.flatten()
+                    e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).float())
+                    e = e.unflatten(0, (bt, seq_len))
+                    e0 = self.time_projection(e).unflatten(2, (6, self.dim))
+                e = e.to(torch.bfloat16)
+                e0 = e0.to(torch.bfloat16)
+        else:
+            with torch.amp.autocast(device_type=device.type, dtype=torch.float32):
+                if self.model_version == "2.1" or self.force_v2_1_time_embedding:
+                    e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).float())
+                    e0 = self.time_projection(e).unflatten(1, (6, self.dim))
+                    if self.model_version != "2.1":
+                        e0 = e0.unsqueeze(1)
+                        e = e.unsqueeze(1)
+                        t = t.unsqueeze(1).expand(-1, seq_len)
+                else:
+                    if t.dim() == 1:
+                        t = t.unsqueeze(1).expand(-1, seq_len)
+                    bt = t.size(0)
+                    t = t.flatten()
+                    e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, t).float())
+                    e = e.unflatten(0, (bt, seq_len))
+                    e0 = self.time_projection(e).unflatten(2, (6, self.dim))
 
         # context
         context_lens = None

--- a/src/musubi_tuner/wan/modules/t5.py
+++ b/src/musubi_tuner/wan/modules/t5.py
@@ -454,7 +454,7 @@ class T5EncoderModel:
         self,
         text_len,
         dtype=torch.bfloat16,
-        device=torch.cuda.current_device(),
+        device=torch.device("cuda" if torch.cuda.is_available() else "xpu" if torch.xpu.is_available() else "cpu"),
         checkpoint_path=None,
         tokenizer_path=None,
         shard_fn=None,

--- a/src/musubi_tuner/wan_cache_latents.py
+++ b/src/musubi_tuner/wan_cache_latents.py
@@ -230,7 +230,7 @@ def main():
     if args.clip is not None:
         args.i2v = True
 
-    device = args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "cpu"
+    device = args.device if args.device is not None else ("xpu" if torch.xpu.is_available() else "cuda" if torch.cuda.is_available() else "cpu")
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/wan_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/wan_cache_text_encoder_outputs.py
@@ -46,7 +46,7 @@ def main():
 
     args = parser.parse_args()
 
-    device = args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "cpu"
+    device = args.device if args.device is not None else ("xpu" if torch.xpu.is_available() else "cuda" if torch.cuda.is_available() else "cpu")
     device = torch.device(device)
 
     # Load dataset config

--- a/src/musubi_tuner/wan_train_network.py
+++ b/src/musubi_tuner/wan_train_network.py
@@ -60,7 +60,12 @@ class WanNetworkTrainer(NetworkTrainer):
         self.dit_dtype = detect_wan_sd_dtype(args.dit)
 
         if self.dit_dtype == torch.float16:
-            assert args.mixed_precision in ["fp16", "no"], "DiT weights are in fp16, mixed precision must be fp16 or no"
+            if args.mixed_precision not in ["fp16", "no"]:
+                if torch.xpu.is_available():
+                    logger.warning(f"XPU detected: using mixed_precision={args.mixed_precision} with fp16 DiT weights (forcing bf16 for computation)")
+                    self.dit_dtype = torch.bfloat16
+                else:
+                    assert args.mixed_precision in ["fp16", "no"], "DiT weights are in fp16, mixed precision must be fp16 or no"
         elif self.dit_dtype == torch.bfloat16:
             assert args.mixed_precision in ["bf16", "no"], "DiT weights are in bf16, mixed precision must be bf16 or no"
 


### PR DESCRIPTION
Draft Notes: No Prior issue (I think) but another PR #801 found by the maintainer @kohya-ss so I  hope you're fine with me just babbeling on ... this is more a RFC, i Know there's work to do (commit message style, linting ...). However, this works, so I think there's value in doing a draft PR.

I don't mind if someone else fixes the issues and get's this into a accepable state, I'd be willing to re-test. But to be honest.. only if you actually have also tested it on a XPU GPU (the main issue being, that it's easy to break this and the biggest help is automating the change/test/validate loop). LLMs used include: MiniMax m2.7, m3, Opus 4.8 and Fable 5. Been doing this for the last couple of months. I still don't have a full-validation suite to ensure LTX 2.3, Wan 2.2 and Flux 2 (Dev) compatibility ... not sure how to handle this properly yet .. I also got an older RTX 3060, so I can validate against cuda (in principal, I'm not sure how big the differences between archs are there).

# Add Intel Arc (XPU) support: Flux 2 LoRA training

I've been rebasing a couple of times re-doing the XPU support a few times. I've an Intel Arc Pro B70 and have been using musubi-tuner to train Flux 2 Dev and LTX 2.3 (albeit the LTX 2.3 port has stalled out and I haven't included that change here).

There's still validation work to do:

- [ ] Verify CUDA still works (I've got an old 3060 12GB so I can verify, but haven't automated that yet)
- [ ] Make sure other base models / LoRA trainings still work (I've verified with Flux 2 Dev only in this latest iteration)
- [ ] Re-validate that there is no meaningful performance drop when supporting XPU in addition to CUDA
- [ ] Validate which base-version libraries and torch versions work and document the matrix
- [ ] Update to latest torch, transformers and bitsandbytes to make sure there's no incompatibility
- [ ] Clean up agent files and B70 support instructions

It's still rough on the edges, but I've validated it works on my machine :tm: the H2D-only swap makes it run a bit faster. The B70 is still slow compared to the NVIDIA beasts, but it has a lot of RAM for its price, so it's a niche I think is worth supporting.

## Summary

This PR ports and validates **Intel Arc (XPU)** support for training and inference on `kohya-ss/musubi-tuner` v0.3.4, with primary target hardware being **Intel Arc B70**. Training and caching now work end-to-end on `torch.xpu` for Flux 2.

The work is organized as a layered port: an XPU core in the offloader, then trainer and caching plumbing, then a model-specific port (Flux 2), then a hardware-tuned performance extension (H2D-only block swap), and finally docs.

## Changes

### Core XPU plumbing

- **`port(xpu): offloader XPU core`** — `custom_offloading_utils.py` now exposes XPU-aware device / stream / event abstractions alongside the existing CUDA path. All block-swap synchronization uses the same `stream_available` abstraction used upstream, generalized for `torch.xpu`.
- **`port(xpu): trainer + caching XPU plumbing`** — trainer and dataset caching paths select the XPU device correctly and skip CUDA-only codepaths.

### Model ports

- **`port(flux2): --device_map_auto for Mistral 3 text encoder`** — automatic device-map selection for the Mistral 3 text encoder used by Flux 2, removing the need to hand-tune placement on memory-constrained accelerators like Arc B70.
- **`port(flux2): block-swap ratio fix + drop Modulation/LastLayer fp32 upcasts`** — fixes block-swap ratios that were too aggressive on smaller VRAM budgets and removes unnecessary fp32 upcasts in Modulation / LastLayer that hurt throughput on Arc without measurable quality loss.
- **`port(lora): reimplement fused LoRA addition atop dtype bridging`** — fused LoRA `addmm` rewritten to handle dtype bridging between fp32 master weights and XPU activation dtypes.

### Performance

- **`perf(xpu): enable H2D-only block swap (LoRAStreamOffloader) on XPU`** — an XPU-only path that overlaps block H2D transfers with compute via dedicated streams, eliminating redundant D2H traffic during forward passes.

### Docs

- **`docs(xpu): current-state XPU docs + generic Flux 2 XPU training example`** — current state of XPU support, supported models, known limitations, and a runnable Flux 2 XPU training example.

## Validation

- Hardware: Intel Arc B70 (48 GB).
- Validated end-to-end:
  - Flux 2 LoRA training with `--device_map_auto`.
  - H2D-only block-swap path correctness.
- No CUDA-only behavior is regressed; the XPU additions are gated behind device availability, and the existing `cuda_available` checks were generalized to `stream_available`.

## Relationship to upstream PR #801

Upstream PR #801 (kohya-ss) adds XPU device / stream / event support to `custom_offloading_utils.py` and a forward-only ring-buffer offloading strategy. This PR overlaps with that work in the offloader core and is intended to be rebased on top of it once merged, or to feed back the Arc B70-specific extensions (stream sync details, H2D-only path) as follow-ups. I'd suggest coordinating in that PR's thread before this one is reviewed to avoid duplicate churn in the same file.

## Known limitations

- Some PyTorch XPU operations still have higher memory overhead than CUDA equivalents; the block-swap ratio fixes here mitigate this but do not eliminate it.
- FP8 paths are CUDA-only upstream at this point and are not enabled on XPU in this PR.