### PR TITLE
Speed up streamed safetensors FP8 loading with bounded prefetch

### DIFF
--- a/src/musubi_tuner/modules/fp8_optimization_utils.py
+++ b/src/musubi_tuner/modules/fp8_optimization_utils.py
@@ -1,4 +1,5 @@
 import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional, Union
 import torch
 import torch.nn as nn
@@ -14,6 +15,27 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 from musubi_tuner.utils.device_utils import clean_memory_on_device
+
+
+def _prefetch_tensors(reader, keys):
+    """Keep two independent file reads ahead of tensor processing."""
+    if not keys:
+        return
+
+    with MemoryEfficientSafeOpen(reader.filename, disable_numpy_memmap=reader.disable_numpy_memmap) as second_reader:
+        readers = (reader, second_reader)
+        with ThreadPoolExecutor(max_workers=2, thread_name_prefix="safetensors-prefetch") as executor:
+            pending = {
+                index: executor.submit(readers[index % len(readers)].get_tensor, keys[index])
+                for index in range(min(len(readers), len(keys)))
+            }
+            for index, key in enumerate(keys):
+                value = pending.pop(index).result()
+                next_index = index + len(readers)
+                if next_index < len(keys):
+                    next_reader = readers[next_index % len(readers)]
+                    pending[next_index] = executor.submit(next_reader.get_tensor, keys[next_index])
+                yield key, value
 
 
 def calculate_fp8_maxval(exp_bits=4, mantissa_bits=3, sign_bits=1):
@@ -299,9 +321,9 @@ def load_safetensors_with_fp8_optimization(
             f = TensorWeightAdapter(weight_transform_hooks, original_f) if weight_transform_hooks is not None else original_f
 
             keys = f.keys()
-            for key in tqdm(keys, desc=f"Loading {os.path.basename(model_file)}", unit="key"):
-                value = f.get_tensor(key)
-
+            use_prefetch = weight_transform_hooks is None and calc_device is not None and torch.device(calc_device).type != "cpu"
+            tensors = _prefetch_tensors(f, keys) if use_prefetch else ((key, f.get_tensor(key)) for key in keys)
+            for key, value in tqdm(tensors, total=len(keys), desc=f"Loading {os.path.basename(model_file)}", unit="key"):
                 # Save original device
                 original_device = value.device  # usually cpu
 


### PR DESCRIPTION
## Summary

- Overlap safetensors disk reads with the current tensor's CUDA FP8 conversion.
- Keep the pipeline bounded to two prefetched tensors instead of materializing the checkpoint in RAM.
- Preserve the original sequential behavior for CPU loading and `weight_transform_hooks` paths.
- Do not increase peak CUDA memory usage.

## Problem

`load_safetensors_with_fp8_optimization` currently performs each stage serially:

1. Read one tensor from the safetensors file into CPU memory.
2. Transfer the tensor to the calculation device.
3. Quantize it to FP8 and transfer the result back when required.
4. Start reading the next tensor only after all of that work finishes.

For large BF16 checkpoints, disk I/O and CUDA conversion therefore cannot overlap. This is especially visible on the 26.3 GB Krea 2 base checkpoint, where 24.3 GB across 224 target weights is dynamically block-quantized during startup.

## Implementation

This PR adds a small ordered prefetch iterator:

- It uses two independent `MemoryEfficientSafeOpen` readers.
- Each reader has at most one outstanding read on a standard-library `ThreadPoolExecutor` worker.
- Results are yielded in the original key order, so state-dict construction and quantization order are unchanged.
- While the caller transfers and quantizes tensor N, the workers can read tensors N+1 and N+2.
- The optimization is enabled only for a non-CPU calculation device and when no weight transform hooks are installed. CPU-only and transform-hook loading retain the old synchronous path.

The implementation uses only Python file handles and `concurrent.futures`, with no platform-specific I/O APIs. It works with the existing Windows and Linux loader path.

## Memory and correctness

The read-ahead happens only in CPU RAM. For the tested Krea 2 checkpoint, the largest source tensors are about 201.3 MB, so the additional temporary CPU memory is bounded to roughly two tensors (about 403 MB worst case). No additional tensors are queued on CUDA.

Full-checkpoint CUDA measurements were identical before and after the change:

| CUDA metric | Sequential loader | Prefetched loader |
| --- | ---: | ---: |
| Peak allocated | 1,217,396,736 bytes | 1,217,396,736 bytes |
| Peak reserved | 1,684,013,056 bytes | 1,684,013,056 bytes |
| `mem_get_info` free-memory drop | 1,480,589,312 bytes | 1,480,589,312 bytes |

The complete converted state dict also matched the original path:

- 654 output keys
- 14,508,042,544 tensor bytes
- Matching FP8 sample checksum and scale tensor

## Performance

Test environment:

- Windows
- Python 3.12.10
- PyTorch 2.13.0 + CUDA 13.0
- RTX 5090
- `Krea_2_Raw_Base.safetensors` (26,283,332,608 bytes, 430 source keys)
- Block FP8 conversion on CUDA with results retained on CPU for block swapping

| Scenario | Sequential loader | Prefetched loader | Improvement |
| --- | ---: | ---: | ---: |
| Cached file, separate processes | 9.722 s | 6.400 s | 34.2% |
| Fresh unbuffered file-copy runs | 13.012 s | 10.739 s | 17.5% |

Storage and host load naturally affect absolute timing, but both controlled cases improve while retaining identical output and CUDA peaks.

## Tests

- `python -m pytest -q tests/test_ideogram4_fp8_loading.py tests/test_krea2_gather_valid_text.py tests/test_krea2_timesteps.py`
  - 10 passed
- `python -m ruff check src/musubi_tuner/modules/fp8_optimization_utils.py`
- `python -m ruff format --check src/musubi_tuner/modules/fp8_optimization_utils.py`
- Full 26.3 GB checkpoint conversion with output-size, key-count, FP8 checksum, scale, and CUDA peak assertions