### PR TITLE
docs: document --log_grad_metrics option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -58,6 +58,10 @@
 
 GitHub Discussionsを有効にしました。コミュニティのQ&A、知識共有、技術情報の交換などにご利用ください。バグ報告や機能リクエストにはIssuesを、質問や経験の共有にはDiscussionsをご利用ください。[Discussionはこちら](https://github.com/kohya-ss/musubi-tuner/discussions)
 
+- 2026/07/14
+    - 勾配ノルムの診断メトリクス（`grad/norm`, `grad/mean_norm`, `grad/max`、勾配クリッピング前の値）をトラッカーに出力する `--log_grad_metrics` オプションを追加しました。[PR #988](https://github.com/kohya-ss/musubi-tuner/pull/988) rockerBOO氏に感謝します。
+        - 勾配の爆発・消失の診断や、適切な `--max_grad_norm` の値を決める際に役立ちます。デフォルトでは無効です。詳細は[高度な設定のドキュメント](./docs/advanced_config.md#log-gradient-metrics--勾配メトリクスのログ出力)を参照してください。
+
 - 2026/06/24
     - Krea 2に実験的に対応しました（LoRA学習、推論）。[PR #980](https://github.com/kohya-ss/musubi-tuner/pull/980)
         - 詳細は[ドキュメント](./docs/krea2.md)を参照してください。

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ If you find this project helpful, please consider supporting its development via
 
 GitHub Discussions Enabled: We've enabled GitHub Discussions for community Q&A, knowledge sharing, and technical information exchange. Please use Issues for bug reports and feature requests, and Discussions for questions and sharing experiences. [Join the conversation →](https://github.com/kohya-ss/musubi-tuner/discussions)
 
+- July 14, 2026
+    - Added the `--log_grad_metrics` option to log gradient norm diagnostics (`grad/norm`, `grad/mean_norm`, `grad/max`, measured before gradient clipping) to the tracker. Thank you rockerBOO [PR #988](https://github.com/kohya-ss/musubi-tuner/pull/988).
+        - Useful for diagnosing gradient explosion / vanishing and for choosing an appropriate `--max_grad_norm` value. Disabled by default. See the [advanced configuration documentation](./docs/advanced_config.md#log-gradient-metrics--勾配メトリクスのログ出力) for details.
+
 - June 24, 2026
     - Added experimental support for Krea 2 (LoRA training and inference). See [PR #980](https://github.com/kohya-ss/musubi-tuner/pull/980) for details.
         - For details, please refer to the [documentation](./docs/krea2.md).

--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -11,6 +11,7 @@
 - [Select the target modules of LoRA](#select-the-target-modules-of-lora--loraの対象モジュールを選択する)
 - [Save and view logs in TensorBoard format](#save-and-view-logs-in-tensorboard-format--tensorboard形式のログの保存と参照)
 - [Save and view logs in wandb](#save-and-view-logs-in-wandb--wandbでログの保存と参照)
+- [Log gradient metrics](#log-gradient-metrics--勾配メトリクスのログ出力)
 - [FP8 weight optimization for models](#fp8-weight-optimization-for-models--モデルの重みのfp8への最適化)
 - [PyTorch Dynamo optimization for model training](#pytorch-dynamo-optimization-for-model-training--モデルの学習におけるpytorch-dynamoの最適化)
 - [MagCache](#magcache)
@@ -272,6 +273,32 @@ Specify the project name with `--log_tracker_name` when using wandb.
 `--log_with wandb`オプションを指定するとwandb形式でログを保存することができます。`tensorboard`や`all`も指定可能です。デフォルトは`tensorboard`です。
 
 wandbを使用する場合は、`--log_tracker_name`でプロジェクト名を指定してください。
+</details>
+
+## Log gradient metrics / 勾配メトリクスのログ出力
+
+The `--log_grad_metrics` option logs gradient norm diagnostics to the tracker (TensorBoard or wandb) at each optimization step. It is disabled by default.
+
+The following metrics are recorded, measured **before gradient clipping** (i.e. before `--max_grad_norm` is applied):
+
+- `grad/norm`: the total L2 norm over all trainable parameters (the same value that `--max_grad_norm` clips against).
+- `grad/mean_norm`: the mean of the per-parameter L2 norms.
+- `grad/max`: the maximum absolute gradient element.
+
+These are useful for diagnosing gradient explosion / vanishing and for choosing an appropriate `--max_grad_norm` value. Enabling this option adds a small per-step GPU synchronization overhead, so it is recommended to enable it only when needed.
+
+<details>
+<summary>日本語</summary>
+
+`--log_grad_metrics`オプションを指定すると、各最適化ステップで勾配ノルムの診断メトリクスをトラッカー（TensorBoardまたはwandb）に出力します。デフォルトでは無効です。
+
+以下のメトリクスが、**勾配クリッピング前**（`--max_grad_norm`の適用前）の値として記録されます。
+
+- `grad/norm`: 全学習対象パラメータの合計L2ノルム（`--max_grad_norm`がクリッピングの基準とする値と同じ）。
+- `grad/mean_norm`: パラメータごとのL2ノルムの平均。
+- `grad/max`: 勾配要素の絶対値の最大。
+
+勾配の爆発・消失の診断や、適切な`--max_grad_norm`の値を決める際に役立ちます。本オプションを有効にするとステップごとにわずかなGPU同期のオーバーヘッドが発生するため、必要なときのみ有効にすることをお勧めします。
 </details>
 
 ## FP8 weight optimization for models / モデルの重みのFP8への最適化


### PR DESCRIPTION
Documents the gradient metrics logging feature added in #988.

## Changes
- Add a new **Log gradient metrics** section to `docs/advanced_config.md` (with a Table of Contents entry), describing the `--log_grad_metrics` option, the three logged metrics (`grad/norm`, `grad/mean_norm`, `grad/max`, measured before gradient clipping), their intended use, and the small per-step GPU sync overhead.
- Add a Recent Updates entry to `README.md` and `README.ja.md` (July 14, 2026), crediting rockerBOO / #988 and linking to the new documentation section.

Docs-only follow-up; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)