### PR TITLE
Fix training progress rate after the first warmup step

### DIFF
--- a/src/musubi_tuner/hidream_o1_train.py
+++ b/src/musubi_tuner/hidream_o1_train.py
@@ -527,8 +527,6 @@ class HiDreamO1Trainer(HiDreamO1NetworkTrainer):
                 keys_scaled, mean_norm, maximum_norm = None, None, None
 
                 if accelerator.sync_gradients:
-                    if global_step == 0:
-                        progress_bar.reset()
                     progress_bar.update(1)
                     global_step += 1
 
@@ -562,6 +560,8 @@ class HiDreamO1Trainer(HiDreamO1NetworkTrainer):
                         optimizer_train_fn()
 
                 current_loss = loss.detach().item()
+                if accelerator.sync_gradients and global_step == 1:
+                    train_utils.reset_progress_bar_timing(progress_bar)
                 loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
                 avr_loss = loss_recorder.moving_average
                 progress_bar.set_postfix(**{"avr_loss": avr_loss})

--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -1136,6 +1136,8 @@ class FineTuningTrainer:
                     optimizer_train_fn()
 
                 current_loss = loss.detach().item()
+                if accelerator.sync_gradients and global_step == 1:
+                    train_utils.reset_progress_bar_timing(progress_bar)
                 loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
                 avr_loss: float = loss_recorder.moving_average
                 logs = {"avr_loss": avr_loss}  # , "lr": lr_scheduler.get_last_lr()[0]}

--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -652,8 +652,6 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
 
                 # Checks if the accelerator has performed an optimization step behind the scenes
                 if accelerator.sync_gradients:
-                    if global_step == 0:
-                        progress_bar.reset()  # exclude first step from progress bar, because it may take long due to initializations
                     progress_bar.update(1)
                     global_step += 1
 
@@ -688,6 +686,8 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                         optimizer_train_fn()
 
                 current_loss = loss.detach().item()
+                if accelerator.sync_gradients and global_step == 1:
+                    train_utils.reset_progress_bar_timing(progress_bar)
                 loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
                 avr_loss: float = loss_recorder.moving_average
                 logs = {"avr_loss": avr_loss}  # , "lr": lr_scheduler.get_last_lr()[0]}

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -2082,8 +2082,6 @@ class NetworkTrainer:
 
                 # Checks if the accelerator has performed an optimization step behind the scenes
                 if accelerator.sync_gradients:
-                    if global_step == 0:
-                        progress_bar.reset()  # exclude first step from progress bar, because it may take long due to initializations
                     progress_bar.update(1)
                     global_step += 1
 
@@ -2112,6 +2110,8 @@ class NetworkTrainer:
                         optimizer_train_fn()
 
                 current_loss = loss.detach().item()
+                if accelerator.sync_gradients and global_step == 1:
+                    train_utils.reset_progress_bar_timing(progress_bar)
                 loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
                 avr_loss: float = loss_recorder.moving_average
                 logs = {"avr_loss": avr_loss}  # , "lr": lr_scheduler.get_last_lr()[0]}

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -61,6 +61,29 @@ def get_sanitized_config_or_none(args: argparse.Namespace):
     return filtered_args
 
 
+def reset_progress_bar_timing(progress_bar) -> None:
+    """Exclude the first completed step from tqdm rate and ETA calculations."""
+
+    if getattr(progress_bar, "disable", False):
+        return
+
+    completed = progress_bar.n
+    now = progress_bar._time()
+    progress_bar.initial = completed
+    progress_bar.start_t = now
+    progress_bar.last_print_n = completed
+    progress_bar.last_print_t = now
+
+    # Match tqdm.reset()'s timing state without resetting the visible step count.
+    for attribute in ("_ema_dn", "_ema_dt", "_ema_miniters"):
+        average = getattr(progress_bar, attribute, None)
+        if average is not None:
+            average.last = 0
+            average.calls = 0
+
+    progress_bar.refresh()
+
+
 class LossRecorder:
     def __init__(self):
         self.loss_list: list[float] = []

--- a/src/musubi_tuner/zimage_train.py
+++ b/src/musubi_tuner/zimage_train.py
@@ -566,8 +566,6 @@ class ZImageTrainer(ZImageNetworkTrainer):
 
                 # Checks if the accelerator has performed an optimization step behind the scenes
                 if accelerator.sync_gradients:
-                    if global_step == 0:
-                        progress_bar.reset()  # exclude first step from progress bar, because it may take long due to initializations
                     progress_bar.update(1)
                     global_step += 1
 
@@ -602,6 +600,8 @@ class ZImageTrainer(ZImageNetworkTrainer):
                         optimizer_train_fn()
 
                 current_loss = loss.detach().item()
+                if accelerator.sync_gradients and global_step == 1:
+                    train_utils.reset_progress_bar_timing(progress_bar)
                 loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
                 avr_loss: float = loss_recorder.moving_average
                 logs = {"avr_loss": avr_loss}

--- a/tests/test_progress_bar_timing.py
+++ b/tests/test_progress_bar_timing.py
@@ -1,0 +1,102 @@
+import io
+from pathlib import Path
+
+import pytest
+from tqdm import tqdm
+
+from musubi_tuner.utils import train_utils
+
+
+class ManualClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def make_progress_bar(*, smoothing: float = 0.0):
+    clock = ManualClock()
+    output = io.StringIO()
+    progress_bar = tqdm(total=10, smoothing=smoothing, mininterval=0, miniters=1, file=output)
+    progress_bar._time = clock
+    progress_bar.start_t = clock.value
+    progress_bar.last_print_t = clock.value
+    return progress_bar, clock, output
+
+
+def test_first_step_is_baseline_for_rate_and_eta():
+    progress_bar, clock, _ = make_progress_bar()
+    try:
+        clock.value = 10.0
+        progress_bar.update(1)
+        train_utils.reset_progress_bar_timing(progress_bar)
+
+        assert progress_bar.n == 1
+        assert progress_bar.initial == 1
+        assert progress_bar.total == 10
+        assert progress_bar.format_dict["elapsed"] == 0
+        assert "?it/s" in tqdm.format_meter(**progress_bar.format_dict)
+
+        clock.value = 14.0
+        progress_bar.update(1)
+        assert progress_bar.format_dict["elapsed"] == 4
+        meter = tqdm.format_meter(**progress_bar.format_dict)
+        assert "4.00s/it" in meter
+        assert "<00:32" in meter
+
+        clock.value = 22.0
+        progress_bar.update(2)
+        meter = tqdm.format_meter(**progress_bar.format_dict)
+        assert "4.00s/it" in meter
+        assert "<00:24" in meter
+    finally:
+        progress_bar.close()
+
+
+def test_timing_reset_clears_exponential_average_history():
+    progress_bar, clock, _ = make_progress_bar(smoothing=0.3)
+    try:
+        clock.value = 10.0
+        progress_bar.update(1)
+        assert progress_bar._ema_dt.calls == 1
+
+        train_utils.reset_progress_bar_timing(progress_bar)
+        assert progress_bar._ema_dn.calls == 0
+        assert progress_bar._ema_dt.calls == 0
+        assert progress_bar._ema_miniters.calls == 0
+
+        clock.value = 14.0
+        progress_bar.update(1)
+        assert progress_bar.format_dict["rate"] == pytest.approx(0.25)
+    finally:
+        progress_bar.close()
+
+
+def test_disabled_progress_bar_is_unchanged():
+    progress_bar = tqdm(total=10, disable=True)
+    train_utils.reset_progress_bar_timing(progress_bar)
+    assert progress_bar.n == 0
+    assert progress_bar.total == 10
+
+
+def test_all_training_loops_reset_after_first_synchronized_loss():
+    source_root = Path(__file__).resolve().parents[1] / "src" / "musubi_tuner"
+    training_files = (
+        source_root / "training" / "trainer_base.py",
+        source_root / "hv_train.py",
+        source_root / "qwen_image_train.py",
+        source_root / "zimage_train.py",
+        source_root / "hidream_o1_train.py",
+    )
+
+    for path in training_files:
+        source = path.read_text(encoding="utf-8")
+        update = source.index("progress_bar.update(1)")
+        increment = source.index("global_step += 1", update)
+        synchronized_loss = source.index("current_loss = loss.detach().item()", increment)
+        reset = source.index("train_utils.reset_progress_bar_timing(progress_bar)", synchronized_loss)
+
+        assert update < increment < synchronized_loss < reset, path
+        assert "if accelerator.sync_gradients and global_step == 1:" in source[increment:reset]
+        assert "progress_bar.reset()" not in source


### PR DESCRIPTION
## Problem

Training progress uses `tqdm(..., smoothing=0)`, so its displayed rate is calculated from `(n - initial) / elapsed`.

The existing warmup exclusion resets the bar **before** the first `update(1)`. That restarts the clock, but leaves the baseline at zero. At step 4, for example, the elapsed time covers only steps 2-4 while the rate calculation still counts all four steps. This is why the reported `3.61s/it` initially looks substantially faster than the stable `~4.7s/it` rate and produces an optimistic ETA.

## Solution

Use the first completed synchronized training step as the timing baseline:

- update the visible bar to step 1 normally
- synchronize through `loss.detach().item()`, ensuring queued CUDA work from the first step is complete
- preserve the visible step and total while setting tqdm's rate baseline to the current count
- restart cumulative timing and clear EMA timing history
- refresh the first-step display to an unknown rate; step 2 and later then use only post-warmup timings
- no-op for disabled progress bars on non-main distributed processes

The helper uses tqdm's own clock, so there is no platform-specific timer behavior.

## Training paths covered

The shared behavior is applied to every training progress loop currently in the repository:

- general `NetworkTrainer` model training
- legacy Hunyuan Video training
- Qwen Image training
- Z-Image training
- HiDream O1 training

It runs only on synchronized gradient steps, so gradient accumulation does not reset the timer early.

## Result

The visible count remains correct at `1 / total`, but the first step no longer contaminates rate or ETA. Starting when step 2 completes, both values are calculated from completed post-warmup steps only.

A live wall-clock check used a 2-second first step followed by three 1-second steps:

```text
n=4 baseline=1 measured_steps=3 elapsed=3.002s seconds_per_step=1.001
```

## Validation

- `python -m pytest -q`: **64 passed**
- focused timing tests cover cumulative rate/ETA, EMA reset, disabled bars, and all five loop integrations
- `python -m ruff check`: passed for all touched files
- `python -m ruff format --check`: passed for all touched files
- live wall-clock behavior validated in the project venv on Windows
- implementation contains no OS-specific code and follows tqdm's same clock path on Linux