### PR TITLE
Optimize Krea 2 SDPA fallback performance on Windows

### DIFF
--- a/src/musubi_tuner/krea2_train_network.py
+++ b/src/musubi_tuner/krea2_train_network.py
@@ -32,6 +32,7 @@ from musubi_tuner.hv_train_network import (
 )
 from musubi_tuner.krea2 import krea2_utils
 from musubi_tuner.krea2 import krea2_sampling
+from musubi_tuner.modules.attention import should_use_external_flash_for_sdpa
 from musubi_tuner.qwen_image import qwen_image_utils
 from musubi_tuner.utils import model_utils
 
@@ -73,6 +74,13 @@ class Krea2NetworkTrainer(NetworkTrainer):
         # whole DiT (incl. norms) to fp8, which breaks. Require --fp8_scaled with --fp8_base.
         if args.fp8_base and not args.fp8_scaled:
             raise ValueError("Krea 2 fp8 supports only scaled fp8: pass --fp8_scaled together with --fp8_base.")
+        if args.sdpa and should_use_external_flash_for_sdpa():
+            args.sdpa = False
+            args.flash_attn = True
+            logger.info(
+                "PyTorch native FlashAttention is unavailable; using the external FlashAttention backend for SDPA. "
+                "Set MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA=1 to keep PyTorch's fallback backend."
+            )
         # RAW-train / Turbo-sample: the recommended K2 LoRA workflow is to train on the RAW
         # checkpoint and run inference on the distilled Turbo. --turbo_dit makes sample
         # generation during training swap the base weights to Turbo (LoRA, hooked on the live

--- a/src/musubi_tuner/modules/attention.py
+++ b/src/musubi_tuner/modules/attention.py
@@ -1,5 +1,6 @@
 # Unified attention function supporting various implementations
 
+import os
 from dataclasses import dataclass
 import torch
 from typing import Optional, Union
@@ -25,6 +26,62 @@ try:
     import xformers.ops as xops
 except ImportError:
     xops = None
+
+
+_external_flash_training_probe: dict[int, bool] = {}
+
+
+def _external_flash_supports_training(device: Optional[Union[str, torch.device]] = None) -> bool:
+    try:
+        parsed_device = torch.device("cuda" if device is None else device)
+        if parsed_device.type != "cuda":
+            return False
+        device_index = torch.cuda.current_device() if parsed_device.index is None else parsed_device.index
+    except (AssertionError, RuntimeError, TypeError, ValueError):
+        return False
+    if device_index in _external_flash_training_probe:
+        return _external_flash_training_probe[device_index]
+
+    supported = False
+    try:
+        probe_device = torch.device("cuda", device_index)
+        q = torch.zeros((1, 16, 2, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        k = torch.zeros((1, 16, 1, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        v = torch.zeros((1, 16, 1, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        output = flash_attn_func(q, k, v, dropout_p=0.0)
+        output.sum().backward()
+        torch.cuda.synchronize(probe_device)
+        supported = True
+    except Exception:
+        supported = False
+    _external_flash_training_probe[device_index] = supported
+    return supported
+
+
+def should_use_external_flash_for_sdpa(device: Optional[Union[str, torch.device]] = None) -> bool:
+    """Use FlashAttention when this PyTorch build has no native fused SDPA backend.
+
+    Windows PyTorch wheels can expose SDPA while lacking the native FlashAttention
+    implementation. In that case SDPA falls back to a substantially slower memory-efficient
+    kernel. The external FlashAttention package implements the same operation and keeps the
+    requested SDPA behavior aligned with Linux. Set MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA=1 to
+    retain PyTorch's fallback backend.
+    """
+    disabled = os.environ.get("MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA", "").strip().casefold()
+    if disabled in {"1", "true", "yes", "on"}:
+        return False
+    if flash_attn_func is None or flash_attn_varlen_func is None or not torch.cuda.is_available():
+        return False
+
+    native_flash_available = getattr(torch.backends.cuda, "is_flash_attention_available", None)
+    if native_flash_available is not None and native_flash_available():
+        return False
+
+    try:
+        major, _minor = torch.cuda.get_device_capability(device)
+    except (AssertionError, RuntimeError, ValueError):
+        return False
+    return major >= 8 and _external_flash_supports_training(device)
 
 
 @dataclass

--- a/tests/test_attention_backend_selection.py
+++ b/tests/test_attention_backend_selection.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import torch
+
+from musubi_tuner.modules import attention
+from musubi_tuner import krea2_train_network
+
+
+def _mock_external_flash_ready(monkeypatch, *, native_available=False, capability=(12, 0)):
+    monkeypatch.delenv("MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA", raising=False)
+    monkeypatch.setattr(attention, "flash_attn_func", object())
+    monkeypatch.setattr(attention, "flash_attn_varlen_func", object())
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+    monkeypatch.setattr(torch.backends.cuda, "is_flash_attention_available", lambda: native_available)
+    monkeypatch.setattr(attention, "_external_flash_supports_training", lambda device=None: True)
+
+
+def test_external_flash_replaces_missing_native_sdpa_flash(monkeypatch):
+    _mock_external_flash_ready(monkeypatch)
+
+    assert attention.should_use_external_flash_for_sdpa()
+
+
+def test_external_flash_does_not_replace_native_sdpa_flash(monkeypatch):
+    _mock_external_flash_ready(monkeypatch, native_available=True)
+
+    assert not attention.should_use_external_flash_for_sdpa()
+
+
+def test_external_flash_sdpa_can_be_disabled(monkeypatch):
+    _mock_external_flash_ready(monkeypatch)
+    monkeypatch.setenv("MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA", "1")
+
+    assert not attention.should_use_external_flash_for_sdpa()
+
+
+def test_external_flash_falls_back_when_training_probe_fails(monkeypatch):
+    _mock_external_flash_ready(monkeypatch)
+    monkeypatch.setattr(attention, "_external_flash_supports_training", lambda device=None: False)
+
+    assert not attention.should_use_external_flash_for_sdpa()
+
+
+def test_krea2_routes_sdpa_to_external_flash_when_needed(monkeypatch):
+    monkeypatch.setattr(krea2_train_network, "should_use_external_flash_for_sdpa", lambda: True)
+    args = SimpleNamespace(
+        fp8_base=True,
+        fp8_scaled=True,
+        sdpa=True,
+        flash_attn=False,
+        turbo_dit_cache=False,
+        turbo_dit=None,
+        blocks_to_swap=0,
+        sample_prompts=None,
+    )
+
+    krea2_train_network.Krea2NetworkTrainer().handle_model_specific_args(args)
+
+    assert not args.sdpa
+    assert args.flash_attn


### PR DESCRIPTION
## Summary

- Keep the portable `--sdpa` setting while routing Krea 2 training to external FlashAttention when the current PyTorch build has no native fused FlashAttention backend.
- Gate the fallback on CUDA capability, external package availability, and a real BF16 GQA forward/backward probe.
- Preserve PyTorch SDPA whenever native FlashAttention is available or the external backend cannot train successfully.
- Add `MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA=1` as an explicit opt-out.

## Why

On the tested Windows PyTorch/CUDA build, `torch.backends.cuda.is_flash_attention_available()` is false. Krea 2 SDPA therefore selects PyTorch's slower memory-efficient CUTLASS kernel, even though the same config uses native fused FlashAttention on Linux. The installed external FlashAttention package supports the required BF16 grouped-query forward and backward path on the same GPU.

## Benchmark

Same RTX 5090, Krea 2 config, 1024px dataset, batch size 1, rank 128, scaled FP8, and gradient checkpointing:

| Mode | Windows before | Windows after | Linux reference |
| --- | ---: | ---: | ---: |
| Eager | 3.38 s/it | 2.68-2.69 s/it | 2.73 s/it |
| `torch.compile` | 2.84 s/it | 2.15-2.17 s/it | 2.23 s/it |

The Linux numbers are from the supplied reference logs; Windows measurements used the same hardware and training settings.

## Safety and compatibility

The automatic fallback is Krea 2-specific and activates only when `--sdpa` is selected, CUDA compute capability is at least 8.0, both external FlashAttention entry points import, PyTorch reports no native FlashAttention, and a one-time forward/backward probe succeeds. Otherwise behavior is unchanged.

A 20-step comparison against SDPA produced a checkpoint relative L2 difference of approximately 0.00172.

## Validation

- `python -m pytest -q`: 65 passed
- `ruff check` on all changed Python files: passed
- `ruff format --check` on all changed Python files: passed
- End-to-end Krea 2 LoRA training tested in eager and compiled modes on Windows

Breaking changes: none.