### PR TITLE
feat: Support seamless resume

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
   "matplotlib==3.10.0",
   "tensorboard",
   "prompt-toolkit==3.0.51",
-  "ruff>=0.12.10",
+  "ruff==0.15.12",
 ]
 
 [build-system]

--- a/src/musubi_tuner/dataset/bucket.py
+++ b/src/musubi_tuner/dataset/bucket.py
@@ -194,13 +194,14 @@ class BucketBatchManager:
 
         logger.info(f"total batches: {len(self)}")
 
-    def shuffle(self):
+    def shuffle(self, rng: Optional[random.Random] = None):
+        rng = rng if rng is not None else random
         # shuffle each bucket
         for bucket in self.buckets.values():
-            random.shuffle(bucket)
+            rng.shuffle(bucket)
 
         # shuffle the order of batches
-        random.shuffle(self.bucket_batch_indices)
+        rng.shuffle(self.bucket_batch_indices)
 
         if self.num_timestep_buckets is not None and self.num_timestep_buckets > 1:
             # prepare timesteps for each timestep buckets
@@ -217,10 +218,10 @@ class BucketBatchManager:
                 min_t = i / self.num_timestep_buckets
                 max_t = (i + 1) / self.num_timestep_buckets
                 for _ in range(samples_per_bucket):
-                    all_timesteps.append(random.uniform(min_t, max_t))
+                    all_timesteps.append(rng.uniform(min_t, max_t))
 
             # 3. Shuffle the entire pool thoroughly
-            random.shuffle(all_timesteps)
+            rng.shuffle(all_timesteps)
 
             # Trim the excess timesteps to match the exact number needed
             all_timesteps = all_timesteps[:total_timesteps_needed]

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -29,6 +29,7 @@ def _sorted_glob(pattern: str) -> list[str]:
 
     return sorted(glob.glob(pattern), key=os.path.normcase)
 
+
 from musubi_tuner.dataset.architectures import *  # noqa: F401,F403
 from musubi_tuner.dataset.architectures import (  # explicit imports for local use
     ARCHITECTURE_FLUX_2_DEV,

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -23,6 +23,12 @@ import logging
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+
+def _sorted_glob(pattern: str) -> list[str]:
+    """Return a stable file order across dataset reconstruction on resume."""
+
+    return sorted(glob.glob(pattern), key=os.path.normcase)
+
 from musubi_tuner.dataset.architectures import *  # noqa: F401,F403
 from musubi_tuner.dataset.architectures import (  # explicit imports for local use
     ARCHITECTURE_FLUX_2_DEV,
@@ -144,10 +150,10 @@ class BaseDataset(torch.utils.data.Dataset):
         return metadata
 
     def get_all_latent_cache_files(self):
-        return glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
+        return _sorted_glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
 
     def get_all_text_encoder_output_cache_files(self):
-        return glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}_te.safetensors"))
+        return _sorted_glob(os.path.join(self.cache_directory, f"*_{self.architecture}_te.safetensors"))
 
     def get_latent_cache_path(self, item_info: ItemInfo) -> str:
         """
@@ -505,7 +511,7 @@ class ImageDataset(BaseDataset):
         bucket_selector = BucketSelector(self.resolution, self.enable_bucket, self.bucket_no_upscale, self.architecture)
 
         # glob cache files
-        latent_cache_files = glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
+        latent_cache_files = _sorted_glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
 
         # assign cache files to item info
         # (width, height) -> [ItemInfo] or (width, height, other conds...) -> [ItemInfo]
@@ -561,9 +567,9 @@ class ImageDataset(BaseDataset):
         self.num_train_items = sum([len(bucket) for bucket in bucketed_item_info.values()])
 
     def shuffle_buckets(self):
-        # set random seed for this epoch
-        random.seed(self.seed + self.current_epoch)
-        self.batch_manager.shuffle()
+        # Keep dataset shuffling independent from the model's Python RNG.
+        rng = random.Random(self.seed + self.current_epoch)
+        self.batch_manager.shuffle(rng)
 
     def __len__(self):
         if self.batch_manager is None:
@@ -858,7 +864,7 @@ class VideoDataset(BaseDataset):
         bucket_selector = BucketSelector(self.resolution, self.enable_bucket, self.bucket_no_upscale, self.architecture)
 
         # glob cache files
-        latent_cache_files = glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
+        latent_cache_files = _sorted_glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
 
         # assign cache files to item info
         bucketed_item_info: dict[tuple[int, int, int], list[ItemInfo]] = {}  # (width, height, frame_count) -> [ItemInfo]
@@ -895,9 +901,9 @@ class VideoDataset(BaseDataset):
         self.num_train_items = sum([len(bucket) for bucket in bucketed_item_info.values()])
 
     def shuffle_buckets(self):
-        # set random seed for this epoch
-        random.seed(self.seed + self.current_epoch)
-        self.batch_manager.shuffle()
+        # Keep dataset shuffling independent from the model's Python RNG.
+        rng = random.Random(self.seed + self.current_epoch)
+        self.batch_manager.shuffle(rng)
 
     def __len__(self):
         if self.batch_manager is None:

--- a/src/musubi_tuner/training/accelerator_setup.py
+++ b/src/musubi_tuner/training/accelerator_setup.py
@@ -11,6 +11,8 @@ from packaging.version import Version
 from accelerate import Accelerator, InitProcessGroupKwargs, DistributedDataParallelKwargs
 from accelerate.utils import TorchDynamoPlugin, DynamoBackend
 
+from musubi_tuner.training.training_state import TrainingProgressState
+
 
 def clean_memory_on_device(device: torch.device):
     r"""
@@ -46,15 +48,51 @@ class collator_class:
         return examples[0]  # batch size is always 1, so we unwrap it here
 
 
-def prepare_accelerator(args: argparse.Namespace) -> Accelerator:
-    """
-    DeepSpeed is not supported in this script currently.
-    """
-    if args.logging_dir is None:
+class EpochSeededRandomSampler(torch.utils.data.Sampler[int]):
+    """Random sampler whose order is a pure function of seed and epoch."""
+
+    def __init__(self, data_source, seed: int, shared_epoch):
+        self.data_source = data_source
+        self.seed = int(seed)
+        self.shared_epoch = shared_epoch
+
+    def __iter__(self):
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + int(self.shared_epoch.value))
+        yield from torch.randperm(len(self.data_source), generator=generator).tolist()
+
+    def __len__(self):
+        return len(self.data_source)
+
+
+def resolve_logging_dir(args: argparse.Namespace) -> str | None:
+    """Resolve a new timestamped log directory or reuse the saved one."""
+
+    resume_logging_dir = None
+    if args.resume and not getattr(args, "resume_from_huggingface", False):
+        resume_state = TrainingProgressState.read_json(os.path.expanduser(args.resume))
+        if resume_state is not None:
+            resume_logging_dir = resume_state.logging_dir
+
+    if resume_logging_dir is not None:
+        logging_dir = resume_logging_dir
+    elif args.logging_dir is None:
         logging_dir = None
     else:
         log_prefix = "" if args.log_prefix is None else args.log_prefix
         logging_dir = args.logging_dir + "/" + log_prefix + time.strftime("%Y%m%d%H%M%S", time.localtime())
+
+    if logging_dir is not None:
+        logging_dir = os.path.abspath(os.path.expanduser(logging_dir))
+    args.resolved_logging_dir = logging_dir
+    return logging_dir
+
+
+def prepare_accelerator(args: argparse.Namespace) -> Accelerator:
+    """
+    DeepSpeed is not supported in this script currently.
+    """
+    logging_dir = resolve_logging_dir(args)
 
     if args.log_with is None:
         if logging_dir is not None:
@@ -78,6 +116,8 @@ def prepare_accelerator(args: argparse.Namespace) -> Accelerator:
                 os.environ["WANDB_DIR"] = logging_dir
             if args.wandb_api_key is not None:
                 wandb.login(key=args.wandb_api_key)
+
+    args.resolved_log_with = log_with
 
     kwargs_handlers = [
         (

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -619,7 +619,13 @@ def _add_save_load_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="base name of trained model file / 学習後のモデルの拡張子を除くファイル名",
     )
-    parser.add_argument("--resume", type=str, default=None, help="saved state to resume training / 学習再開するモデルのstate")
+    parser.add_argument(
+        "--resume",
+        type=str,
+        default=None,
+        help="saved state directory to resume training seamlessly; keep the original schedule, dataset, seed, "
+        "gradient accumulation, and process count / 学習再開するモデルのstateディレクトリ",
+    )
 
     parser.add_argument(
         "--save_every_n_epochs",

--- a/src/musubi_tuner/training/tensorboard_logs.py
+++ b/src/musubi_tuner/training/tensorboard_logs.py
@@ -21,11 +21,35 @@ class TensorBoardTrimResult:
     removed_events: int
 
 
+def _normalize_epoch_summary_step(event, epoch_log_step_mode: str, num_update_steps_per_epoch: Optional[int]):
+    """Migrate version-1 loss/epoch records from global-step to epoch-step."""
+
+    if (
+        epoch_log_step_mode != "global_step"
+        or not num_update_steps_per_epoch
+        or not event.HasField("summary")
+        or not event.summary.value
+        or any(value.tag != "loss/epoch" for value in event.summary.value)
+    ):
+        return event
+
+    epoch_step, remainder = divmod(int(event.step), int(num_update_steps_per_epoch))
+    if epoch_step <= 0 or remainder != 0:
+        return event
+
+    normalized_event = type(event)()
+    normalized_event.CopyFrom(event)
+    normalized_event.step = epoch_step
+    return normalized_event
+
+
 def trim_tensorboard_log_to_checkpoint(
     logging_dir: str,
     tracker_name: str,
     global_step: int,
     checkpoint_saved_at: Optional[float],
+    epoch_log_step_mode: str = "epoch",
+    num_update_steps_per_epoch: Optional[int] = None,
 ) -> TensorBoardTrimResult:
     """Physically remove TensorBoard events newer than a training state.
 
@@ -58,6 +82,7 @@ def trim_tensorboard_log_to_checkpoint(
 
     kept_events = 0
     removed_events = 0
+    migrated_events = 0
     wrote_file_version = False
     temp_fd, temp_path = tempfile.mkstemp(prefix=".musubi-tensorboard-", suffix=".tmp", dir=run_dir)
     os.close(temp_fd)
@@ -78,6 +103,7 @@ def trim_tensorboard_log_to_checkpoint(
                     continue
                 if checkpoint_saved_at is not None and float(event.wall_time) > float(checkpoint_saved_at):
                     continue
+                event = _normalize_epoch_summary_step(event, epoch_log_step_mode, num_update_steps_per_epoch)
                 if event.HasField("summary"):
                     for value in event.summary.value:
                         latest_summary_record[(int(event.step), value.tag)] = record_index
@@ -106,6 +132,11 @@ def trim_tensorboard_log_to_checkpoint(
                         removed_events += 1
                         continue
 
+                    original_event = event
+                    event = _normalize_epoch_summary_step(event, epoch_log_step_mode, num_update_steps_per_epoch)
+                    if event is not original_event:
+                        migrated_events += 1
+
                     event_to_write = event
                     if event.HasField("summary") and event.summary.value:
                         values_to_keep = [
@@ -128,7 +159,7 @@ def trim_tensorboard_log_to_checkpoint(
             os.fsync(compacted_file.fileno())
 
         # Do not rewrite a clean, single event file unnecessarily.
-        if removed_events == 0 and len(event_files) == 1:
+        if removed_events == 0 and migrated_events == 0 and len(event_files) == 1:
             os.remove(temp_path)
             return TensorBoardTrimResult(1, kept_events, 0)
 
@@ -198,6 +229,8 @@ def main() -> None:
         args.tracker_name or state.tracker_name or "network_train",
         state.global_step,
         checkpoint_saved_at,
+        state.epoch_log_step_mode,
+        state.num_update_steps_per_epoch,
     )
     print(
         f"TensorBoard compacted to step {state.global_step}: "

--- a/src/musubi_tuner/training/tensorboard_logs.py
+++ b/src/musubi_tuner/training/tensorboard_logs.py
@@ -177,9 +177,7 @@ def trim_tensorboard_log_to_checkpoint(
             # ``musubi-compacted`` suffix sorts after SummaryWriter's ``.0``,
             # making TensorBoard watch the static file instead of new logs.
             compacted_timestamp = max(0, int(time.time()) - 1)
-            compacted_name = (
-                f"{_EVENT_FILE_PREFIX}{compacted_timestamp:010d}.{socket.gethostname()}.{os.getpid()}.musubi-compacted"
-            )
+            compacted_name = f"{_EVENT_FILE_PREFIX}{compacted_timestamp:010d}.{socket.gethostname()}.{os.getpid()}.musubi-compacted"
             compacted_path = os.path.join(run_dir, compacted_name)
             os.replace(temp_path, compacted_path)
         except Exception:

--- a/src/musubi_tuner/training/tensorboard_logs.py
+++ b/src/musubi_tuner/training/tensorboard_logs.py
@@ -1,0 +1,210 @@
+"""Utilities for making TensorBoard history transactional with training state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import argparse
+import os
+import socket
+import tempfile
+import time
+from typing import Optional
+
+
+_EVENT_FILE_PREFIX = "events.out.tfevents."
+
+
+@dataclass(frozen=True)
+class TensorBoardTrimResult:
+    event_files: int
+    kept_events: int
+    removed_events: int
+
+
+def trim_tensorboard_log_to_checkpoint(
+    logging_dir: str,
+    tracker_name: str,
+    global_step: int,
+    checkpoint_saved_at: Optional[float],
+) -> TensorBoardTrimResult:
+    """Physically remove TensorBoard events newer than a training state.
+
+    TensorBoard's ``purge_step`` only records a session marker and leaves all
+    orphaned records in the event files. Repeatedly resuming an older state can
+    therefore still produce overlapping curves with some TensorBoard reload
+    modes. This function compacts the main tracker run before a new writer is
+    opened, retaining only events committed by the checkpoint.
+    """
+
+    run_dir = os.path.join(os.path.abspath(os.path.expanduser(logging_dir)), tracker_name)
+    if not os.path.isdir(run_dir):
+        return TensorBoardTrimResult(0, 0, 0)
+
+    event_files = sorted(
+        os.path.join(run_dir, name)
+        for name in os.listdir(run_dir)
+        if name.startswith(_EVENT_FILE_PREFIX) and os.path.isfile(os.path.join(run_dir, name))
+    )
+    if not event_files:
+        return TensorBoardTrimResult(0, 0, 0)
+
+    try:
+        from tensorboard.backend.event_processing.event_file_loader import LegacyEventFileLoader
+        from tensorboard.summary.writer.record_writer import RecordWriter
+    except ImportError as exc:
+        raise RuntimeError(
+            "TensorBoard is required to compact resumed logs. Install tensorboard or disable TensorBoard logging."
+        ) from exc
+
+    kept_events = 0
+    removed_events = 0
+    wrote_file_version = False
+    temp_fd, temp_path = tempfile.mkstemp(prefix=".musubi-tensorboard-", suffix=".tmp", dir=run_dir)
+    os.close(temp_fd)
+
+    try:
+        # A state may have been reached more than once (for example, two
+        # separate epoch-7 resumes both wrote steps 71..80). First locate the
+        # last eligible record for every tag+step so compaction keeps the
+        # branch that actually corresponds to the newest selected state.
+        latest_summary_record: dict[tuple[int, str], int] = {}
+        record_index = 0
+        for event_file in event_files:
+            for event in LegacyEventFileLoader(event_file).Load():
+                record_index += 1
+                if event.HasField("file_version") or event.HasField("session_log"):
+                    continue
+                if int(event.step) > int(global_step):
+                    continue
+                if checkpoint_saved_at is not None and float(event.wall_time) > float(checkpoint_saved_at):
+                    continue
+                if event.HasField("summary"):
+                    for value in event.summary.value:
+                        latest_summary_record[(int(event.step), value.tag)] = record_index
+
+        with open(temp_path, "wb") as compacted_file:
+            writer = RecordWriter(compacted_file)
+            record_index = 0
+            for event_file in event_files:
+                for event in LegacyEventFileLoader(event_file).Load():
+                    record_index += 1
+                    # The compacted stream needs one header, not one per old
+                    # writer session. SessionLog markers are obsolete after
+                    # physical compaction and can trigger another purge.
+                    if event.HasField("file_version"):
+                        if wrote_file_version:
+                            removed_events += 1
+                            continue
+                        wrote_file_version = True
+                    elif event.HasField("session_log"):
+                        removed_events += 1
+                        continue
+                    elif int(event.step) > int(global_step):
+                        removed_events += 1
+                        continue
+                    elif checkpoint_saved_at is not None and float(event.wall_time) > float(checkpoint_saved_at):
+                        removed_events += 1
+                        continue
+
+                    event_to_write = event
+                    if event.HasField("summary") and event.summary.value:
+                        values_to_keep = [
+                            value
+                            for value in event.summary.value
+                            if latest_summary_record.get((int(event.step), value.tag)) == record_index
+                        ]
+                        if not values_to_keep:
+                            removed_events += 1
+                            continue
+                        if len(values_to_keep) != len(event.summary.value):
+                            event_to_write = type(event)()
+                            event_to_write.CopyFrom(event)
+                            del event_to_write.summary.value[:]
+                            event_to_write.summary.value.extend(values_to_keep)
+
+                    writer.write(event_to_write.SerializeToString())
+                    kept_events += 1
+            compacted_file.flush()
+            os.fsync(compacted_file.fileno())
+
+        # Do not rewrite a clean, single event file unnecessarily.
+        if removed_events == 0 and len(event_files) == 1:
+            os.remove(temp_path)
+            return TensorBoardTrimResult(1, kept_events, 0)
+
+        backup_paths: list[tuple[str, str]] = []
+        try:
+            for index, source_path in enumerate(event_files):
+                backup_path = os.path.join(run_dir, f".musubi-tensorboard-backup-{os.getpid()}-{index}.tmp")
+                os.replace(source_path, backup_path)
+                backup_paths.append((source_path, backup_path))
+
+            # TensorBoard normally tails only the lexicographically newest
+            # event file in a run. Give the immutable compacted history an
+            # earlier timestamp than the SummaryWriter that is opened next;
+            # otherwise both can be created in the same second and the
+            # ``musubi-compacted`` suffix sorts after SummaryWriter's ``.0``,
+            # making TensorBoard watch the static file instead of new logs.
+            compacted_timestamp = max(0, int(time.time()) - 1)
+            compacted_name = (
+                f"{_EVENT_FILE_PREFIX}{compacted_timestamp:010d}.{socket.gethostname()}.{os.getpid()}.musubi-compacted"
+            )
+            compacted_path = os.path.join(run_dir, compacted_name)
+            os.replace(temp_path, compacted_path)
+        except Exception:
+            # Restore every original file if publishing the compacted stream
+            # fails. This keeps log cleanup transactional.
+            for source_path, backup_path in reversed(backup_paths):
+                if os.path.exists(backup_path):
+                    os.replace(backup_path, source_path)
+            raise
+        else:
+            for _, backup_path in backup_paths:
+                if os.path.exists(backup_path):
+                    os.remove(backup_path)
+
+        return TensorBoardTrimResult(len(event_files), kept_events, removed_events)
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
+
+
+def main() -> None:
+    """Compact an existing TensorBoard run without starting training."""
+
+    parser = argparse.ArgumentParser(description="Remove TensorBoard events newer than a Musubi training state.")
+    parser.add_argument("--state", required=True, help="Path to the resumable state directory")
+    parser.add_argument("--logging_dir", default=None, help="Override the logging directory stored in the state")
+    parser.add_argument("--tracker_name", default=None, help="Override the tracker name stored in the state")
+    args = parser.parse_args()
+
+    from musubi_tuner.training.training_state import TRAINING_STATE_FILE, TrainingProgressState
+
+    state_dir = os.path.abspath(os.path.expanduser(args.state))
+    state = TrainingProgressState.read_json(state_dir)
+    if state is None:
+        raise ValueError(f"No {TRAINING_STATE_FILE} found in state directory: {state_dir}")
+
+    logging_dir = args.logging_dir or state.logging_dir
+    if not logging_dir:
+        raise ValueError("No logging directory is stored in the state; pass --logging_dir explicitly.")
+
+    checkpoint_saved_at = state.checkpoint_saved_at
+    if checkpoint_saved_at is None:
+        checkpoint_saved_at = os.path.getmtime(os.path.join(state_dir, TRAINING_STATE_FILE))
+
+    result = trim_tensorboard_log_to_checkpoint(
+        logging_dir,
+        args.tracker_name or state.tracker_name or "network_train",
+        state.global_step,
+        checkpoint_saved_at,
+    )
+    print(
+        f"TensorBoard compacted to step {state.global_step}: "
+        f"{result.event_files} event file(s), {result.kept_events} event(s) kept, "
+        f"{result.removed_events} orphaned event(s) removed."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -53,11 +53,18 @@ from musubi_tuner.utils import huggingface_utils, model_utils, train_utils, sai_
 # Helpers that used to live alongside NetworkTrainer in hv_train_network.py.
 # Imported by name so existing method bodies keep working unchanged.
 from musubi_tuner.training.accelerator_setup import (
+    EpochSeededRandomSampler,
     clean_memory_on_device,
     collator_class,
     prepare_accelerator,
 )
 from musubi_tuner.training.sampling_prompts import should_sample_images
+from musubi_tuner.training.tensorboard_logs import trim_tensorboard_log_to_checkpoint
+from musubi_tuner.training.training_state import (
+    TRAINING_STATE_FILE,
+    TrainingProgressState,
+    configure_resume_tracker_init_kwargs,
+)
 from musubi_tuner.training.timesteps import (
     compute_density_for_timestep_sampling,
     compute_ideogram4_shift_timestep,
@@ -448,16 +455,13 @@ class NetworkTrainer:
             **lr_scheduler_kwargs,
         )
 
-    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> bool:
+    def resolve_resume_state_path(self, args: argparse.Namespace) -> Optional[str]:
         if not args.resume:
-            return False
+            return None
 
         if not args.resume_from_huggingface:
-            logger.info(f"resume training from local state: {args.resume}")
-            accelerator.load_state(args.resume)
-            return True
+            return os.path.abspath(os.path.expanduser(args.resume))
 
-        logger.info(f"resume training from huggingface state: {args.resume}")
         repo_id = args.resume.split("/")[0] + "/" + args.resume.split("/")[1]
         path_in_repo = "/".join(args.resume.split("/")[2:])
         revision = None
@@ -498,8 +502,15 @@ class NetworkTrainer:
                 "No files found in the specified repo id/path/revision / 指定されたリポジトリID/パス/リビジョンにファイルが見つかりませんでした"
             )
         dirname = os.path.dirname(results[0])
-        accelerator.load_state(dirname)
+        return dirname
 
+    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> bool:
+        resume_path = getattr(args, "resolved_resume_state_path", None) or self.resolve_resume_state_path(args)
+        if resume_path is None:
+            return False
+
+        logger.info(f"resume training from state: {resume_path}")
+        accelerator.load_state(resume_path)
         return True
 
     def get_bucketed_timestep(self) -> float:
@@ -1333,6 +1344,16 @@ class NetworkTrainer:
         if not self._validate_args_and_init(args):
             return
 
+        resolved_resume_path = self.resolve_resume_state_path(args)
+        args.resolved_resume_state_path = resolved_resume_path
+
+        # The effective seed may have been generated automatically in the
+        # original process. Recover it before rebuilding the dataset.
+        if args.seed is None and resolved_resume_path is not None:
+            resume_preview = TrainingProgressState.read_json(resolved_resume_path)
+            if resume_preview is not None:
+                args.seed = resume_preview.seed
+
         session_id, training_started_at = self._init_session(args)
         train_dataset_group, collator, current_epoch = self._build_dataset(args)
         accelerator, weight_dtype, dit_dtype, dit_weight_dtype, vae_dtype = self._prepare_accelerator_and_dtypes(args)
@@ -1350,7 +1371,9 @@ class NetworkTrainer:
             lr_scheduler,
             lr_descriptions,
             train_dataloader,
-        ) = self._build_optimizer_and_dataloader(args, accelerator, network, train_dataset_group, collator, transformer)
+        ) = self._build_optimizer_and_dataloader(
+            args, accelerator, network, train_dataset_group, collator, current_epoch, transformer
+        )
         (
             transformer,
             network,
@@ -1371,7 +1394,19 @@ class NetworkTrainer:
             dit_dtype,
             dit_weight_dtype,
         )
-        self._register_hooks_and_resume(args, accelerator, network)
+        training_state = self._register_hooks_and_resume(
+            args,
+            accelerator,
+            network,
+            session_id,
+            training_started_at,
+        )
+        if training_state.loaded:
+            if training_state.session_id is not None:
+                session_id = training_state.session_id
+            if training_state.training_started_at is not None:
+                training_started_at = training_state.training_started_at
+            self.timestep_range_pool = list(training_state.timestep_range_pool)
         self._run_training_loop(
             args,
             accelerator,
@@ -1394,6 +1429,7 @@ class NetworkTrainer:
             sample_parameters,
             dit_dtype,
             network_dtype,
+            training_state,
         )
 
     def _validate_args_and_init(self, args) -> bool:
@@ -1632,7 +1668,9 @@ class NetworkTrainer:
         # net_kwargs is reconstructed in the metadata phase from args.network_args
         return network
 
-    def _build_optimizer_and_dataloader(self, args, accelerator, network, train_dataset_group, collator, transformer):
+    def _build_optimizer_and_dataloader(
+        self, args, accelerator, network, train_dataset_group, collator, current_epoch, transformer
+    ):
         # prepare optimizer, data loader etc.
         accelerator.print("prepare optimizer, data loader etc.")
 
@@ -1650,10 +1688,13 @@ class NetworkTrainer:
         train_dataloader = torch.utils.data.DataLoader(
             train_dataset_group,
             batch_size=1,
-            shuffle=True,
+            sampler=EpochSeededRandomSampler(train_dataset_group, args.seed, current_epoch),
             collate_fn=collator,
             num_workers=n_workers,
             persistent_workers=args.persistent_data_loader_workers,
+            # Worker base seeds must not consume the model RNG when an iterator
+            # is recreated during resume.
+            generator=torch.Generator().manual_seed(args.seed),
         )
 
         # calculate max_train_steps
@@ -1753,7 +1794,14 @@ class NetworkTrainer:
 
         return transformer, network, optimizer, train_dataloader, lr_scheduler, training_model, network_dtype
 
-    def _register_hooks_and_resume(self, args, accelerator, network):
+    def _register_hooks_and_resume(
+        self,
+        args,
+        accelerator,
+        network,
+        session_id: int,
+        training_started_at: float,
+    ) -> TrainingProgressState:
         # before resuming make hook for saving/loading to save/load the network weights only
         def save_model_hook(models, weights, output_dir):
             # pop weights of other models than network to save only network weights
@@ -1781,8 +1829,60 @@ class NetworkTrainer:
         accelerator.register_save_state_pre_hook(save_model_hook)
         accelerator.register_load_state_pre_hook(load_model_hook)
 
-        # resume from local or huggingface. accelerator.step is set
-        self.resume_from_local_or_hf_if_specified(accelerator, args)  # accelerator.load_state(args.resume)
+        tracker_name = "network_train" if args.log_tracker_name is None else args.log_tracker_name
+        training_state = TrainingProgressState(
+            logging_dir=getattr(args, "resolved_logging_dir", None),
+            log_with=getattr(args, "resolved_log_with", args.log_with),
+            tracker_name=tracker_name,
+            session_id=session_id,
+            training_started_at=training_started_at,
+        )
+
+        resume_path = getattr(args, "resolved_resume_state_path", None) or self.resolve_resume_state_path(args)
+        has_seamless_state = TrainingProgressState.has_metadata(resume_path)
+
+        # New checkpoints contain one registered custom object. Legacy state
+        # directories do not, so loading them must happen before registration.
+        if resume_path is None or has_seamless_state:
+            accelerator.register_for_checkpointing(training_state)
+
+        if resume_path is not None:
+            logger.info(f"resume training from state: {resume_path}")
+            accelerator.load_state(resume_path)
+
+            if not has_seamless_state:
+                logger.warning(
+                    "The resume directory predates seamless resume metadata. Model/optimizer state was restored, "
+                    "but epoch and dataloader position cannot be recovered for this checkpoint. Future states from "
+                    "this run will contain seamless resume metadata."
+                )
+                accelerator.register_for_checkpointing(training_state)
+
+        if training_state.loaded and training_state.checkpoint_saved_at is None and resume_path is not None:
+            # Seamless states written before checkpoint_saved_at was added can
+            # use the atomic JSON sidecar's mtime as a local fallback.
+            state_metadata_path = os.path.join(resume_path, TRAINING_STATE_FILE)
+            if os.path.isfile(state_metadata_path):
+                training_state.checkpoint_saved_at = os.path.getmtime(state_metadata_path)
+
+        if training_state.loaded and training_state.logging_dir:
+            saved_logging_dir = os.path.abspath(os.path.expanduser(training_state.logging_dir))
+            can_reuse_logging_dir = not args.resume_from_huggingface or os.path.isdir(saved_logging_dir)
+            if can_reuse_logging_dir:
+                os.makedirs(saved_logging_dir, exist_ok=True)
+                accelerator.project_configuration.set_directories(saved_logging_dir)
+                accelerator.project_configuration.logging_dir = saved_logging_dir
+                args.resolved_logging_dir = saved_logging_dir
+                if args.log_with in ("wandb", "all"):
+                    os.environ["WANDB_DIR"] = saved_logging_dir
+                logger.info(f"resuming logs in: {saved_logging_dir}")
+            else:
+                logger.warning(
+                    f"Saved logging directory is not available locally: {saved_logging_dir}. "
+                    "TensorBoard will use the newly resolved directory; WandB can still resume by run id."
+                )
+
+        return training_state
 
     def _run_training_loop(
         self,
@@ -1807,6 +1907,7 @@ class NetworkTrainer:
         sample_parameters,
         dit_dtype,
         network_dtype,
+        training_state: TrainingProgressState,
     ):
         is_main_process = accelerator.is_main_process
 
@@ -1815,6 +1916,61 @@ class NetworkTrainer:
         # epoch数を計算する
         num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
         num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
+
+        if training_state.loaded:
+            incompatibilities = []
+            if training_state.max_train_steps != args.max_train_steps:
+                incompatibilities.append(
+                    f"max_train_steps changed ({training_state.max_train_steps} -> {args.max_train_steps})"
+                )
+            if training_state.num_update_steps_per_epoch != num_update_steps_per_epoch:
+                incompatibilities.append(
+                    "number of update steps per epoch changed "
+                    f"({training_state.num_update_steps_per_epoch} -> {num_update_steps_per_epoch})"
+                )
+            if training_state.num_batches_per_epoch != len(train_dataloader):
+                incompatibilities.append(
+                    f"number of batches per epoch changed ({training_state.num_batches_per_epoch} -> {len(train_dataloader)})"
+                )
+            if training_state.gradient_accumulation_steps != args.gradient_accumulation_steps:
+                incompatibilities.append(
+                    "gradient_accumulation_steps changed "
+                    f"({training_state.gradient_accumulation_steps} -> {args.gradient_accumulation_steps})"
+                )
+            if training_state.num_processes != accelerator.num_processes:
+                incompatibilities.append(
+                    f"number of processes changed ({training_state.num_processes} -> {accelerator.num_processes})"
+                )
+            if training_state.seed != args.seed:
+                incompatibilities.append(f"seed changed ({training_state.seed} -> {args.seed})")
+            if training_state.log_with != getattr(args, "resolved_log_with", args.log_with):
+                incompatibilities.append(
+                    f"logging backend changed ({training_state.log_with} -> "
+                    f"{getattr(args, 'resolved_log_with', args.log_with)})"
+                )
+            current_tracker_name = "network_train" if args.log_tracker_name is None else args.log_tracker_name
+            if training_state.tracker_name != current_tracker_name:
+                incompatibilities.append(
+                    f"tracker name changed ({training_state.tracker_name} -> {current_tracker_name})"
+                )
+            if training_state.step_in_epoch < 0 or training_state.step_in_epoch > len(train_dataloader):
+                incompatibilities.append(
+                    f"saved step_in_epoch {training_state.step_in_epoch} is outside [0, {len(train_dataloader)}]"
+                )
+            if incompatibilities:
+                raise ValueError(
+                    "Seamless resume requires the original training topology and schedule:\n- "
+                    + "\n- ".join(incompatibilities)
+                )
+        else:
+            training_state.max_train_steps = args.max_train_steps
+            training_state.num_batches_per_epoch = len(train_dataloader)
+            training_state.num_update_steps_per_epoch = num_update_steps_per_epoch
+            training_state.gradient_accumulation_steps = args.gradient_accumulation_steps
+            training_state.num_processes = accelerator.num_processes
+            training_state.seed = args.seed
+
+        training_state.logging_dir = getattr(args, "resolved_logging_dir", None) or accelerator.project_dir
 
         # 学習する
         # total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
@@ -1925,25 +2081,79 @@ class NetworkTrainer:
                 minimum_metadata[key] = metadata[key]
 
         if accelerator.is_main_process:
+            resume_rng_state = None
+            if training_state.loaded:
+                resume_rng_state = {
+                    "python": random.getstate(),
+                    "numpy": np.random.get_state(),
+                    "torch": torch.get_rng_state(),
+                    "cuda": torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None,
+                }
+
+                if training_state.log_with in ("tensorboard", "all") and training_state.logging_dir:
+                    trim_result = trim_tensorboard_log_to_checkpoint(
+                        training_state.logging_dir,
+                        training_state.tracker_name or "network_train",
+                        training_state.global_step,
+                        training_state.checkpoint_saved_at,
+                    )
+                    if trim_result.event_files:
+                        logger.info(
+                            "compacted TensorBoard history to checkpoint step %s: "
+                            "%s event file(s), %s event(s) kept, %s orphaned event(s) removed",
+                            training_state.global_step,
+                            trim_result.event_files,
+                            trim_result.kept_events,
+                            trim_result.removed_events,
+                        )
+
             init_kwargs = {}
-            if args.wandb_run_name:
-                init_kwargs["wandb"] = {"name": args.wandb_run_name}
             if args.log_tracker_config is not None:
                 init_kwargs = toml.load(args.log_tracker_config)
+            if args.wandb_run_name or training_state.wandb_run_id:
+                wandb_kwargs = init_kwargs.setdefault("wandb", {})
+                if args.wandb_run_name:
+                    wandb_kwargs["name"] = args.wandb_run_name
+                if training_state.wandb_run_id and not training_state.loaded:
+                    wandb_kwargs["id"] = training_state.wandb_run_id
+                    wandb_kwargs["resume"] = "must"
+            configure_resume_tracker_init_kwargs(init_kwargs, training_state)
             accelerator.init_trackers(
                 "network_train" if args.log_tracker_name is None else args.log_tracker_name,
                 config=train_utils.get_sanitized_config_or_none(args),
                 init_kwargs=init_kwargs,
             )
 
-        # TODO skip until initial step
-        progress_bar = tqdm(range(args.max_train_steps), smoothing=0, disable=not accelerator.is_local_main_process, desc="steps")
+            try:
+                wandb_tracker = accelerator.get_tracker("wandb", unwrap=True)
+                training_state.wandb_run_id = wandb_tracker.id
+            except (KeyError, RuntimeError, ValueError):
+                pass
 
-        epoch_to_start = 0
-        global_step = 0
+            # Recreating a tracker is resume bookkeeping, not a training RNG
+            # event. Restore the checkpoint RNG in case a backend consumed it.
+            if resume_rng_state is not None:
+                random.setstate(resume_rng_state["python"])
+                np.random.set_state(resume_rng_state["numpy"])
+                torch.set_rng_state(resume_rng_state["torch"])
+                if resume_rng_state["cuda"] is not None:
+                    torch.cuda.set_rng_state_all(resume_rng_state["cuda"])
+
+        epoch_to_start = training_state.epoch if training_state.loaded else 0
+        global_step = training_state.global_step if training_state.loaded else 0
+        progress_bar = tqdm(
+            total=args.max_train_steps,
+            initial=global_step,
+            smoothing=0,
+            disable=not accelerator.is_local_main_process,
+            desc="steps",
+        )
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
+        if training_state.loaded:
+            loss_recorder.loss_list = list(training_state.loss_list)
+            loss_recorder.loss_total = training_state.loss_total
         del train_dataset_group
 
         # function for saving/removing
@@ -2015,12 +2225,12 @@ class NetworkTrainer:
                     accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
                 )
 
-        # For --sample_at_first
-        if should_sample_images(args, global_step, epoch=0):
+        # For --sample_at_first. Never repeat it when resuming.
+        if global_step == 0 and should_sample_images(args, global_step, epoch=0):
             optimizer_eval_fn()
             _do_sample(0, global_step)
             optimizer_train_fn()
-        if len(accelerator.trackers) > 0:
+        if global_step == 0 and len(accelerator.trackers) > 0:
             # log empty object to commit the sample images to wandb
             accelerator.log({}, step=0)
 
@@ -2037,7 +2247,11 @@ class NetworkTrainer:
 
         optimizer_train_fn()  # Set training mode
 
+        stop_training = global_step >= args.max_train_steps
         for epoch in range(epoch_to_start, num_train_epochs):
+            if stop_training:
+                break
+
             accelerator.print(f"\nepoch {epoch + 1}/{num_train_epochs}")
             current_epoch.value = epoch + 1
 
@@ -2045,7 +2259,20 @@ class NetworkTrainer:
 
             accelerator.unwrap_model(network).on_epoch_start(transformer)
 
-            for step, batch in enumerate(train_dataloader):
+            # Keep worker base seeds epoch-deterministic and separate from the
+            # model RNG. skip_first_batches reuses this generator.
+            data_loader_generator = getattr(train_dataloader, "generator", None)
+            if data_loader_generator is not None:
+                data_loader_generator.manual_seed(args.seed + epoch + 1)
+
+            step_to_start = training_state.step_in_epoch if training_state.loaded and epoch == epoch_to_start else 0
+            epoch_dataloader = train_dataloader
+            if step_to_start > 0:
+                accelerator.print(f"resuming epoch {epoch + 1} at batch {step_to_start + 1}/{len(train_dataloader)}")
+                epoch_dataloader = accelerator.skip_first_batches(train_dataloader, step_to_start)
+
+            consumed_in_epoch = step_to_start
+            for step, batch in enumerate(epoch_dataloader, start=step_to_start):
                 # torch.compiler.cudagraph_mark_step_begin() # for cudagraphs
 
                 latents = batch["latents"]
@@ -2104,12 +2331,26 @@ class NetworkTrainer:
                 else:
                     keys_scaled, mean_norm, maximum_norm = None, None, None
 
+                current_loss = loss.detach().item()
+                loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
+                avr_loss: float = loss_recorder.moving_average
+                consumed_in_epoch = step + 1
+
+                training_state.epoch = epoch
+                training_state.step_in_epoch = consumed_in_epoch
+                training_state.timestep_range_pool = list(self.timestep_range_pool)
+                training_state.loss_list = list(loss_recorder.loss_list)
+                training_state.loss_total = loss_recorder.loss_total
+
                 # Checks if the accelerator has performed an optimization step behind the scenes
+                should_sampling = False
+                should_saving = False
                 if accelerator.sync_gradients:
-                    if global_step == 0:
+                    if global_step == 0 and not training_state.loaded:
                         progress_bar.reset()  # exclude first step from progress bar, because it may take long due to initializations
                     progress_bar.update(1)
                     global_step += 1
+                    training_state.global_step = global_step
 
                     # to avoid calling optimizer_eval_fn() too frequently, we call it only when we need to sample images or save the model
                     should_sampling = should_sample_images(args, global_step, epoch=None)
@@ -2125,19 +2366,8 @@ class NetworkTrainer:
                             if accelerator.is_main_process:
                                 ckpt_name = train_utils.get_step_ckpt_name(args.output_name, global_step)
                                 save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch)
-
-                                if args.save_state:
-                                    train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
-
-                                remove_step_no = train_utils.get_remove_step_no(args, global_step)
-                                if remove_step_no is not None:
-                                    remove_ckpt_name = train_utils.get_step_ckpt_name(args.output_name, remove_step_no)
-                                    remove_model(remove_ckpt_name)
                         optimizer_train_fn()
 
-                current_loss = loss.detach().item()
-                loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
-                avr_loss: float = loss_recorder.moving_average
                 logs = {"avr_loss": avr_loss}  # , "lr": lr_scheduler.get_last_lr()[0]}
                 progress_bar.set_postfix(**logs)
 
@@ -2153,47 +2383,77 @@ class NetworkTrainer:
                     logs.update(self.extra_step_logs(args, logs))
                     accelerator.log(logs, step=global_step)
 
+                # The state is saved after sampling and logging, so it always
+                # represents the exact next action on resume.
+                if should_saving and args.save_state:
+                    train_utils.save_and_remove_state_stepwise(args, accelerator, global_step, training_state)
+
+                if should_saving and accelerator.is_main_process:
+                    remove_step_no = train_utils.get_remove_step_no(args, global_step)
+                    if remove_step_no is not None:
+                        remove_ckpt_name = train_utils.get_step_ckpt_name(args.output_name, remove_step_no)
+                        remove_model(remove_ckpt_name)
+
                 if global_step >= args.max_train_steps:
+                    stop_training = True
                     break
 
-            if len(accelerator.trackers) > 0:
+            epoch_completed = consumed_in_epoch >= len(train_dataloader)
+            if epoch_completed:
+                training_state.epoch = epoch + 1
+                training_state.step_in_epoch = 0
+
+            if epoch_completed and len(accelerator.trackers) > 0:
                 logs = {"loss/epoch": loss_recorder.moving_average}
-                accelerator.log(logs, step=epoch + 1)
+                # Keep every metric on the same monotonic axis so tracker
+                # rollback can remove stale epoch summaries as well.
+                accelerator.log(logs, step=global_step)
 
             accelerator.wait_for_everyone()
 
             # save model at the end of epoch if needed
             optimizer_eval_fn()
+            saving = False
             if args.save_every_n_epochs is not None:
-                saving = (epoch + 1) % args.save_every_n_epochs == 0 and (epoch + 1) < num_train_epochs
+                saving = (
+                    epoch_completed
+                    and (epoch + 1) % args.save_every_n_epochs == 0
+                    and (epoch + 1) < num_train_epochs
+                )
                 if is_main_process and saving:
                     ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, epoch + 1)
                     save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch + 1)
 
-                    remove_epoch_no = train_utils.get_remove_epoch_no(args, epoch + 1)
-                    if remove_epoch_no is not None:
-                        remove_ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, remove_epoch_no)
-                        remove_model(remove_ckpt_name)
-
-                    if args.save_state:
-                        train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
-
             _do_sample(epoch + 1, global_step)
+
+            if args.save_every_n_epochs is not None and saving and args.save_state:
+                train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1, training_state)
+
+            if args.save_every_n_epochs is not None and saving and is_main_process:
+                remove_epoch_no = train_utils.get_remove_epoch_no(args, epoch + 1)
+                if remove_epoch_no is not None:
+                    remove_ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, remove_epoch_no)
+                    remove_model(remove_ckpt_name)
+
             optimizer_train_fn()
 
             # end of epoch
 
+            if stop_training:
+                break
+
         # metadata["ss_epoch"] = str(num_train_epochs)
         metadata["ss_training_finished_at"] = str(time.time())
+
+        optimizer_eval_fn()
+
+        if args.save_state or args.save_state_on_train_end:
+            train_utils.save_state_on_train_end(args, accelerator, training_state)
 
         if is_main_process:
             network = accelerator.unwrap_model(network)
 
         accelerator.end_training()
-        optimizer_eval_fn()
-
-        if is_main_process and (args.save_state or args.save_state_on_train_end):
-            train_utils.save_state_on_train_end(args, accelerator)
 
         if is_main_process:
             ckpt_name = train_utils.get_last_ckpt_name(args.output_name)

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -2096,6 +2096,8 @@ class NetworkTrainer:
                         training_state.tracker_name or "network_train",
                         training_state.global_step,
                         training_state.checkpoint_saved_at,
+                        training_state.epoch_log_step_mode,
+                        training_state.num_update_steps_per_epoch,
                     )
                     if trim_result.event_files:
                         logger.info(
@@ -2138,6 +2140,10 @@ class NetworkTrainer:
                 torch.set_rng_state(resume_rng_state["torch"])
                 if resume_rng_state["cuda"] is not None:
                     torch.cuda.set_rng_state_all(resume_rng_state["cuda"])
+
+        # All records written from this point use the epoch number for
+        # loss/epoch. Persist the mode so future resumes do not remap them.
+        training_state.epoch_log_step_mode = "epoch"
 
         epoch_to_start = training_state.epoch if training_state.loaded else 0
         global_step = training_state.global_step if training_state.loaded else 0
@@ -2405,9 +2411,10 @@ class NetworkTrainer:
 
             if epoch_completed and len(accelerator.trackers) > 0:
                 logs = {"loss/epoch": loss_recorder.moving_average}
-                # Keep every metric on the same monotonic axis so tracker
-                # rollback can remove stale epoch summaries as well.
-                accelerator.log(logs, step=global_step)
+                # Epoch summaries use the epoch number as their TensorBoard
+                # x-axis. Resume cleanup removes newer summaries by their
+                # checkpoint wall time, independently of this step value.
+                accelerator.log(logs, step=epoch + 1)
 
             accelerator.wait_for_everyone()
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1920,9 +1920,7 @@ class NetworkTrainer:
         if training_state.loaded:
             incompatibilities = []
             if training_state.max_train_steps != args.max_train_steps:
-                incompatibilities.append(
-                    f"max_train_steps changed ({training_state.max_train_steps} -> {args.max_train_steps})"
-                )
+                incompatibilities.append(f"max_train_steps changed ({training_state.max_train_steps} -> {args.max_train_steps})")
             if training_state.num_update_steps_per_epoch != num_update_steps_per_epoch:
                 incompatibilities.append(
                     "number of update steps per epoch changed "
@@ -1945,22 +1943,18 @@ class NetworkTrainer:
                 incompatibilities.append(f"seed changed ({training_state.seed} -> {args.seed})")
             if training_state.log_with != getattr(args, "resolved_log_with", args.log_with):
                 incompatibilities.append(
-                    f"logging backend changed ({training_state.log_with} -> "
-                    f"{getattr(args, 'resolved_log_with', args.log_with)})"
+                    f"logging backend changed ({training_state.log_with} -> {getattr(args, 'resolved_log_with', args.log_with)})"
                 )
             current_tracker_name = "network_train" if args.log_tracker_name is None else args.log_tracker_name
             if training_state.tracker_name != current_tracker_name:
-                incompatibilities.append(
-                    f"tracker name changed ({training_state.tracker_name} -> {current_tracker_name})"
-                )
+                incompatibilities.append(f"tracker name changed ({training_state.tracker_name} -> {current_tracker_name})")
             if training_state.step_in_epoch < 0 or training_state.step_in_epoch > len(train_dataloader):
                 incompatibilities.append(
                     f"saved step_in_epoch {training_state.step_in_epoch} is outside [0, {len(train_dataloader)}]"
                 )
             if incompatibilities:
                 raise ValueError(
-                    "Seamless resume requires the original training topology and schedule:\n- "
-                    + "\n- ".join(incompatibilities)
+                    "Seamless resume requires the original training topology and schedule:\n- " + "\n- ".join(incompatibilities)
                 )
         else:
             training_state.max_train_steps = args.max_train_steps
@@ -2422,11 +2416,7 @@ class NetworkTrainer:
             optimizer_eval_fn()
             saving = False
             if args.save_every_n_epochs is not None:
-                saving = (
-                    epoch_completed
-                    and (epoch + 1) % args.save_every_n_epochs == 0
-                    and (epoch + 1) < num_train_epochs
-                )
+                saving = epoch_completed and (epoch + 1) % args.save_every_n_epochs == 0 and (epoch + 1) < num_train_epochs
                 if is_main_process and saving:
                     ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, epoch + 1)
                     save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch + 1)

--- a/src/musubi_tuner/training/training_state.py
+++ b/src/musubi_tuner/training/training_state.py
@@ -54,9 +54,7 @@ class TrainingProgressState:
     def load_state_dict(self, state: dict[str, Any]) -> None:
         version = int(state.get("version", 0))
         if version > TRAINING_STATE_VERSION:
-            raise ValueError(
-                f"Training state version {version} is newer than supported version {TRAINING_STATE_VERSION}."
-            )
+            raise ValueError(f"Training state version {version} is newer than supported version {TRAINING_STATE_VERSION}.")
 
         for key in self.state_dict():
             if key in state:

--- a/src/musubi_tuner/training/training_state.py
+++ b/src/musubi_tuner/training/training_state.py
@@ -1,0 +1,121 @@
+"""Serializable application-level state for seamless training resume."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+import os
+from typing import Any, Optional
+
+
+TRAINING_STATE_FILE = "musubi_training_state.json"
+TRAINING_STATE_VERSION = 1
+
+
+@dataclass
+class TrainingProgressState:
+    """State that Accelerate does not track for the Musubi training loop.
+
+    ``epoch`` is zero-based and ``step_in_epoch`` is the number of local
+    dataloader batches already consumed in that epoch. Together they identify
+    the next batch to train.
+    """
+
+    version: int = TRAINING_STATE_VERSION
+    global_step: int = 0
+    epoch: int = 0
+    step_in_epoch: int = 0
+    max_train_steps: int = 0
+    num_batches_per_epoch: int = 0
+    num_update_steps_per_epoch: int = 0
+    gradient_accumulation_steps: int = 1
+    num_processes: int = 1
+    seed: int = 0
+    logging_dir: Optional[str] = None
+    log_with: Optional[str] = None
+    tracker_name: Optional[str] = None
+    wandb_run_id: Optional[str] = None
+    session_id: Optional[int] = None
+    training_started_at: Optional[float] = None
+    checkpoint_saved_at: Optional[float] = None
+    timestep_range_pool: list[tuple[float, float]] = field(default_factory=list)
+    loss_list: list[float] = field(default_factory=list)
+    loss_total: float = 0.0
+
+    # Runtime-only marker; deliberately excluded from state_dict/JSON.
+    loaded: bool = field(default=False, init=False, repr=False)
+
+    def state_dict(self) -> dict[str, Any]:
+        state = asdict(self)
+        state.pop("loaded", None)
+        return state
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        version = int(state.get("version", 0))
+        if version > TRAINING_STATE_VERSION:
+            raise ValueError(
+                f"Training state version {version} is newer than supported version {TRAINING_STATE_VERSION}."
+            )
+
+        for key in self.state_dict():
+            if key in state:
+                setattr(self, key, state[key])
+
+        self.timestep_range_pool = [tuple(item) for item in self.timestep_range_pool]
+        self.loss_list = [float(item) for item in self.loss_list]
+        self.loss_total = float(self.loss_total)
+        self.loaded = True
+
+    def write_json(self, state_dir: str) -> str:
+        os.makedirs(state_dir, exist_ok=True)
+        path = os.path.join(state_dir, TRAINING_STATE_FILE)
+        temporary_path = path + ".tmp"
+        with open(temporary_path, "w", encoding="utf-8") as file:
+            json.dump(self.state_dict(), file, ensure_ascii=False, indent=2)
+        os.replace(temporary_path, path)
+        return path
+
+    @classmethod
+    def read_json(cls, state_dir: str) -> Optional["TrainingProgressState"]:
+        path = os.path.join(state_dir, TRAINING_STATE_FILE)
+        if not os.path.isfile(path):
+            return None
+
+        with open(path, "r", encoding="utf-8") as file:
+            state_dict = json.load(file)
+
+        state = cls()
+        state.load_state_dict(state_dict)
+        return state
+
+    @classmethod
+    def has_metadata(cls, state_dir: Optional[str]) -> bool:
+        return bool(state_dir) and os.path.isfile(os.path.join(state_dir, TRAINING_STATE_FILE))
+
+
+def configure_resume_tracker_init_kwargs(init_kwargs: dict, state: TrainingProgressState) -> dict:
+    """Configure tracker rollback so logs cannot remain ahead of a checkpoint.
+
+    ``global_step`` is the last fully committed optimization/logging step in a
+    seamless state. TensorBoard therefore purges from the next step, while W&B
+    rewinds the saved run to the committed step before accepting new history.
+    """
+
+    if not state.loaded:
+        return init_kwargs
+
+    if state.log_with in ("tensorboard", "all"):
+        tensorboard_kwargs = init_kwargs.setdefault("tensorboard", {})
+        tensorboard_kwargs["purge_step"] = state.global_step + 1
+
+    if state.log_with in ("wandb", "all") and state.wandb_run_id:
+        wandb_kwargs = init_kwargs.setdefault("wandb", {})
+        # W&B does not allow resume/resume_from/fork_from together. Rewind is
+        # required here: plain resume would keep any history newer than the
+        # checkpoint and reject replacement steps as non-monotonic.
+        wandb_kwargs.pop("id", None)
+        wandb_kwargs.pop("resume", None)
+        wandb_kwargs.pop("fork_from", None)
+        wandb_kwargs["resume_from"] = f"{state.wandb_run_id}?_step={state.global_step}"
+
+    return init_kwargs

--- a/src/musubi_tuner/training/training_state.py
+++ b/src/musubi_tuner/training/training_state.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 
 TRAINING_STATE_FILE = "musubi_training_state.json"
-TRAINING_STATE_VERSION = 1
+TRAINING_STATE_VERSION = 2
 
 
 @dataclass
@@ -38,6 +38,7 @@ class TrainingProgressState:
     session_id: Optional[int] = None
     training_started_at: Optional[float] = None
     checkpoint_saved_at: Optional[float] = None
+    epoch_log_step_mode: str = "epoch"
     timestep_range_pool: list[tuple[float, float]] = field(default_factory=list)
     loss_list: list[float] = field(default_factory=list)
     loss_total: float = 0.0
@@ -61,9 +62,16 @@ class TrainingProgressState:
             if key in state:
                 setattr(self, key, state[key])
 
+        # Version-1 seamless states were created while loss/epoch used the
+        # optimization step as its TensorBoard x-axis. Mark them for a
+        # one-time migration when the event history is compacted on resume.
+        if "epoch_log_step_mode" not in state:
+            self.epoch_log_step_mode = "global_step"
+
         self.timestep_range_pool = [tuple(item) for item in self.timestep_range_pool]
         self.loss_list = [float(item) for item in self.loss_list]
         self.loss_total = float(self.loss_total)
+        self.version = TRAINING_STATE_VERSION
         self.loaded = True
 
     def write_json(self, state_dir: str) -> str:

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -2,7 +2,8 @@ import argparse
 import logging
 import os
 import shutil
-from typing import Callable
+import time
+from typing import Any, Callable, Optional
 
 import accelerate
 import torch
@@ -116,7 +117,27 @@ def get_remove_step_no(args: argparse.Namespace, step_no: int):
     return remove_step_no
 
 
-def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: accelerate.Accelerator, epoch_no: int):
+def _save_accelerator_and_training_state(
+    accelerator: accelerate.Accelerator, state_dir: str, training_state: Optional[Any] = None
+) -> None:
+    """Save state collectively, then publish application metadata atomically."""
+
+    if training_state is not None:
+        # This is the log transaction boundary. Events with a later wall time
+        # must be removed when this older state is resumed.
+        training_state.checkpoint_saved_at = time.time()
+    accelerator.save_state(state_dir)
+    if accelerator.is_main_process and training_state is not None:
+        training_state.write_json(state_dir)
+    accelerator.wait_for_everyone()
+
+
+def save_and_remove_state_on_epoch_end(
+    args: argparse.Namespace,
+    accelerator: accelerate.Accelerator,
+    epoch_no: int,
+    training_state: Optional[Any] = None,
+):
     model_name = args.output_name
 
     logger.info("")
@@ -124,13 +145,13 @@ def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: ac
     os.makedirs(args.output_dir, exist_ok=True)
 
     state_dir = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, epoch_no))
-    accelerator.save_state(state_dir)
-    if args.save_state_to_huggingface:
+    _save_accelerator_and_training_state(accelerator, state_dir, training_state)
+    if accelerator.is_main_process and args.save_state_to_huggingface:
         logger.info("uploading state to huggingface.")
         huggingface_utils.upload(args, state_dir, "/" + EPOCH_STATE_NAME.format(model_name, epoch_no))
 
     last_n_epochs = args.save_last_n_epochs_state if args.save_last_n_epochs_state else args.save_last_n_epochs
-    if last_n_epochs is not None:
+    if accelerator.is_main_process and last_n_epochs is not None:
         remove_epoch_no = epoch_no - args.save_every_n_epochs * last_n_epochs
         state_dir_old = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, remove_epoch_no))
         if os.path.exists(state_dir_old):
@@ -138,7 +159,12 @@ def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: ac
             shutil.rmtree(state_dir_old)
 
 
-def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accelerate.Accelerator, step_no: int):
+def save_and_remove_state_stepwise(
+    args: argparse.Namespace,
+    accelerator: accelerate.Accelerator,
+    step_no: int,
+    training_state: Optional[Any] = None,
+):
     model_name = args.output_name
 
     logger.info("")
@@ -146,13 +172,13 @@ def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accele
     os.makedirs(args.output_dir, exist_ok=True)
 
     state_dir = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, step_no))
-    accelerator.save_state(state_dir)
-    if args.save_state_to_huggingface:
+    _save_accelerator_and_training_state(accelerator, state_dir, training_state)
+    if accelerator.is_main_process and args.save_state_to_huggingface:
         logger.info("uploading state to huggingface.")
         huggingface_utils.upload(args, state_dir, "/" + STEP_STATE_NAME.format(model_name, step_no))
 
     last_n_steps = args.save_last_n_steps_state if args.save_last_n_steps_state else args.save_last_n_steps
-    if last_n_steps is not None:
+    if accelerator.is_main_process and last_n_steps is not None:
         # last_n_steps前のstep_noから、save_every_n_stepsの倍数のstep_noを計算して削除する
         remove_step_no = step_no - last_n_steps - 1
         remove_step_no = remove_step_no - (remove_step_no % args.save_every_n_steps)
@@ -164,7 +190,9 @@ def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accele
                 shutil.rmtree(state_dir_old)
 
 
-def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Accelerator):
+def save_state_on_train_end(
+    args: argparse.Namespace, accelerator: accelerate.Accelerator, training_state: Optional[Any] = None
+):
     model_name = args.output_name
 
     logger.info("")
@@ -172,9 +200,9 @@ def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Ac
     os.makedirs(args.output_dir, exist_ok=True)
 
     state_dir = os.path.join(args.output_dir, LAST_STATE_NAME.format(model_name))
-    accelerator.save_state(state_dir)
+    _save_accelerator_and_training_state(accelerator, state_dir, training_state)
 
-    if args.save_state_to_huggingface:
+    if accelerator.is_main_process and args.save_state_to_huggingface:
         logger.info("uploading last state to huggingface.")
         huggingface_utils.upload(args, state_dir, "/" + LAST_STATE_NAME.format(model_name))
 

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -190,9 +190,7 @@ def save_and_remove_state_stepwise(
                 shutil.rmtree(state_dir_old)
 
 
-def save_state_on_train_end(
-    args: argparse.Namespace, accelerator: accelerate.Accelerator, training_state: Optional[Any] = None
-):
+def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Accelerator, training_state: Optional[Any] = None):
     model_name = args.output_name
 
     logger.info("")

--- a/tests/test_seamless_resume.py
+++ b/tests/test_seamless_resume.py
@@ -163,9 +163,7 @@ class TrainingProgressStateTest(unittest.TestCase):
             run_dir = os.path.join(logging_dir, "network_train")
             writer = EventFileWriter(run_dir)
             for global_step, loss in ((10, 1.0), (20, 0.5)):
-                summary = summary_pb2.Summary(
-                    value=[summary_pb2.Summary.Value(tag="loss/epoch", simple_value=loss)]
-                )
+                summary = summary_pb2.Summary(value=[summary_pb2.Summary.Value(tag="loss/epoch", simple_value=loss)])
                 writer.add_event(event_pb2.Event(step=global_step, wall_time=100.0 + global_step, summary=summary))
             writer.close()
 

--- a/tests/test_seamless_resume.py
+++ b/tests/test_seamless_resume.py
@@ -1,0 +1,200 @@
+import argparse
+import os
+import random
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+import torch
+
+from musubi_tuner.dataset.bucket import BucketBatchManager
+from musubi_tuner.dataset.image_video_dataset import _sorted_glob
+from musubi_tuner.training.accelerator_setup import EpochSeededRandomSampler, resolve_logging_dir
+from musubi_tuner.training.tensorboard_logs import trim_tensorboard_log_to_checkpoint
+from musubi_tuner.training.training_state import (
+    TRAINING_STATE_FILE,
+    TrainingProgressState,
+    configure_resume_tracker_init_kwargs,
+)
+
+
+class TrainingProgressStateTest(unittest.TestCase):
+    def test_json_round_trip_preserves_resume_and_logging_state(self):
+        state = TrainingProgressState(
+            global_step=17,
+            epoch=2,
+            step_in_epoch=5,
+            max_train_steps=100,
+            num_batches_per_epoch=12,
+            num_update_steps_per_epoch=6,
+            gradient_accumulation_steps=2,
+            num_processes=1,
+            seed=42,
+            logging_dir=os.path.abspath("logs/run"),
+            log_with="all",
+            tracker_name="network_train",
+            wandb_run_id="wandb-id",
+            session_id=123,
+            training_started_at=456.0,
+            checkpoint_saved_at=789.0,
+            timestep_range_pool=[(0.1, 0.2)],
+            loss_list=[1.0, 0.5],
+            loss_total=1.5,
+        )
+
+        with tempfile.TemporaryDirectory() as state_dir:
+            state.write_json(state_dir)
+            self.assertTrue(os.path.isfile(os.path.join(state_dir, TRAINING_STATE_FILE)))
+            restored = TrainingProgressState.read_json(state_dir)
+
+        self.assertIsNotNone(restored)
+        self.assertTrue(restored.loaded)
+        self.assertEqual(restored.state_dict(), state.state_dict())
+        self.assertEqual(restored.timestep_range_pool, [(0.1, 0.2)])
+
+    def test_resolve_logging_dir_reuses_resume_directory(self):
+        with tempfile.TemporaryDirectory() as root:
+            state_dir = os.path.join(root, "run-step00000010-state")
+            log_dir = os.path.join(root, "logs", "original")
+            TrainingProgressState(logging_dir=log_dir).write_json(state_dir)
+            args = argparse.Namespace(
+                resume=state_dir,
+                resume_from_huggingface=False,
+                logging_dir=os.path.join(root, "logs"),
+                log_prefix="new_",
+            )
+
+            self.assertEqual(resolve_logging_dir(args), os.path.abspath(log_dir))
+
+    def test_resume_rolls_trackers_back_to_checkpoint_boundary(self):
+        state = TrainingProgressState(global_step=2000, log_with="all", wandb_run_id="wandb-id")
+        state.loaded = True
+        init_kwargs = {
+            "tensorboard": {"flush_secs": 10, "purge_step": 9999},
+            "wandb": {"name": "run", "id": "old-id", "resume": "must"},
+        }
+
+        configure_resume_tracker_init_kwargs(init_kwargs, state)
+
+        self.assertEqual(init_kwargs["tensorboard"]["purge_step"], 2001)
+        self.assertEqual(init_kwargs["tensorboard"]["flush_secs"], 10)
+        self.assertEqual(init_kwargs["wandb"]["resume_from"], "wandb-id?_step=2000")
+        self.assertEqual(init_kwargs["wandb"]["name"], "run")
+        self.assertNotIn("id", init_kwargs["wandb"])
+        self.assertNotIn("resume", init_kwargs["wandb"])
+
+    def test_tensorboard_events_are_physically_trimmed_to_state(self):
+        try:
+            from tensorboard.backend.event_processing.event_file_loader import LegacyEventFileLoader
+            from tensorboard.compat.proto import event_pb2, summary_pb2
+            from tensorboard.summary.writer.event_file_writer import EventFileWriter
+        except ImportError:
+            self.skipTest("tensorboard is not installed")
+
+        with tempfile.TemporaryDirectory() as logging_dir:
+            run_dir = os.path.join(logging_dir, "network_train")
+            writer = EventFileWriter(run_dir)
+
+            def add_scalar(step, wall_time, value):
+                summary = summary_pb2.Summary(
+                    value=[summary_pb2.Summary.Value(tag="loss/current", simple_value=value)]
+                )
+                writer.add_event(event_pb2.Event(step=step, wall_time=wall_time, summary=summary))
+
+            add_scalar(10, 100.0, 1.0)
+            add_scalar(20, 200.0, 2.0)
+            add_scalar(30, 220.0, 3.0)  # newer step
+            add_scalar(5, 300.0, 4.0)  # low step written after the checkpoint
+            add_scalar(20, 205.0, 2.5)  # retry: latest value for the same tag+step wins
+            writer.add_event(
+                event_pb2.Event(
+                    step=21,
+                    wall_time=230.0,
+                    session_log=event_pb2.SessionLog(status=event_pb2.SessionLog.START),
+                )
+            )
+            writer.close()
+
+            result = trim_tensorboard_log_to_checkpoint(logging_dir, "network_train", 20, 210.0)
+
+            # The writer opened after resume must sort after the immutable
+            # compacted history, or TensorBoard may tail the wrong file.
+            resumed_writer = EventFileWriter(run_dir)
+            resumed_writer.close()
+            event_names = sorted(name for name in os.listdir(run_dir) if name.startswith("events.out.tfevents."))
+            self.assertTrue(any(name.endswith(".musubi-compacted") for name in event_names))
+            self.assertFalse(event_names[-1].endswith(".musubi-compacted"))
+
+            remaining_steps = []
+            remaining_values = []
+            has_session_log = False
+            for name in os.listdir(run_dir):
+                if not name.startswith("events.out.tfevents."):
+                    continue
+                for event in LegacyEventFileLoader(os.path.join(run_dir, name)).Load():
+                    if event.HasField("summary"):
+                        remaining_steps.append(event.step)
+                        remaining_values.extend(value.simple_value for value in event.summary.value)
+                    has_session_log = has_session_log or event.HasField("session_log")
+
+            self.assertEqual(remaining_steps, [10, 20])
+            self.assertEqual(remaining_values, [1.0, 2.5])
+            self.assertFalse(has_session_log)
+            self.assertEqual(result.event_files, 1)
+            self.assertGreaterEqual(result.removed_events, 4)
+
+
+class DeterministicDataOrderTest(unittest.TestCase):
+    def test_cache_file_enumeration_is_stable(self):
+        with mock.patch(
+            "musubi_tuner.dataset.image_video_dataset.glob.glob",
+            return_value=["cache/003.safetensors", "cache/001.safetensors", "cache/002.safetensors"],
+        ):
+            self.assertEqual(
+                _sorted_glob("cache/*.safetensors"),
+                ["cache/001.safetensors", "cache/002.safetensors", "cache/003.safetensors"],
+            )
+
+    def test_epoch_sampler_is_reproducible_without_consuming_torch_rng(self):
+        shared_epoch = SimpleNamespace(value=3)
+        data = list(range(20))
+        torch.manual_seed(1234)
+        rng_before = torch.get_rng_state().clone()
+
+        first = list(EpochSeededRandomSampler(data, 99, shared_epoch))
+        second = list(EpochSeededRandomSampler(data, 99, shared_epoch))
+
+        self.assertEqual(first, second)
+        self.assertTrue(torch.equal(rng_before, torch.get_rng_state()))
+        shared_epoch.value = 4
+        self.assertNotEqual(first, list(EpochSeededRandomSampler(data, 99, shared_epoch)))
+
+    def test_mid_epoch_resume_uses_the_uninterrupted_sampler_suffix(self):
+        shared_epoch = SimpleNamespace(value=8)
+        data = list(range(20))
+        uninterrupted = list(EpochSeededRandomSampler(data, 1024, shared_epoch))
+        reconstructed = list(EpochSeededRandomSampler(data, 1024, shared_epoch))
+
+        self.assertEqual(reconstructed[7:], uninterrupted[7:])
+
+    def test_bucket_shuffle_uses_the_supplied_rng_only(self):
+        def make_manager():
+            return BucketBatchManager({(16, 16): list(range(8))}, batch_size=2, num_timestep_buckets=3)
+
+        random.seed(1234)
+        global_state = random.getstate()
+        first = make_manager()
+        first.shuffle(random.Random(77))
+
+        self.assertEqual(global_state, random.getstate())
+
+        second = make_manager()
+        second.shuffle(random.Random(77))
+        self.assertEqual(first.buckets, second.buckets)
+        self.assertEqual(first.bucket_batch_indices, second.bucket_batch_indices)
+        self.assertEqual(first.timestep_pool, second.timestep_pool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_seamless_resume.py
+++ b/tests/test_seamless_resume.py
@@ -67,6 +67,13 @@ class TrainingProgressStateTest(unittest.TestCase):
 
             self.assertEqual(resolve_logging_dir(args), os.path.abspath(log_dir))
 
+    def test_version_one_state_marks_epoch_logs_for_migration(self):
+        state = TrainingProgressState()
+        state.load_state_dict({"version": 1, "global_step": 80, "epoch": 8})
+
+        self.assertEqual(state.epoch_log_step_mode, "global_step")
+        self.assertEqual(state.version, 2)
+
     def test_resume_rolls_trackers_back_to_checkpoint_boundary(self):
         state = TrainingProgressState(global_step=2000, log_with="all", wandb_run_id="wandb-id")
         state.loaded = True
@@ -96,10 +103,8 @@ class TrainingProgressStateTest(unittest.TestCase):
             run_dir = os.path.join(logging_dir, "network_train")
             writer = EventFileWriter(run_dir)
 
-            def add_scalar(step, wall_time, value):
-                summary = summary_pb2.Summary(
-                    value=[summary_pb2.Summary.Value(tag="loss/current", simple_value=value)]
-                )
+            def add_scalar(step, wall_time, value, tag="loss/current"):
+                summary = summary_pb2.Summary(value=[summary_pb2.Summary.Value(tag=tag, simple_value=value)])
                 writer.add_event(event_pb2.Event(step=step, wall_time=wall_time, summary=summary))
 
             add_scalar(10, 100.0, 1.0)
@@ -107,6 +112,8 @@ class TrainingProgressStateTest(unittest.TestCase):
             add_scalar(30, 220.0, 3.0)  # newer step
             add_scalar(5, 300.0, 4.0)  # low step written after the checkpoint
             add_scalar(20, 205.0, 2.5)  # retry: latest value for the same tag+step wins
+            add_scalar(2, 205.0, 0.75, tag="loss/epoch")  # valid epoch-axis summary
+            add_scalar(3, 220.0, 0.5, tag="loss/epoch")  # orphaned epoch-axis summary
             writer.add_event(
                 event_pb2.Event(
                     step=21,
@@ -138,11 +145,47 @@ class TrainingProgressStateTest(unittest.TestCase):
                         remaining_values.extend(value.simple_value for value in event.summary.value)
                     has_session_log = has_session_log or event.HasField("session_log")
 
-            self.assertEqual(remaining_steps, [10, 20])
-            self.assertEqual(remaining_values, [1.0, 2.5])
+            self.assertEqual(remaining_steps, [10, 20, 2])
+            self.assertEqual(remaining_values, [1.0, 2.5, 0.75])
             self.assertFalse(has_session_log)
             self.assertEqual(result.event_files, 1)
             self.assertGreaterEqual(result.removed_events, 4)
+
+    def test_version_one_epoch_logs_are_migrated_to_epoch_axis(self):
+        try:
+            from tensorboard.backend.event_processing.event_file_loader import LegacyEventFileLoader
+            from tensorboard.compat.proto import event_pb2, summary_pb2
+            from tensorboard.summary.writer.event_file_writer import EventFileWriter
+        except ImportError:
+            self.skipTest("tensorboard is not installed")
+
+        with tempfile.TemporaryDirectory() as logging_dir:
+            run_dir = os.path.join(logging_dir, "network_train")
+            writer = EventFileWriter(run_dir)
+            for global_step, loss in ((10, 1.0), (20, 0.5)):
+                summary = summary_pb2.Summary(
+                    value=[summary_pb2.Summary.Value(tag="loss/epoch", simple_value=loss)]
+                )
+                writer.add_event(event_pb2.Event(step=global_step, wall_time=100.0 + global_step, summary=summary))
+            writer.close()
+
+            trim_tensorboard_log_to_checkpoint(
+                logging_dir,
+                "network_train",
+                20,
+                125.0,
+                epoch_log_step_mode="global_step",
+                num_update_steps_per_epoch=10,
+            )
+
+            remaining_steps = []
+            for name in os.listdir(run_dir):
+                if name.startswith("events.out.tfevents."):
+                    for event in LegacyEventFileLoader(os.path.join(run_dir, name)).Load():
+                        if event.HasField("summary"):
+                            remaining_steps.append(event.step)
+
+            self.assertEqual(remaining_steps, [1, 2])
 
 
 class DeterministicDataOrderTest(unittest.TestCase):


### PR DESCRIPTION
## Background

The previous `--resume` implementation primarily restored the model, optimizer, and scheduler states. It did not fully preserve the training-loop position, data-loading order, or logging state.

This could cause:

- Training to resume from the wrong epoch or batch
- A different image order after restarting the process
- TensorBoard retaining invalid events written after the checkpoint
- Duplicated, disconnected, or forked log curves
- Loss history, timestep pools, and session metadata being lost

## Changes

### 1. Persist training-loop progress

A new `musubi_training_state.json` file records application-level state that is not managed by Accelerate, including:

- `global_step`
- `epoch`
- `step_in_epoch`
- Training seed
- Number of batches and update steps per epoch
- Gradient accumulation configuration
- Number of training processes
- Logging directory
- Session ID and original training start time
- Loss history
- Timestep range pool
- Checkpoint creation time

Training can now resume from the exact epoch and DataLoader batch position.

### 2. Reconstruct the data order deterministically

- Generate the DataLoader sampler order from `seed + epoch`
- Use an isolated epoch-specific RNG for bucket shuffling
- Sort image and video latent-cache paths before dataset construction
- Seed DataLoader workers deterministically for each epoch
- Skip only the batches already completed when resuming mid-epoch
- Avoid consuming the model's Python or PyTorch RNG while rebuilding the data order

When the dataset, seed, process count, and training configuration remain unchanged, the resumed data sequence matches the uninterrupted sequence.

### 3. Continue TensorBoard logs

- Reuse the original `logging_dir`
- Remove TensorBoard events newer than the resumed checkpoint
- Compact valid history into a `musubi-compacted` event file
- Ensure the new event writer follows the compacted history
- Deduplicate events with the same tag and step
- Keep all loss metrics on a single monotonic global-step axis

For example, if the checkpoint is at step 2000 while the log already contains steps 2001–2003, those orphaned events are removed before the resumed run writes the steps again.

### 4. Continue W&B runs

- Reuse the original W&B run
- Rewind the run to the checkpoint's committed global step
- Prevent duplicate or non-monotonic steps after resuming

### 5. Validate resume compatibility

The following settings are checked before seamless resume:

- `max_train_steps`
- Number of batches per epoch
- Number of update steps per epoch
- `gradient_accumulation_steps`
- Number of training processes
- Training seed

Training stops with a clear error when the saved state is incompatible with the current configuration.

### 6. Preserve backward compatibility

Legacy state directories without `musubi_training_state.json` can still restore the model and optimizer state.

A warning is emitted because legacy states cannot reliably recover:

- The exact epoch and batch position
- The original data-loading sequence
- Continuous application-level statistics

States created afterward will include the new seamless-resume metadata.

## Tests

Added coverage for:

- Training-state JSON serialization and restoration
- Logging-directory reuse
- Physical TensorBoard event trimming
- Ordering between compacted history and the resumed writer
- Deterministic epoch sampling
- Mid-epoch sampler suffix continuity
- Bucket shuffling without modifying the global Python RNG
- Stable latent-cache file enumeration

Validation completed:

- Python syntax compilation
- `git diff --check`

The complete test suite was not executed in the current development environment because PyTorch is unavailable.

## Requirements for deterministic resume

Deterministic continuation requires the following to remain unchanged:

- Dataset and cache-file set
- Training seed
- Batch size and gradient accumulation
- Number of training processes
- Model, optimizer, and scheduler configuration
- Software, hardware, and deterministic-computation environment

States created before this change did not record the original cache-file enumeration order, so strict historical data-order equivalence cannot be guaranteed for those states. New training runs and states created with this change reconstruct the data order deterministically.

**Complete 100 training steps**:
<img width="1233" height="978" alt="full" src="https://github.com/user-attachments/assets/76d87120-3c18-45ef-9631-0a84a038a295" />

**Resume from step 20**:
<img width="1231" height="993" alt="2" src="https://github.com/user-attachments/assets/5c0fe5cd-acc6-4b02-955b-8dfa00f47c60" />

**Resume from step 30**:
<img width="1235" height="981" alt="3" src="https://github.com/user-attachments/assets/d4a9c438-2f6b-4f44-95cb-b893b14b8330" />

**Resume from step 40**:
<img width="1245" height="1009" alt="4" src="https://github.com/user-attachments/assets/fd186529-da8b-49e2-9be5-8c62c0a9275a" />

<img width="1235" height="1006" alt="PixPin_2026-07-24_22-41-34" src="https://github.com/user-attachments/assets/5f39d4d0-e1d3-4506-bd2b-cc3092901717" />
