### PR TITLE
Unify guarded SDPA acceleration across model trainers

### DIFF
--- a/src/musubi_tuner/hunyuan_model/attention.py
+++ b/src/musubi_tuner/hunyuan_model/attention.py
@@ -3,12 +3,14 @@ import math
 import torch
 import torch.nn.functional as F
 
+from musubi_tuner.modules.attention import AUTO_FLASH_ATTENTION_MODE, resolve_automatic_flash_mode
+
 try:
     import flash_attn
     from flash_attn.flash_attn_interface import _flash_attn_forward
     from flash_attn.flash_attn_interface import flash_attn_varlen_func
     from flash_attn.flash_attn_interface import flash_attn_func
-except ImportError:
+except Exception:
     flash_attn = None
     flash_attn_varlen_func = None
     _flash_attn_forward = None
@@ -127,6 +129,8 @@ def attention(
     q, k, v = q_or_qkv_list if type(q_or_qkv_list) == list else (q_or_qkv_list, k, v)
     if type(q_or_qkv_list) == list:
         q_or_qkv_list.clear()
+    if mode == AUTO_FLASH_ATTENTION_MODE:
+        mode = resolve_automatic_flash_mode(q, k, v)
     split_attn = total_len is not None
     if (split_attn or cu_seqlens_q is None) and mode == "sageattn":
         mode = "sageattn_fixlen"

--- a/src/musubi_tuner/hunyuan_model/models.py
+++ b/src/musubi_tuner/hunyuan_model/models.py
@@ -807,11 +807,11 @@ class HYVideoDiffusionTransformer(nn.Module):  # ModelMixin, ConfigMixin):
         max_seqlen_kv = max_seqlen_q
 
         attn_mask = total_len = None
-        if self.split_attn or self.attn_mode == "torch":
+        if self.split_attn or self.attn_mode in {"torch", "flash_auto"}:
             # calculate text length and total length
             text_len = text_mask.sum(dim=1)  #  (bs, )
             total_len = img_seq_len + text_len  # (bs, )
-        if self.attn_mode == "torch" and not self.split_attn:
+        if self.attn_mode in {"torch", "flash_auto"} and not self.split_attn:
             # initialize attention mask: bool tensor for sdpa, (b, 1, n, n)
             bs = img.shape[0]
             attn_mask = torch.zeros((bs, 1, max_seqlen_q, max_seqlen_q), dtype=torch.bool, device=text_mask.device)

--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -32,6 +32,7 @@ from diffusers.optimization import (
 from transformers.optimization import SchedulerType, TYPE_TO_SCHEDULER_FUNCTION
 
 from musubi_tuner.dataset import config_utils
+from musubi_tuner.modules.attention import resolve_sdpa_backend
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.hunyuan_model.models import load_transformer, get_rotary_pos_embed_by_shape
 import musubi_tuner.hunyuan_model.text_encoder as text_encoder_module
@@ -789,7 +790,7 @@ class FineTuningTrainer:
 
         logger.info(f"Loading DiT model from {args.dit}")
         if args.sdpa:
-            attn_mode = "torch"
+            attn_mode = resolve_sdpa_backend(getattr(args, "use_legacy_sdpa", False), accelerator.device)
         elif args.flash_attn:
             attn_mode = "flash"
         elif args.sage_attn:
@@ -1227,6 +1228,14 @@ def setup_parser() -> argparse.ArgumentParser:
         "--sdpa",
         action="store_true",
         help="use sdpa for CrossAttention (requires PyTorch 2.0) / CrossAttentionにsdpaを使う（PyTorch 2.0が必要）",
+    )
+    parser.add_argument(
+        "--use_legacy_sdpa",
+        action="store_true",
+        help=(
+            "keep PyTorch SDPA even when a verified external FlashAttention backend can replace a slower fallback; "
+            "only applies with --sdpa"
+        ),
     )
     parser.add_argument(
         "--flash_attn",

--- a/src/musubi_tuner/modules/attention.py
+++ b/src/musubi_tuner/modules/attention.py
@@ -1,19 +1,27 @@
 # Unified attention function supporting various implementations
 
-from dataclasses import dataclass
+import logging
+import os
+from dataclasses import dataclass, replace
 import torch
 from typing import Optional, Union
+
+
+logger = logging.getLogger(__name__)
+
+_flash_attn_import_error: Optional[Exception] = None
 
 try:
     import flash_attn
     from flash_attn.flash_attn_interface import _flash_attn_forward
     from flash_attn.flash_attn_interface import flash_attn_varlen_func
     from flash_attn.flash_attn_interface import flash_attn_func
-except ImportError:
+except Exception as exc:
     flash_attn = None
     flash_attn_varlen_func = None
     _flash_attn_forward = None
     flash_attn_func = None
+    _flash_attn_import_error = exc
 
 try:
     from sageattention import sageattn_varlen, sageattn
@@ -25,6 +33,130 @@ try:
     import xformers.ops as xops
 except ImportError:
     xops = None
+
+
+_external_flash_training_probe: dict[int, bool] = {}
+_automatic_flash_runtime_fallbacks: set[str] = set()
+AUTO_FLASH_ATTENTION_MODE = "flash_auto"
+
+
+def _external_flash_supports_training(device: Optional[Union[str, torch.device]] = None) -> bool:
+    if flash_attn_func is None or flash_attn_varlen_func is None:
+        return False
+    try:
+        parsed_device = torch.device("cuda" if device is None else device)
+        if parsed_device.type != "cuda":
+            return False
+        device_index = torch.cuda.current_device() if parsed_device.index is None else parsed_device.index
+    except (AssertionError, RuntimeError, TypeError, ValueError):
+        return False
+    if device_index in _external_flash_training_probe:
+        return _external_flash_training_probe[device_index]
+
+    supported = False
+    try:
+        probe_device = torch.device("cuda", device_index)
+        q = torch.zeros((2, 16, 2, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        k = torch.zeros((2, 16, 1, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        v = torch.zeros((2, 16, 1, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        fixed_output = flash_attn_func(q, k, v, dropout_p=0.0)
+
+        variable_tokens = 24
+        q_varlen = torch.zeros((variable_tokens, 2, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        k_varlen = torch.zeros((variable_tokens, 1, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        v_varlen = torch.zeros((variable_tokens, 1, 128), dtype=torch.bfloat16, device=probe_device, requires_grad=True)
+        cu_seqlens = torch.tensor([0, 8, variable_tokens], dtype=torch.int32, device=probe_device)
+        varlen_output = flash_attn_varlen_func(
+            q_varlen,
+            k_varlen,
+            v_varlen,
+            cu_seqlens,
+            cu_seqlens,
+            16,
+            16,
+            0.0,
+        )
+        (fixed_output.sum() + varlen_output.sum()).backward()
+        torch.cuda.synchronize(probe_device)
+        supported = True
+    except Exception:
+        supported = False
+    _external_flash_training_probe[device_index] = supported
+    return supported
+
+
+def should_use_external_flash_for_sdpa(device: Optional[Union[str, torch.device]] = None) -> bool:
+    """Use FlashAttention when this PyTorch build has no native fused SDPA backend.
+
+    Windows PyTorch wheels can expose SDPA while lacking the native FlashAttention
+    implementation. In that case SDPA falls back to a substantially slower memory-efficient
+    kernel. The external FlashAttention package implements the same operation and keeps the
+    requested SDPA behavior aligned with Linux. Set MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA=1 to
+    retain PyTorch's fallback backend.
+    """
+    disabled = os.environ.get("MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA", "").strip().casefold()
+    if disabled in {"1", "true", "yes", "on"}:
+        return False
+    if flash_attn_func is None or flash_attn_varlen_func is None or not torch.cuda.is_available():
+        return False
+
+    native_flash_available = getattr(torch.backends.cuda, "is_flash_attention_available", None)
+    try:
+        if native_flash_available is not None and native_flash_available():
+            return False
+    except Exception:
+        pass
+
+    try:
+        major, _minor = torch.cuda.get_device_capability(device)
+    except (AssertionError, RuntimeError, TypeError, ValueError):
+        return False
+    return major >= 8 and _external_flash_supports_training(device)
+
+
+def resolve_sdpa_backend(
+    use_legacy_sdpa: bool = False,
+    device: Optional[Union[str, torch.device]] = None,
+) -> str:
+    """Resolve an SDPA request to the fastest verified compatible backend.
+
+    PyTorch's native fused SDPA remains the first choice. When it is unavailable,
+    the external FlashAttention package is selected only after a CUDA forward and
+    backward probe succeeds. Any import, capability, or probe failure keeps the
+    original PyTorch SDPA path.
+    """
+    if use_legacy_sdpa:
+        logger.info("Using legacy PyTorch SDPA because --use_legacy_sdpa is enabled.")
+        return "torch"
+    if should_use_external_flash_for_sdpa(device):
+        logger.info("PyTorch native FlashAttention is unavailable; using the verified external FlashAttention backend for SDPA.")
+        return AUTO_FLASH_ATTENTION_MODE
+    logger.info("Using PyTorch SDPA; no compatible external replacement was selected.")
+    return "torch"
+
+
+def external_flash_supports_inputs(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> bool:
+    """Return whether a QKV triplet satisfies external FlashAttention's runtime contract."""
+    if not (q.is_cuda and k.is_cuda and v.is_cuda):
+        return False
+    if q.dtype not in {torch.float16, torch.bfloat16} or k.dtype != q.dtype or v.dtype != q.dtype:
+        return False
+    head_dim = q.shape[-1]
+    if head_dim <= 0 or head_dim > 256 or head_dim % 8 != 0:
+        return False
+    return q.shape[-2] % k.shape[-2] == 0 and k.shape[-2] == v.shape[-2]
+
+
+def resolve_automatic_flash_mode(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> str:
+    """Resolve the internal automatic mode for the actual model tensors."""
+    if external_flash_supports_inputs(q, k, v):
+        return "flash"
+
+    reason = f"device={q.device.type}, qkv_dtypes={q.dtype}/{k.dtype}/{v.dtype}, head_dim={q.shape[-1]}"
+    if reason not in _automatic_flash_runtime_fallbacks:
+        logger.info("Automatic external FlashAttention is incompatible with these tensors (%s); using PyTorch SDPA.", reason)
+        _automatic_flash_runtime_fallbacks.add(reason)
+    return "torch"
 
 
 @dataclass
@@ -113,6 +245,12 @@ def attention(
         assert k is not None and v is not None, "k and v must be provided if qkv_or_q is a tensor"
     if attn_params is None:
         attn_params = AttentionParams.create_attention_params("torch", False)
+    elif attn_params.attn_mode == AUTO_FLASH_ATTENTION_MODE:
+        runtime_mode = resolve_automatic_flash_mode(q, k, v)
+        attention_mask = attn_params.attention_mask
+        if runtime_mode == "torch" and isinstance(attention_mask, torch.Tensor) and attention_mask.ndim == 2:
+            attention_mask = attention_mask[:, None, None, :].to(torch.bool)
+        attn_params = replace(attn_params, attn_mode=runtime_mode, attention_mask=attention_mask)
 
     # GQA: q may carry more heads than k/v (e.g. Krea 2 = 48 query / 12 kv heads). flash and
     # sageattn group heads natively inside the kernel (verified), so they ignore this. For the

--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -15,6 +15,7 @@ from safetensors.torch import save_file
 
 from musubi_tuner import qwen_image_train_network
 from musubi_tuner.dataset import config_utils
+from musubi_tuner.modules.attention import resolve_sdpa_backend
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
 from musubi_tuner.modules.scheduling_flow_match_discrete import FlowMatchDiscreteScheduler
@@ -238,7 +239,7 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
 
         logger.info(f"Loading DiT model from {args.dit}")
         if args.sdpa:
-            attn_mode = "torch"
+            attn_mode = resolve_sdpa_backend(getattr(args, "use_legacy_sdpa", False), accelerator.device)
         elif args.flash_attn:
             attn_mode = "flash"
         elif args.sage_attn:

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -54,6 +54,14 @@ def _add_attention_args(parser: argparse.ArgumentParser) -> None:
         help="use sdpa for CrossAttention (requires PyTorch 2.0) / CrossAttentionにsdpaを使う（PyTorch 2.0が必要）",
     )
     parser.add_argument(
+        "--use_legacy_sdpa",
+        action="store_true",
+        help=(
+            "keep PyTorch SDPA even when a verified external FlashAttention backend can replace a slower fallback; "
+            "only applies with --sdpa"
+        ),
+    )
+    parser.add_argument(
         "--flash_attn",
         action="store_true",
         help="use FlashAttention for CrossAttention, requires FlashAttention / CrossAttentionにFlashAttentionを使う、FlashAttentionが必要",

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -39,6 +39,7 @@ from diffusers.optimization import (
 from transformers.optimization import SchedulerType, TYPE_TO_SCHEDULER_FUNCTION
 
 from musubi_tuner.dataset import config_utils
+from musubi_tuner.modules.attention import resolve_sdpa_backend
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.modules.lr_schedulers import RexLR
 from musubi_tuner.modules.scheduling_flow_match_discrete import FlowMatchDiscreteScheduler
@@ -1499,7 +1500,7 @@ class NetworkTrainer:
 
         logger.info(f"Loading DiT model from {args.dit}")
         if args.sdpa:
-            attn_mode = "torch"
+            attn_mode = resolve_sdpa_backend(getattr(args, "use_legacy_sdpa", False), accelerator.device)
         elif args.flash_attn:
             attn_mode = "flash"
         elif args.sage_attn:

--- a/src/musubi_tuner/wan/modules/attention.py
+++ b/src/musubi_tuner/wan/modules/attention.py
@@ -2,18 +2,20 @@
 from typing import Optional
 import torch
 
+from musubi_tuner.modules.attention import AUTO_FLASH_ATTENTION_MODE, resolve_automatic_flash_mode
+
 try:
     import flash_attn_interface
 
     FLASH_ATTN_3_AVAILABLE = True
-except ModuleNotFoundError:
+except Exception:
     FLASH_ATTN_3_AVAILABLE = False
 
 try:
     import flash_attn
 
     FLASH_ATTN_2_AVAILABLE = True
-except ModuleNotFoundError:
+except Exception:
     FLASH_ATTN_2_AVAILABLE = False
 
 try:
@@ -87,6 +89,12 @@ def flash_attention(
         assert k_lens is None or (
             min(k_lens) == max(k_lens) and k_lens[0] == lk
         ), f"k_lens is not supported except for flash attention 3 or sage attention. k_lens={k_lens}, lk={lk}."
+
+    if attn_mode == AUTO_FLASH_ATTENTION_MODE:
+        q = half(q)
+        k = half(k)
+        v = half(v)
+        attn_mode = resolve_automatic_flash_mode(q, k, v)
 
     # SDPA
     if attn_mode == "torch" or attn_mode == "sdpa":

--- a/src/musubi_tuner/zimage_train.py
+++ b/src/musubi_tuner/zimage_train.py
@@ -15,6 +15,7 @@ from safetensors.torch import save_file
 
 from musubi_tuner import zimage_train_network
 from musubi_tuner.dataset import config_utils
+from musubi_tuner.modules.attention import resolve_sdpa_backend
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
 from musubi_tuner.modules.scheduling_flow_match_discrete import FlowMatchDiscreteScheduler
@@ -173,7 +174,7 @@ class ZImageTrainer(ZImageNetworkTrainer):
 
         logger.info(f"Loading DiT model from {args.dit}")
         if args.sdpa:
-            attn_mode = "torch"
+            attn_mode = resolve_sdpa_backend(getattr(args, "use_legacy_sdpa", False), accelerator.device)
         elif args.flash_attn:
             attn_mode = "flash"
         elif args.sage_attn:

--- a/tests/test_attention_backend_selection.py
+++ b/tests/test_attention_backend_selection.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+
+import torch
+
+from musubi_tuner.modules import attention
+from musubi_tuner import hv_train
+from musubi_tuner.training.parser_common import setup_parser_common
+
+
+def _mock_external_flash_ready(monkeypatch, *, native_available=False, capability=(12, 0)):
+    monkeypatch.delenv("MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA", raising=False)
+    monkeypatch.setattr(attention, "flash_attn_func", object())
+    monkeypatch.setattr(attention, "flash_attn_varlen_func", object())
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+    monkeypatch.setattr(torch.backends.cuda, "is_flash_attention_available", lambda: native_available)
+    monkeypatch.setattr(attention, "_external_flash_supports_training", lambda device=None: True)
+
+
+def test_external_flash_replaces_missing_native_sdpa_flash(monkeypatch):
+    _mock_external_flash_ready(monkeypatch)
+
+    assert attention.should_use_external_flash_for_sdpa()
+
+
+def test_external_flash_does_not_replace_native_sdpa_flash(monkeypatch):
+    _mock_external_flash_ready(monkeypatch, native_available=True)
+
+    assert not attention.should_use_external_flash_for_sdpa()
+
+
+def test_external_flash_sdpa_can_be_disabled(monkeypatch):
+    _mock_external_flash_ready(monkeypatch)
+    monkeypatch.setenv("MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA", "1")
+
+    assert not attention.should_use_external_flash_for_sdpa()
+
+
+def test_external_flash_falls_back_when_training_probe_fails(monkeypatch):
+    _mock_external_flash_ready(monkeypatch)
+    monkeypatch.setattr(attention, "_external_flash_supports_training", lambda device=None: False)
+
+    assert not attention.should_use_external_flash_for_sdpa()
+
+
+def test_external_flash_handles_broken_native_availability_probe(monkeypatch):
+    _mock_external_flash_ready(monkeypatch)
+    monkeypatch.setattr(
+        torch.backends.cuda,
+        "is_flash_attention_available",
+        lambda: (_ for _ in ()).throw(RuntimeError("backend probe failed")),
+    )
+
+    assert attention.should_use_external_flash_for_sdpa()
+
+
+def test_sdpa_resolver_routes_to_verified_external_flash(monkeypatch):
+    monkeypatch.setattr(attention, "should_use_external_flash_for_sdpa", lambda device=None: True)
+
+    assert attention.resolve_sdpa_backend() == attention.AUTO_FLASH_ATTENTION_MODE
+
+
+def test_sdpa_resolver_falls_back_to_torch(monkeypatch):
+    monkeypatch.setattr(attention, "should_use_external_flash_for_sdpa", lambda device=None: False)
+
+    assert attention.resolve_sdpa_backend() == "torch"
+
+
+def test_legacy_sdpa_bypasses_external_probe(monkeypatch):
+    def unexpected_probe(device=None):
+        raise AssertionError("legacy SDPA must not probe the external backend")
+
+    monkeypatch.setattr(attention, "should_use_external_flash_for_sdpa", unexpected_probe)
+
+    assert attention.resolve_sdpa_backend(use_legacy_sdpa=True) == "torch"
+
+
+def test_automatic_flash_runtime_falls_back_for_unsupported_tensors(monkeypatch):
+    def unexpected_flash(*args, **kwargs):
+        raise AssertionError("unsupported tensors must not reach external FlashAttention")
+
+    monkeypatch.setattr(attention, "flash_attn_func", unexpected_flash)
+    query = torch.randn(1, 4, 1, 8, dtype=torch.float32)
+    params = attention.AttentionParams.create_attention_params(attention.AUTO_FLASH_ATTENTION_MODE, False)
+
+    output = attention.attention(query, query.clone(), query.clone(), params)
+
+    assert output.shape == (1, 4, 8)
+    assert output.dtype == torch.float32
+
+
+def test_automatic_flash_runtime_fallback_preserves_attention_mask():
+    query = torch.randn(1, 4, 1, 8, dtype=torch.float32)
+    text_mask = torch.tensor([[1, 0]], dtype=torch.int64)
+    automatic = attention.AttentionParams.create_attention_params_from_mask(
+        attention.AUTO_FLASH_ATTENTION_MODE, False, 2, text_mask
+    )
+    legacy = attention.AttentionParams.create_attention_params_from_mask("torch", False, 2, text_mask)
+
+    automatic_output = attention.attention(query, query.clone(), query.clone(), automatic)
+    legacy_output = attention.attention(query, query.clone(), query.clone(), legacy)
+
+    torch.testing.assert_close(automatic_output, legacy_output)
+
+
+def test_automatic_flash_runtime_routes_compatible_tensors(monkeypatch):
+    monkeypatch.setattr(attention, "external_flash_supports_inputs", lambda q, k, v: True)
+    monkeypatch.setattr(attention, "flash_attn_func", lambda q, k, v, dropout_p: q + k + v)
+    query = torch.ones(1, 4, 1, 8, dtype=torch.bfloat16)
+    params = attention.AttentionParams.create_attention_params(attention.AUTO_FLASH_ATTENTION_MODE, False)
+
+    output = attention.attention(query, query.clone(), query.clone(), params)
+
+    torch.testing.assert_close(output, torch.full((1, 4, 8), 3, dtype=torch.bfloat16))
+
+
+def test_common_parser_accepts_legacy_sdpa_flag():
+    args = setup_parser_common().parse_args(["--sdpa", "--use_legacy_sdpa"])
+
+    assert args.sdpa
+    assert args.use_legacy_sdpa
+
+
+def test_hunyuan_parser_accepts_legacy_sdpa_flag():
+    args = hv_train.setup_parser().parse_args(["--sdpa", "--use_legacy_sdpa"])
+
+    assert args.sdpa
+    assert args.use_legacy_sdpa
+
+
+def test_every_training_selector_delegates_sdpa_resolution():
+    source_root = Path(__file__).resolve().parents[1] / "src" / "musubi_tuner"
+    selector_files = [
+        source_root / "training" / "trainer_base.py",
+        source_root / "qwen_image_train.py",
+        source_root / "zimage_train.py",
+        source_root / "hv_train.py",
+    ]
+
+    for path in selector_files:
+        source = path.read_text(encoding="utf-8")
+        assert 'resolve_sdpa_backend(getattr(args, "use_legacy_sdpa", False)' in source, path.name


### PR DESCRIPTION
## Summary

- Centralize SDPA backend selection for every current network and full-training entry point instead of mutating Krea 2 arguments.
- Keep PyTorch SDPA as the portable user-facing choice and prefer its native fused FlashAttention backend when available.
- When native fused SDPA is unavailable, select external FlashAttention only after fixed-length and variable-length BF16 GQA forward/backward CUDA probes pass.
- Re-check the real Q/K/V tensors at runtime and fall back to PyTorch SDPA for incompatible devices, dtypes, head dimensions, or GQA layouts while preserving padding masks.
- Add `--use_legacy_sdpa` as an explicit compatibility/benchmark opt-out. `MUSUBI_DISABLE_EXTERNAL_FLASH_SDPA=1` remains available for diagnostics.

## Coverage

The shared resolver is used by:

- the common `NetworkTrainer` path (Krea 2, Qwen Image, Wan, FLUX.2/Klein, Z-Image, Ideogram 4, and other network trainers)
- Qwen Image full training
- Z-Image full training
- the legacy HunyuanVideo full trainer

Wan and HunyuanVideo retain only small layout adapters for the internal automatic mode. Explicit FlashAttention, FlashAttention 3, SageAttention, and xFormers selections are unchanged.

## Why

Some Windows PyTorch builds expose SDPA without a native fused FlashAttention kernel. Those builds can fall back to a substantially slower memory-efficient kernel even when the installed external FlashAttention package supports the model. The previous PR handled only Krea 2 by rewriting its attention arguments. This version makes the policy shared, keeps user intent intact, and adds a per-tensor fallback needed by models such as Ideogram 4.

## Controlled Windows benchmarks

RTX 5090, Torch 2.13.0+cu130, batch size 1, rank 128 LoRA, gradient checkpointing, 20 steps, `torch.compile` disabled, and `blocks_to_swap = 0` in every pair:

| Model | Legacy PyTorch SDPA | Automatic | Change |
| --- | ---: | ---: | ---: |
| Krea 2, 1024 px | 3.50 s/it | 2.81 s/it | 19.71% faster |
| Qwen Image, 512 px | 3.05 s/it | 2.80 s/it | 8.20% faster |
| FLUX Klein 4B, 512 px | 5.10 s/it | 4.99 s/it | 2.16% faster |
| FLUX Klein 9B, 512 px | 5.79 s/it | 5.64 s/it | 2.59% faster |
| Wan 2.1 14B, 512 px | 1.58 s/it | 1.54 s/it | 2.53% faster |
| Z-Image, 512 px | 5.57 s/it | 5.42 s/it | 2.69% faster |
| Ideogram 4, 512 px | 5.79 s/it | 5.73 s/it | safe PyTorch fallback |

The Ideogram run produced FlashAttention-incompatible mixed/FP32 attention tensors. Automatic mode detected this and completed on PyTorch SDPA; its 1% difference is treated as measurement noise rather than an acceleration claim.

## Safety

Automatic external FlashAttention is selected only when all of these hold:

1. SDPA was requested and legacy mode was not requested.
2. CUDA and both external FlashAttention entry points are available.
3. PyTorch reports no native fused FlashAttention backend.
4. The GPU is compute capability 8.0 or newer.
5. Fixed and variable-length BF16 GQA forward/backward probes succeed.
6. Actual runtime tensors satisfy FlashAttention's device, dtype, head-dimension, and grouping contract.

Any failed check retains the existing PyTorch SDPA path. Native fused SDPA platforms, unsupported GPUs, CPU execution, missing/broken FlashAttention installations, and explicit alternative attention modes keep their previous behavior.

## Validation

- Full clean-upstream test suite: `74 passed`
- Focused backend/parser/fallback tests: `14 passed`
- Ruff check on every changed Python file: passed
- Ruff format check on every changed Python file: passed
- Seven real no-block-swap legacy/automatic training pairs completed on Windows

Breaking changes: none.