### PR TITLE
fix: cast non-target fp32 weights to dtype in ConvRot int8 quantizer

### DIFF
--- a/src/musubi_tuner/krea2/krea2_utils.py
+++ b/src/musubi_tuner/krea2/krea2_utils.py
@@ -113,7 +113,7 @@ def load_krea2_dit(
             target_keys=KREA2_FP8_OPTIMIZATION_TARGET_KEYS if fp8_scaled else None,
             exclude_keys=KREA2_FP8_OPTIMIZATION_EXCLUDE_KEYS if fp8_scaled else None,
             quantizer=(
-                ConvRotInt8Quantizer(KREA2_FP8_OPTIMIZATION_TARGET_KEYS, KREA2_FP8_OPTIMIZATION_EXCLUDE_KEYS)
+                ConvRotInt8Quantizer(KREA2_FP8_OPTIMIZATION_TARGET_KEYS, KREA2_FP8_OPTIMIZATION_EXCLUDE_KEYS, dtype=dtype)
                 if convrot_int8
                 else None
             ),

--- a/src/musubi_tuner/modules/convrot_int8_utils.py
+++ b/src/musubi_tuner/modules/convrot_int8_utils.py
@@ -74,10 +74,20 @@ class ConvRotInt8Quantizer:
         target_layer_keys: Optional[List[str]] = None,
         exclude_layer_keys: Optional[List[str]] = None,
         groupsize: int = CONVROT_GROUPSIZE,
+        dtype: Optional[torch.dtype] = None,
     ):
         self.target_layer_keys = target_layer_keys
         self.exclude_layer_keys = exclude_layer_keys
         self.groupsize = groupsize
+        # Cast non-quantized floating weights (excluded/indivisible/non-target) to this
+        # dtype. Checkpoints can store some of these (e.g. K2's "first" patch-embed) in
+        # fp32; left uncast, they mismatch the bf16 activations at forward time.
+        self.dtype = dtype
+
+    def _cast(self, value: torch.Tensor) -> torch.Tensor:
+        if self.dtype is not None and value.is_floating_point() and value.dtype != self.dtype:
+            return value.to(self.dtype)
+        return value
 
     def is_target_key(self, key: str) -> bool:
         is_target = (
@@ -116,7 +126,7 @@ class ConvRotInt8Quantizer:
 
                     if not self.is_target_key(key):
                         target_device = calc_device if (calc_device is not None and move_to_device) else original_device
-                        state_dict[key] = value.to(target_device)
+                        state_dict[key] = self._cast(value).to(target_device)
                         continue
 
                     if calc_device is not None:
@@ -132,7 +142,8 @@ class ConvRotInt8Quantizer:
 
                     result = quantize_weight_convrot(key, value, self.groupsize)
                     if result is None:
-                        # leave the layer unquantized (bf16)
+                        # leave the layer unquantized (cast to dtype, e.g. bf16)
+                        value = self._cast(value)
                         if not move_to_device:
                             value = value.to(original_device)
                         state_dict[key] = value

--- a/tests/test_krea2_convrot_int8.py
+++ b/tests/test_krea2_convrot_int8.py
@@ -272,6 +272,26 @@ def test_quantizer_patch_and_meta_load_state_dict_roundtrip(tmp_path):
     assert _relerr(fresh.head(x), F.linear(x, qsd["head.weight"])) < 1e-2
 
 
+def test_quantizer_casts_non_target_fp32_weights_to_dtype(tmp_path):
+    # Real K2 checkpoints store some non-block weights (e.g. the patch-embed "first"
+    # Linear) in fp32. Without a cast, those load as fp32 while the rest of the model
+    # runs bf16, breaking F.linear in the LoRA-wrapped module at inference/sample time.
+    torch.manual_seed(0)
+    model = _TinyModel()
+    sd = {k: v.to(torch.bfloat16) for k, v in model.state_dict().items()}
+    sd["first.weight"] = sd["first.weight"].to(torch.float32)
+    sd["head.weight"] = sd["head.weight"].to(torch.float32)
+    path = str(tmp_path / "tiny_fp32_head.safetensors")
+    save_file(sd, path)
+
+    quantizer = ConvRotInt8Quantizer(target_layer_keys=["blocks."], exclude_layer_keys=["norm"], dtype=torch.bfloat16)
+    qsd = quantizer.load_and_quantize([path], calc_device=None)
+
+    assert qsd["blocks.0.attn.weight"].dtype == torch.int8
+    assert qsd["first.weight"].dtype == torch.bfloat16  # indivisible, was fp32 -> must be cast
+    assert qsd["head.weight"].dtype == torch.bfloat16  # non-target, was fp32 -> must be cast
+
+
 def test_quantizer_rejects_prequantized_weights(tmp_path):
     sd = {"blocks.0.attn.weight": torch.zeros(N, K, dtype=torch.float8_e4m3fn)}
     path = str(tmp_path / "prequant.safetensors")


### PR DESCRIPTION
Ran into a dtype issue when running `--sample_at_first` and running the `--convrot_int8`. This PR looks to cast these appropriately. Maybe this could be "fixed" by setting things up before the sample images are done but this PR does fix the issue.

## Summary
- `ConvRotInt8Quantizer.load_and_quantize` left excluded/indivisible/non-target keys (e.g. K2's `first` patch-embed Linear) at whatever dtype the checkpoint stored, since `dit_weight_dtype` was never threaded through for the quantized load path (`load_krea2_dit` always passed `dit_weight_dtype=None` when `quantized` is true, regardless of `fp8_scaled` vs `convrot_int8`).
- When a checkpoint stores those non-target weights in fp32 (as the K2 checkpoint does), this breaks `F.linear` with a `BFloat16`/`Float32` dtype mismatch once the rest of the model runs bf16 — hit this training a K2 LoRA with `--convrot_int8` enabled, failing at step-0 sample-image generation inside a LoRA-wrapped `first` Linear.
- `ConvRotInt8Quantizer` now accepts a `dtype` and casts any non-quantized floating weight to it in both non-target and indivisible-weight branches; `krea2_utils.load_krea2_dit` passes the real `dtype` through for `--convrot_int8`. The `--fp8_scaled` path is untouched — its checkpoint-dtype behavior there is documented as intentional in the existing docstrings/comments.

## Test plan
- [x] Added `test_quantizer_casts_non_target_fp32_weights_to_dtype`, reproducing a checkpoint with fp32 non-target/indivisible weights and asserting they're cast when a `dtype` is supplied; fails on `main`/pre-fix code (`TypeError: unexpected keyword argument 'dtype'`), passes after the fix.
- [x] `uv run --no-sync --with pytest pytest tests/test_krea2_convrot_int8.py -q` — 21 passed (all existing ConvRot int8 tests plus the new one).