### PR TITLE
Migrate MiniMax-H3 onto the common audio dataset seam (2/2)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -57,10 +57,11 @@ cache_directory = "/data/h3/cache"
 caption_extension = ".txt"
 target_frames = [124]
 frame_extraction = "head"
-source_fps = 24.0
 ```
 
-For a directory item such as `clip.mp4`, put the caption in `clip.txt`. Target audio is resolved in this order: the JSONL `audio_path` when JSONL is used, exactly one same-stem audio sidecar such as `clip.wav`, then the video's embedded audio stream, then an unsupervised silence placeholder.
+H3 always normalizes source videos to 24 fps using frame timestamps, so `source_fps` is not needed and is ignored if set.
+
+For a directory item such as `clip.mp4`, put the caption in `clip.txt`. Target audio is resolved in this order: the JSONL `audio_path` when JSONL is used, exactly one same-stem audio sidecar such as `clip.wav`, then the video's embedded audio stream, then an unsupervised silence placeholder. Audio sources are resolved and validated when the dataset is constructed, so a broken explicit `audio_path` fails before any caching work starts.
 
 Ref2VA requires `video_jsonl_file`:
 
@@ -76,7 +77,6 @@ video_jsonl_file = "/data/h3/ref2va.jsonl"
 cache_directory = "/data/h3/cache-ref2va"
 target_frames = [124]
 frame_extraction = "head"
-source_fps = 24.0
 ```
 
 Each JSONL line contains the target plus its ordered references. Relative paths resolve from the JSONL directory.
@@ -110,9 +110,13 @@ python minimax_h3_cache_latents.py \
 
 The video VAE is upcast to FP32 for target and condition encoding so cached training targets do not inherit FP16 encoder outliers. It uses a reproducible posterior sample for each target. Visual conditions use the released fixed sampling policy, including the required FP16 round-trip of the sampled condition latent before normalization. Video decode keeps the released FP16 artifact in FP16. Target and reference audio use the audio posterior mode directly in `[32,2,A]` layout.
 
-By default, caching uses real target audio when available. If a video has no target audio, caching encodes duration-matched silence as the structurally required audio latent and marks that sample's audio loss disabled; missing audio is not treated as a silent supervision target. To avoid flooding large silent datasets, the cache command warns with paths for only the first 10 missing-audio records and then prints one completion summary with policy counts and the supervised fraction. To ignore all target audio intentionally, add `--h3_video_only` to the latent-cache command only. Ref2VA reference audio remains active conditioning.
+Caching always uses real target audio when available. If a video has no target audio, caching encodes duration-matched silence as the structurally required audio latent and records `audio_present=0`; missing audio is never treated as a silent supervision target, and such samples are automatically excluded from audio supervision during training. To avoid flooding large silent datasets, dataset construction warns with paths for only the first 10 missing-audio records, and the cache command prints one completion summary with the supervised fraction.
 
-`--audio_vae` is still required with `--h3_video_only`. H3 always includes target-audio rows, and the released Audio VAE encoding of a zero waveform is not guaranteed to be an all-zero latent. Each cache stores its own small silence latent: at `F=124`, it is about 52 KB versus about 7.16 MB for the BF16 video latent, so no shared-silence or deduplication mechanism is used. Existing real-audio H3 latent caches remain compatible and do not require a blanket rebuild.
+The cache stores only this fact about the data. Whether and how strongly audio is supervised is decided at training time with `--video_only` and `--audio_loss_weight` (see LoRA Training below); there is no cache-time video-only mode.
+
+`--audio_vae` is always required. H3 always includes target-audio rows, and the released Audio VAE encoding of a zero waveform is not guaranteed to be an all-zero latent. Each cache stores its own small silence latent: at `F=124`, it is about 52 KB versus about 7.16 MB for the BF16 video latent, so no shared-silence or deduplication mechanism is used.
+
+Latent caches created before the `audio_present` contract (releases with `target_audio_policy` metadata) are not compatible; re-run latent caching. Text encoder caches are unaffected.
 
 ## Cache Text Encoder Outputs
 
@@ -149,15 +153,20 @@ accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 minimax
   --output_name h3-lora
 ```
 
-The default LoRA targets only `attn.qkv_proj`, `attn.out_proj`, `mlp.fc1`, and `mlp.fc2` in the 50 main DiT blocks. Every sample contributes `mean(video_mse)`. A sample with real target audio additionally contributes `mean(audio_mse)` at equal per-sample coefficient; a missing-audio or video-only sample contributes no audio MSE. With `batch_size=1` and gradient accumulation, the expected run-level audio coefficient is therefore the supervised-audio sample fraction, not always one. This fraction is not a uniform per-step scale: at low values, most optimizer steps receive no audio gradient and occasional steps receive the full audio term. Training does not renormalize by the fraction, because doing so would amplify a small supervised subset.
+The default LoRA targets only `attn.qkv_proj`, `attn.out_proj`, `mlp.fc1`, and `mlp.fc2` in the 50 main DiT blocks. Every sample contributes `mean(video_mse)`. A sample cached with real target audio additionally contributes `audio_loss_weight * mean(audio_mse)`; a sample cached from missing audio (`audio_present=0`) never contributes audio MSE. With `batch_size=1` and gradient accumulation, the expected run-level audio coefficient is therefore `audio_loss_weight` times the supervised-audio sample fraction. This fraction is not a uniform per-step scale: at low values, most optimizer steps receive no audio gradient and occasional steps receive the full audio term. Training does not renormalize by the fraction, because doing so would amplify a small supervised subset.
 
-The trainer logs this value as `supervised_audio_fraction` and saves it as `ss_minimax_h3_supervised_audio_fraction`. It also records `ss_minimax_h3_loss_policy=video_mean_plus_optional_audio_mean` and `ss_minimax_h3_audio_supervision=per_sample_binary_cache_weight`. H3 enforces uniform base-time sampling, no generic SD3 loss weighting, and independent video/audio shifts of 12 and 3.
+Two training arguments control audio supervision:
 
-Zero audio loss does not preserve the base model's audio behavior. H3 is single-stream, and these LoRA targets modify the same attention and MLP weights used by video and audio tokens. A video-only or low-`supervised_audio_fraction` LoRA can therefore produce audio worse than the base model; the risk generally increases with adapter capacity/strength and training exposure, although degradation is not guaranteed to be monotonic. Treat audio from a fully video-only LoRA as unconstrained output.
+- `--video_only` disables audio supervision entirely (audio loss weight 0 for all samples). The model still attends to the real audio latents as context, which matches the inference-time distribution where audio tokens are always generated audio, never silence.
+- `--audio_loss_weight` (default 1.0) scales the audio loss term for supervised samples, e.g. to rebalance a small audio loss against the video loss.
+
+The trainer logs the supervised fraction as `supervised_audio_fraction` and saves it as `ss_minimax_h3_supervised_audio_fraction`, along with `ss_minimax_h3_audio_loss_weight` and `ss_minimax_h3_video_only`. It also records `ss_minimax_h3_loss_policy=video_mean_plus_weighted_audio_mean` and `ss_minimax_h3_audio_supervision=presence_gated_training_weight`. H3 enforces uniform base-time sampling, no generic SD3 loss weighting, and independent video/audio shifts of 12 and 3.
+
+Zero audio loss does not preserve the base model's audio behavior. H3 is single-stream, and these LoRA targets modify the same attention and MLP weights used by video and audio tokens. A `--video_only` or low-`supervised_audio_fraction` LoRA can therefore produce audio worse than the base model; the risk generally increases with adapter capacity/strength and training exposure, although degradation is not guaranteed to be monotonic. Treat audio from a fully video-only LoRA as unconstrained output.
 
 Block swap supports up to 48 of the 50 main blocks. `--block_swap_h2d_only` is also supported for frozen-base LoRA training and requires `--gradient_checkpointing`.
 
-R1 requires `batch_size = 1` in every H3 dataset. Use Accelerate gradient accumulation for a larger effective batch. The batch-size gate runs immediately after dataset construction and reads no cache files. Fraction validation then uses the cache paths already stored in the constructed batch managers, counts repeats from those entries, and opens each unique cache once; it does not run a second glob or load video/audio latent payloads. The runtime/model repeat the batch-size check for direct API calls. Real packed batching needs text padding, an attention mask, and per-sample structural tensors, so it is deferred to a separate PR.
+R1 requires `batch_size = 1` in every H3 dataset. Use Accelerate gradient accumulation for a larger effective batch. The batch-size gate runs immediately after dataset construction and reads no cache files. The supervised-fraction scan then uses the cache paths already stored in the constructed batch managers, counts repeats from those entries, and opens each unique cache once to read its `audio_present` entry; it does not run a second glob or load video/audio latent payloads. The runtime/model repeat the batch-size check for direct API calls. Real packed batching needs text padding, an attention mask, and per-sample structural tensors, so it is deferred to a separate PR.
 
 Saved `ss_minimax_h3_base_family` names the released transformer family, not the task. T2VA therefore records `ss_minimax_h3_task=t2va` and `ss_minimax_h3_base_family=fl2va`, because T2VA uses the released FL2VA base.
 

--- a/src/musubi_tuner/dataset/cache_io.py
+++ b/src/musubi_tuner/dataset/cache_io.py
@@ -543,19 +543,11 @@ def save_latent_cache_minimax_h3(
 
     target_count = 0
     audio_count = 0
-    audio_loss_weight_count = 0
-    audio_loss_weight = None
     normalized = {}
     for key, tensor in tensors.items():
         if not isinstance(tensor, torch.Tensor):
             raise ValueError(f"MiniMax-H3 cache value must be a tensor: {key}")
-        if key == "mmh3_audio_loss_weight_float32":
-            if tensor.shape != torch.Size([]) or tensor.dtype != torch.float32:
-                raise ValueError("MiniMax-H3 audio loss weight must be a scalar float32 tensor")
-            if not torch.isfinite(tensor).item() or tensor.item() not in {0.0, 1.0}:
-                raise ValueError("MiniMax-H3 audio loss weight must be exactly 0.0 or 1.0")
-            audio_loss_weight_count += 1
-            audio_loss_weight = tensor.item()
+        if key == AUDIO_PRESENT_KEY:
             normalized[key] = tensor.detach().cpu().contiguous()
             continue
 
@@ -599,17 +591,13 @@ def save_latent_cache_minimax_h3(
         raise ValueError(f"MiniMax-H3 cache requires exactly one target video latent, found {target_count}")
     if audio_count != 1:
         raise ValueError(f"MiniMax-H3 cache requires exactly one target audio latent, found {audio_count}")
-    if audio_loss_weight_count != 1:
-        raise ValueError(f"MiniMax-H3 cache requires exactly one audio loss weight tensor, found {audio_loss_weight_count}")
-    target_audio_policy = (metadata or {}).get("target_audio_policy")
-    valid_audio_policies = {"real-supervised", "missing-unsupervised", "video-only-unsupervised"}
-    if target_audio_policy not in valid_audio_policies:
-        raise ValueError(f"MiniMax-H3 cache requires valid target_audio_policy metadata, got {target_audio_policy!r}")
-    expected_audio_loss_weight = 1.0 if target_audio_policy == "real-supervised" else 0.0
-    if audio_loss_weight != expected_audio_loss_weight:
+    audio_present = validate_audio_present_entry(normalized)
+    metadata_present = (metadata or {}).get("audio_present")
+    if metadata_present not in {"0", "1"}:
+        raise ValueError(f'MiniMax-H3 cache requires audio_present metadata of "0" or "1", got {metadata_present!r}')
+    if float(metadata_present) != audio_present:
         raise ValueError(
-            f"MiniMax-H3 cache has contradictory target_audio_policy={target_audio_policy!r} "
-            f"and audio loss weight={audio_loss_weight}"
+            f"MiniMax-H3 cache has contradictory audio_present metadata={metadata_present!r} and tensor value={audio_present}"
         )
     save_latent_cache_common(item_info, normalized, ARCHITECTURE_MINIMAX_H3_FULL, metadata)
 

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -10,7 +10,6 @@ import torch
 
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode
 from musubi_tuner.minimax_h3.media import (
-    H3AudioSource,
     H3Record,
     audio_latent_frames,
     load_h3_jsonl_records,
@@ -26,11 +25,9 @@ VIDEO_VAE_SPATIAL_RATIO = 16
 
 
 def dummy_record(prompt: str) -> H3Record:
-    placeholder = Path(".")
     return H3Record(
-        video_path=placeholder,
+        video_path=Path("."),
         caption=prompt,
-        target_audio=H3AudioSource(placeholder, embedded=False),
         references=(),
         jsonl_line=0,
     )

--- a/src/musubi_tuner/minimax_h3/media.py
+++ b/src/musubi_tuner/minimax_h3/media.py
@@ -7,24 +7,24 @@ from typing import Callable, Literal, Optional
 
 import av
 
+from musubi_tuner.dataset.audio_utils import AudioSource as H3AudioSource
+from musubi_tuner.dataset.audio_utils import AudioSpec
+from musubi_tuner.dataset.datasources import VideoDatasource, VideoJsonlDatasource
+
 
 H3Task = Literal["t2va", "fl2va", "ref2va"]
 H3ReferenceType = Literal["image", "video", "audio"]
 H3MediaProbe = Callable[[Path], "H3MediaInfo"]
 
-AUDIO_SIDECAR_EXTENSIONS = frozenset({".aac", ".flac", ".m4a", ".mp3", ".ogg", ".opus", ".wav"})
+TARGET_FPS = 24
+AUDIO_SAMPLE_RATE = 32000
+AUDIO_TERMINAL_TOLERANCE_SAMPLES = 800
 
 
 @dataclass(frozen=True)
 class H3MediaInfo:
     has_audio: bool
     duration_seconds: Optional[float]
-
-
-@dataclass(frozen=True)
-class H3AudioSource:
-    path: Path
-    embedded: bool
 
 
 @dataclass(frozen=True)
@@ -39,7 +39,6 @@ class H3Reference:
 class H3Record:
     video_path: Path
     caption: str
-    target_audio: Optional[H3AudioSource]
     references: tuple[H3Reference, ...]
     jsonl_line: int
 
@@ -63,6 +62,15 @@ def waveform_samples(audio_frames: int) -> int:
     if audio_frames <= 0:
         raise ValueError(f"Audio latent frame count must be positive, got {audio_frames}")
     return audio_frames * 800
+
+
+# passed to the shared dataset layer so that it decodes and windows target audio for us
+H3_AUDIO_SPEC = AudioSpec(
+    sample_rate=AUDIO_SAMPLE_RATE,
+    channels=2,
+    samples_per_crop=lambda frame_count: waveform_samples(audio_latent_frames(frame_count)),
+    codec_pad_tolerance=AUDIO_TERMINAL_TOLERANCE_SAMPLES,
+)
 
 
 def probe_h3_media(path: Path) -> H3MediaInfo:
@@ -101,73 +109,6 @@ def _probe_required_audio(path: Path, probe: H3MediaProbe, label: str, line_numb
     if not info.has_audio:
         raise ValueError(f"H3 JSONL line {line_number}: {label} contains no audio stream: {path}")
     return info
-
-
-def _same_stem_audio_sidecars(video_path: Path) -> list[Path]:
-    return sorted(
-        (
-            candidate.resolve()
-            for candidate in video_path.parent.iterdir()
-            if candidate.is_file() and candidate.stem == video_path.stem and candidate.suffix.lower() in AUDIO_SIDECAR_EXTENSIONS
-        ),
-        key=lambda path: path.name.lower(),
-    )
-
-
-def _resolve_target_audio(
-    data: dict,
-    video_path: Path,
-    base_directory: Path,
-    line_number: int,
-    probe: H3MediaProbe,
-    *,
-    video_only: bool = False,
-) -> Optional[H3AudioSource]:
-    if video_only:
-        return None
-
-    if data.get("audio_path") is not None:
-        path = _resolve_existing_path(data["audio_path"], base_directory, "audio_path", line_number)
-        _probe_required_audio(path, probe, "Explicit target audio", line_number)
-        return H3AudioSource(path=path, embedded=False)
-
-    sidecars = _same_stem_audio_sidecars(video_path)
-    if len(sidecars) > 1:
-        formatted = ", ".join(str(path) for path in sidecars)
-        raise ValueError(f"H3 JSONL line {line_number}: Multiple same-stem audio sidecars found: {formatted}")
-    if sidecars:
-        _probe_required_audio(sidecars[0], probe, "Target audio sidecar", line_number)
-        return H3AudioSource(path=sidecars[0], embedded=False)
-
-    try:
-        video_info = probe(video_path)
-    except Exception as error:
-        raise ValueError(f"H3 JSONL line {line_number}: Target video failed to decode: {error}") from error
-    if video_info.has_audio:
-        return H3AudioSource(path=video_path, embedded=True)
-    return None
-
-
-def make_h3_directory_record(
-    video_path: str | Path,
-    caption: str,
-    probe: H3MediaProbe = probe_h3_media,
-    *,
-    video_only: bool = False,
-) -> H3Record:
-    video_path = Path(video_path).resolve()
-    if not video_path.is_file():
-        raise ValueError(f"MiniMax-H3 target video does not exist: {video_path}")
-    if not isinstance(caption, str):
-        raise ValueError("MiniMax-H3 directory caption must be a string")
-    target_audio = _resolve_target_audio({}, video_path, video_path.parent, 0, probe, video_only=video_only)
-    return H3Record(
-        video_path=video_path,
-        caption=caption,
-        target_audio=target_audio,
-        references=(),
-        jsonl_line=0,
-    )
 
 
 def _validate_reference_counts(references: list, line_number: int) -> None:
@@ -252,12 +193,36 @@ def _parse_references(
     return tuple(references)
 
 
+def _record_from_jsonl_data(
+    data: object,
+    base_directory: Path,
+    line_number: int,
+    task: H3Task,
+    probe: H3MediaProbe,
+) -> H3Record:
+    if not isinstance(data, dict):
+        raise ValueError(f"H3 JSONL line {line_number}: each record must be an object")
+
+    video_path = _resolve_existing_path(data.get("video_path"), base_directory, "video_path", line_number)
+    caption = data.get("caption")
+    if not isinstance(caption, str):
+        raise ValueError(f"H3 JSONL line {line_number}: caption must be a string")
+
+    raw_references = data.get("references", [])
+    if task == "ref2va":
+        references = _parse_references(raw_references, base_directory, line_number, probe)
+    else:
+        if raw_references:
+            raise ValueError(f"H3 JSONL line {line_number}: references require task ref2va")
+        references = ()
+
+    return H3Record(video_path=video_path, caption=caption, references=references, jsonl_line=line_number)
+
+
 def load_h3_jsonl_records(
     jsonl_path: str | Path,
     task: H3Task,
     probe: H3MediaProbe = probe_h3_media,
-    *,
-    video_only: bool = False,
 ) -> list[H3Record]:
     if task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
@@ -276,40 +241,45 @@ def load_h3_jsonl_records(
                 data = json.loads(line)
             except json.JSONDecodeError as error:
                 raise ValueError(f"H3 JSONL line {line_number}: invalid JSON: {error.msg}") from error
-            if not isinstance(data, dict):
-                raise ValueError(f"H3 JSONL line {line_number}: each record must be an object")
-
-            video_path = _resolve_existing_path(data.get("video_path"), base_directory, "video_path", line_number)
-            caption = data.get("caption")
-            if not isinstance(caption, str):
-                raise ValueError(f"H3 JSONL line {line_number}: caption must be a string")
-            target_audio = _resolve_target_audio(
-                data,
-                video_path,
-                base_directory,
-                line_number,
-                probe,
-                video_only=video_only,
-            )
-
-            raw_references = data.get("references", [])
-            if task == "ref2va":
-                references = _parse_references(raw_references, base_directory, line_number, probe)
-            else:
-                if raw_references:
-                    raise ValueError(f"H3 JSONL line {line_number}: references require task ref2va")
-                references = ()
-
-            records.append(
-                H3Record(
-                    video_path=video_path,
-                    caption=caption,
-                    target_audio=target_audio,
-                    references=references,
-                    jsonl_line=line_number,
-                )
-            )
+            records.append(_record_from_jsonl_data(data, base_directory, line_number, task, probe))
 
     if not records:
         raise ValueError(f"MiniMax-H3 JSONL contains no records: {jsonl_path}")
+    return records
+
+
+def h3_records_from_datasource(
+    datasource: VideoDatasource,
+    task: H3Task,
+    probe: H3MediaProbe = probe_h3_media,
+) -> list[H3Record]:
+    """Builds H3 records from the datasource's already-parsed data (no JSONL re-read).
+
+    Records align with datasource indices, so cache items reference them through
+    ItemInfo.datasource_index.
+    """
+    if task not in {"t2va", "fl2va", "ref2va"}:
+        raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
+
+    if isinstance(datasource, VideoJsonlDatasource):
+        base_directory = Path(datasource.video_jsonl_file).resolve().parent
+        records = [
+            _record_from_jsonl_data(data, base_directory, index + 1, task, probe) for index, data in enumerate(datasource.data)
+        ]
+        if not records:
+            raise ValueError(f"MiniMax-H3 JSONL contains no records: {datasource.video_jsonl_file}")
+        return records
+
+    if task == "ref2va":
+        raise ValueError("MiniMax-H3 Ref2VA requires video_jsonl_file")
+
+    records = []
+    for index in range(len(datasource)):
+        video_path, caption = datasource.get_caption(index)
+        video_path = Path(video_path).resolve()
+        if not video_path.is_file():
+            raise ValueError(f"MiniMax-H3 target video does not exist: {video_path}")
+        if not isinstance(caption, str):
+            raise ValueError("MiniMax-H3 directory caption must be a string")
+        records.append(H3Record(video_path=video_path, caption=caption, references=(), jsonl_line=0))
     return records

--- a/src/musubi_tuner/minimax_h3/media.py
+++ b/src/musubi_tuner/minimax_h3/media.py
@@ -64,11 +64,16 @@ def waveform_samples(audio_frames: int) -> int:
     return audio_frames * 800
 
 
+def h3_samples_per_crop(frame_count: int) -> int:
+    # module-level (not a lambda) so the spec stays picklable for spawned DataLoader workers
+    return waveform_samples(audio_latent_frames(frame_count))
+
+
 # passed to the shared dataset layer so that it decodes and windows target audio for us
 H3_AUDIO_SPEC = AudioSpec(
     sample_rate=AUDIO_SAMPLE_RATE,
     channels=2,
-    samples_per_crop=lambda frame_count: waveform_samples(audio_latent_frames(frame_count)),
+    samples_per_crop=h3_samples_per_crop,
     codec_pad_tolerance=AUDIO_TERMINAL_TOLERANCE_SAMPLES,
 )
 

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-from bisect import bisect_left
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -10,12 +9,10 @@ import hashlib
 import json
 import logging
 import math
+import os
 from pathlib import Path
-import re
-from types import MethodType
 from typing import Protocol
 
-import av
 import numpy as np
 from PIL import Image
 from safetensors import safe_open
@@ -24,20 +21,25 @@ import torch
 import musubi_tuner.cache_latents as cache_latents
 from musubi_tuner.dataset import config_utils
 from musubi_tuner.dataset.architectures import ARCHITECTURE_MINIMAX_H3
-from musubi_tuner.dataset.cache_io import save_latent_cache_minimax_h3
+from musubi_tuner.dataset.audio_utils import decode_audio as decode_audio_waveform
+from musubi_tuner.dataset.audio_utils import slice_audio_window
+from musubi_tuner.dataset.cache_io import append_audio_present_entry, save_latent_cache_minimax_h3
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
 from musubi_tuner.dataset.image_video_dataset import ItemInfo, VideoDataset
-from musubi_tuner.dataset.media_utils import resize_image_to_bucket
+from musubi_tuner.dataset.media_utils import load_video
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode, load_audio_vae
 from musubi_tuner.minimax_h3.checkpoint import resolve_safetensors_files
 from musubi_tuner.minimax_h3.media import (
+    AUDIO_SAMPLE_RATE,
+    AUDIO_TERMINAL_TOLERANCE_SAMPLES,
+    H3_AUDIO_SPEC,
     H3AudioSource,
     H3Record,
     H3Reference,
     H3Task,
+    TARGET_FPS,
     audio_latent_frames,
-    load_h3_jsonl_records,
-    make_h3_directory_record,
+    h3_records_from_datasource,
     video_latent_frames,
     waveform_samples,
 )
@@ -53,14 +55,9 @@ from musubi_tuner.utils.model_utils import dtype_to_str
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-TARGET_FPS = 24
-AUDIO_SAMPLE_RATE = 32000
-AUDIO_TERMINAL_TOLERANCE_SAMPLES = 800
-AUDIO_TIMESTAMP_TOLERANCE_SAMPLES = 2
 CANVAS_MULTIPLE = 32
 BASE_SHORT_EDGE = 768
 MAX_PIXELS = 768 * 1344
-TARGET_AUDIO_POLICIES = frozenset({"real-supervised", "missing-unsupervised", "video-only-unsupervised"})
 
 
 @dataclass(frozen=True)
@@ -86,67 +83,6 @@ class H3MediaDecoder(Protocol):
         target_frame_count: int,
         target_size: tuple[int, int],
     ) -> torch.Tensor: ...
-
-
-def resample_frame_indices(
-    timestamps: Sequence[float],
-    *,
-    source_frame_duration: float,
-    target_fps: int = TARGET_FPS,
-) -> list[int]:
-    if not timestamps:
-        return []
-    if source_frame_duration <= 0 or target_fps <= 0:
-        raise ValueError("Video frame durations and target FPS must be positive")
-    if any(right < left for left, right in zip(timestamps, timestamps[1:])):
-        raise ValueError("Video timestamps must be nondecreasing")
-
-    origin = timestamps[0]
-    normalized = [timestamp - origin for timestamp in timestamps]
-    duration = normalized[-1] + source_frame_duration
-    target_count = max(1, math.ceil(duration * target_fps - 1e-9))
-    indices = []
-    for target_index in range(target_count):
-        target_time = target_index / target_fps
-        right = bisect_left(normalized, target_time)
-        if right == 0:
-            source_index = 0
-        elif right == len(normalized):
-            source_index = len(normalized) - 1
-        else:
-            left = right - 1
-            left_distance = target_time - normalized[left]
-            right_distance = normalized[right] - target_time
-            source_index = left if left_distance <= right_distance + 1e-12 else right
-        indices.append(source_index)
-    return indices
-
-
-def _decode_video_frames(path: Path) -> tuple[list[np.ndarray], list[float], float]:
-    with av.open(str(path)) as container:
-        if not container.streams.video:
-            raise ValueError(f"MiniMax-H3 visual source has no video stream: {path}")
-        stream = container.streams.video[0]
-        average_rate = float(stream.average_rate) if stream.average_rate is not None else TARGET_FPS
-        source_frame_duration = 1.0 / average_rate if average_rate > 0 else 1.0 / TARGET_FPS
-        frames = []
-        timestamps = []
-        for index, frame in enumerate(container.decode(stream)):
-            if frame.pts is not None and frame.time_base is not None:
-                timestamp = float(frame.pts * frame.time_base)
-            else:
-                timestamp = index * source_frame_duration
-            frames.append(frame.to_ndarray(format="rgb24"))
-            timestamps.append(timestamp)
-    if not frames:
-        raise ValueError(f"MiniMax-H3 visual source decoded no frames: {path}")
-    return frames, timestamps, source_frame_duration
-
-
-def _video_at_24fps(path: Path) -> list[np.ndarray]:
-    frames, timestamps, source_frame_duration = _decode_video_frames(path)
-    indices = resample_frame_indices(timestamps, source_frame_duration=source_frame_duration)
-    return [frames[index] for index in indices]
 
 
 def _round_to_multiple(value: float, multiple: int = CANVAS_MULTIPLE) -> int:
@@ -176,22 +112,10 @@ def _resize_frames(frames: Sequence[np.ndarray], size: tuple[int, int]) -> torch
 
 
 class PyAVH3MediaDecoder:
+    """Decodes MiniMax-H3 reference media (target media is decoded by the shared dataset layer)."""
+
     def __init__(self, terminal_tolerance_samples: int = AUDIO_TERMINAL_TOLERANCE_SAMPLES):
         self.terminal_tolerance_samples = terminal_tolerance_samples
-
-    def decode_target_video(
-        self,
-        path: str | Path,
-        start_frame: int | None,
-        end_frame: int | None,
-        bucket_selector,
-    ) -> list[np.ndarray]:
-        frames = _video_at_24fps(Path(path).resolve())
-        frames = frames[slice(start_frame, end_frame)]
-        if not frames:
-            raise ValueError(f"MiniMax-H3 target crop decoded no frames: {path}")
-        bucket_resolution = bucket_selector.get_bucket_resolution((frames[0].shape[1], frames[0].shape[0]))
-        return [resize_image_to_bucket(frame, bucket_resolution) for frame in frames]
 
     def decode_audio(
         self,
@@ -203,41 +127,15 @@ class PyAVH3MediaDecoder:
     ) -> torch.Tensor:
         if start_sample < 0 or sample_count <= 0:
             raise ValueError("MiniMax-H3 audio window must have a nonnegative start and positive length")
-
-        chunks = []
-        next_start_sample = 0
-        with av.open(str(source.path)) as container:
-            if not container.streams.audio:
-                raise ValueError(f"MiniMax-H3 audio source has no audio stream: {source.path}")
-            stream = container.streams.audio[0]
-            resampler = av.AudioResampler(format="fltp", layout="stereo", rate=AUDIO_SAMPLE_RATE)
-            for frame in container.decode(stream):
-                for resampled in resampler.resample(frame):
-                    chunk = _audio_frame_to_tensor(resampled)
-                    chunk_start = _audio_frame_start_sample(resampled, next_start_sample)
-                    chunks.append((chunk_start, chunk))
-                    next_start_sample = chunk_start + chunk.shape[1]
-            for resampled in resampler.resample(None):
-                chunk = _audio_frame_to_tensor(resampled)
-                chunk_start = _audio_frame_start_sample(resampled, next_start_sample)
-                chunks.append((chunk_start, chunk))
-                next_start_sample = chunk_start + chunk.shape[1]
-
-        if not chunks:
-            raise ValueError(f"MiniMax-H3 audio source decoded no samples: {source.path}")
-        waveform = assemble_audio_chunks(chunks)
-        window = waveform[:, start_sample : start_sample + sample_count]
-        if require_exact and window.shape[1] < sample_count:
-            deficit = sample_count - window.shape[1]
-            if deficit > self.terminal_tolerance_samples:
-                raise ValueError(
-                    f"MiniMax-H3 audio source is materially short at sample {start_sample}: "
-                    f"need {sample_count}, decoded {window.shape[1]}"
-                )
-            window = torch.nn.functional.pad(window, (0, deficit))
-        if window.shape[1] == 0:
-            raise ValueError(f"MiniMax-H3 audio window is empty at sample {start_sample}: {source.path}")
-        return window.contiguous()
+        waveform = decode_audio_waveform(source, sample_rate=AUDIO_SAMPLE_RATE, channels=2)
+        return slice_audio_window(
+            waveform,
+            start_sample=start_sample,
+            sample_count=sample_count,
+            pad_tolerance=self.terminal_tolerance_samples,
+            require_exact=require_exact,
+            context=str(source.path),
+        )
 
     def decode_reference_visual(
         self,
@@ -257,7 +155,7 @@ class PyAVH3MediaDecoder:
 
         if reference.type != "video":
             raise ValueError(f"Reference type {reference.type!r} has no visual stream")
-        frames = _video_at_24fps(reference.path)
+        frames = load_video(str(reference.path), target_fps=TARGET_FPS, fps_resample_mode="timestamps")
         usable_frames = min(len(frames), target_frame_count)
         if usable_frames < 5:
             raise ValueError(f"MiniMax-H3 reference video requires at least 5 frames: {reference.path}")
@@ -269,51 +167,6 @@ class PyAVH3MediaDecoder:
             width = _round_to_multiple(source_width)
             height = _round_to_multiple(source_height)
         return _resize_frames(frames, (width, height))
-
-
-def _audio_frame_to_tensor(frame: av.AudioFrame) -> torch.Tensor:
-    array = frame.to_ndarray()
-    if array.ndim != 2:
-        raise ValueError(f"Unexpected PyAV audio frame shape: {array.shape}")
-    if array.shape[0] != 2 and array.shape[1] == 2:
-        array = array.T
-    if array.shape[0] != 2:
-        raise ValueError(f"PyAV stereo resampler returned shape {array.shape}")
-    return torch.from_numpy(np.asarray(array, dtype=np.float32).copy())
-
-
-def _audio_frame_start_sample(frame: av.AudioFrame, fallback: int) -> int:
-    if frame.pts is None or frame.time_base is None:
-        return fallback
-    return round(frame.pts * frame.time_base * AUDIO_SAMPLE_RATE)
-
-
-def assemble_audio_chunks(
-    chunks: Sequence[tuple[int, torch.Tensor]],
-    *,
-    timestamp_tolerance_samples: int = AUDIO_TIMESTAMP_TOLERANCE_SAMPLES,
-) -> torch.Tensor:
-    if not chunks:
-        raise ValueError("MiniMax-H3 audio chunk list is empty")
-    if timestamp_tolerance_samples < 0:
-        raise ValueError("MiniMax-H3 audio timestamp tolerance must be nonnegative")
-
-    expected_start = chunks[0][0]
-    assembled = []
-    for start_sample, chunk in chunks:
-        if chunk.ndim != 2 or chunk.shape[0] != 2:
-            raise ValueError(f"MiniMax-H3 audio chunk must be stereo [2,L], got {tuple(chunk.shape)}")
-        delta = start_sample - expected_start
-        if abs(delta) > timestamp_tolerance_samples:
-            raise ValueError(f"MiniMax-H3 audio stream is discontinuous: expected sample {expected_start}, got {start_sample}")
-        if delta > 0:
-            assembled.append(torch.zeros(2, delta, dtype=chunk.dtype, device=chunk.device))
-        elif delta < 0:
-            chunk = chunk[:, -delta:]
-        if chunk.shape[1] > 0:
-            assembled.append(chunk)
-        expected_start = start_sample + chunk.shape[1] + max(0, -delta)
-    return torch.cat(assembled, dim=1)
 
 
 def _validate_task_record(record: H3Record, task: H3Task) -> None:
@@ -395,29 +248,9 @@ def _audio_key(role: str, latent: torch.Tensor) -> str:
     return f"latents_{role + '_' if role else 'audio_'}32x2x{latent.shape[2]}_{dtype_name}"
 
 
-def _audio_start_sample(crop_start_frame: int) -> int:
-    return (crop_start_frame * AUDIO_SAMPLE_RATE + TARGET_FPS // 2) // TARGET_FPS
-
-
 def _media_fingerprint_metadata(fingerprints: Mapping[Path, str]) -> str:
     normalized = {str(Path(path).resolve()): value for path, value in fingerprints.items()}
     return json.dumps(dict(sorted(normalized.items())), ensure_ascii=True, separators=(",", ":"))
-
-
-def _target_audio_policy(record: H3Record, *, video_only: bool) -> str:
-    if video_only:
-        return "video-only-unsupervised"
-    if record.target_audio is None:
-        return "missing-unsupervised"
-    return "real-supervised"
-
-
-def _audio_policy_is_supervised(policy: str | None, *, legacy_missing: bool) -> bool | None:
-    if policy is None:
-        return True if legacy_missing else None
-    if policy not in TARGET_AUDIO_POLICIES:
-        return None
-    return policy == "real-supervised"
 
 
 def build_latent_metadata(
@@ -429,10 +262,10 @@ def build_latent_metadata(
     height: int,
     width: int,
     cache_seed: int,
+    audio_present: bool,
     video_vae_fingerprint: str,
     audio_vae_fingerprint: str,
     media_fingerprints: Mapping[Path, str],
-    video_only: bool = False,
 ) -> dict[str, str]:
     reference_kinds = [
         reference.type + ("+audio" if reference.type == "video" and reference.audio is not None else "")
@@ -450,7 +283,7 @@ def build_latent_metadata(
         "video_vae_fingerprint": video_vae_fingerprint,
         "audio_vae_fingerprint": audio_vae_fingerprint,
         "media_fingerprints": _media_fingerprint_metadata(media_fingerprints),
-        "target_audio_policy": _target_audio_policy(record, video_only=video_only),
+        "audio_present": "1" if audio_present else "0",
     }
 
 
@@ -461,16 +294,7 @@ def cache_metadata_matches(path: str | Path, expected: Mapping[str, str]) -> boo
     except Exception as error:
         logger.warning("Unable to read MiniMax-H3 cache metadata from %s: %s", path, error)
         return False
-    for key, value in expected.items():
-        if key != "target_audio_policy":
-            if actual.get(key) != value:
-                return False
-            continue
-        expected_supervised = _audio_policy_is_supervised(value, legacy_missing=False)
-        actual_supervised = _audio_policy_is_supervised(actual.get(key), legacy_missing=True)
-        if expected_supervised is None or actual_supervised is None or expected_supervised != actual_supervised:
-            return False
-    return True
+    return all(actual.get(key) == value for key, value in expected.items())
 
 
 def build_latent_tensors(
@@ -478,6 +302,8 @@ def build_latent_tensors(
     record: H3Record,
     task: H3Task,
     target_frames: torch.Tensor | np.ndarray,
+    target_waveform: torch.Tensor,
+    audio_present: bool,
     crop_start_frame: int,
     video_vae,
     audio_vae,
@@ -487,7 +313,6 @@ def build_latent_tensors(
     audio_vae_fingerprint: str,
     media_fingerprints: Mapping[Path, str],
     allow_experimental_duration: bool = False,
-    video_only: bool = False,
 ) -> H3LatentCachePayload:
     _validate_task_record(record, task)
     if crop_start_frame < 0:
@@ -508,29 +333,21 @@ def build_latent_tensors(
             "pass --allow_experimental_duration to proceed"
         )
 
+    target_samples = waveform_samples(expected_audio_frames)
+    target_waveform = torch.as_tensor(target_waveform, dtype=torch.float32)
+    if tuple(target_waveform.shape) != (2, target_samples):
+        raise ValueError(
+            f"MiniMax-H3 target waveform must be [2,{target_samples}] for {frame_count} frames, got {tuple(target_waveform.shape)}"
+        )
+    if not audio_present and torch.any(target_waveform != 0):
+        raise ValueError("MiniMax-H3 silence placeholder waveform must be all zeros when audio_present is False")
+
     target_pixels = _prepare_pixels(target_frames)
     canonical_item_key = f"{record.video_path}#{crop_start_frame}:{frame_count}"
     target_video = _encode_target_video(video_vae, target_pixels, cache_seed, canonical_item_key)[0]
     if target_video.shape[1] != expected_video_frames:
         raise ValueError(f"MiniMax-H3 video VAE returned {target_video.shape[1]} frames, expected {expected_video_frames}")
 
-    target_samples = waveform_samples(expected_audio_frames)
-    start_sample = _audio_start_sample(crop_start_frame)
-    target_audio_policy = _target_audio_policy(record, video_only=video_only)
-    if target_audio_policy == "real-supervised":
-        target_audio_source = record.target_audio
-        if target_audio_source is None:
-            raise ValueError("MiniMax-H3 real-supervised audio policy requires a target audio source")
-        target_waveform = media_decoder.decode_audio(
-            target_audio_source,
-            start_sample=start_sample,
-            sample_count=target_samples,
-            require_exact=True,
-        )
-        audio_loss_weight = 1.0
-    else:
-        target_waveform = torch.zeros((2, target_samples), dtype=torch.float32)
-        audio_loss_weight = 0.0
     target_audio = _encode_audio(audio_vae, target_waveform)[0]
     if target_audio.shape[2] != expected_audio_frames:
         raise ValueError(f"MiniMax-H3 audio VAE returned {target_audio.shape[2]} frames, expected {expected_audio_frames}")
@@ -538,8 +355,8 @@ def build_latent_tensors(
     tensors = {
         _visual_key("", target_video): target_video,
         _audio_key("", target_audio): target_audio,
-        "mmh3_audio_loss_weight_float32": torch.tensor(audio_loss_weight, dtype=torch.float32),
     }
+    append_audio_present_entry(tensors, audio_present)
     if task == "fl2va":
         for role, frame in (("first", target_frames[:1]), ("last", target_frames[-1:])):
             condition = _encode_condition_video(video_vae, _prepare_pixels(frame))[0]
@@ -584,10 +401,10 @@ def build_latent_tensors(
         height=height,
         width=width,
         cache_seed=cache_seed,
+        audio_present=audio_present,
         video_vae_fingerprint=video_vae_fingerprint,
         audio_vae_fingerprint=audio_vae_fingerprint,
         media_fingerprints=media_fingerprints,
-        video_only=video_only,
     )
     return H3LatentCachePayload(tensors=tensors, metadata=metadata)
 
@@ -626,8 +443,6 @@ def fingerprint_checkpoint(path: str | Path) -> str:
 
 def record_media_paths(record: H3Record) -> set[Path]:
     paths = {record.video_path}
-    if record.target_audio is not None:
-        paths.add(record.target_audio.path)
     for reference in record.references:
         paths.add(reference.path)
         if reference.audio is not None:
@@ -635,99 +450,37 @@ def record_media_paths(record: H3Record) -> set[Path]:
     return paths
 
 
-def records_for_dataset(dataset: VideoDataset, task: H3Task, *, video_only: bool = False) -> list[H3Record]:
+def validate_h3_dataset(dataset: VideoDataset) -> None:
     if dataset.control_directory is not None or dataset.has_control:
-        raise ValueError("MiniMax-H3 R1 does not use the shared control-video fields")
-    if dataset.video_jsonl_file is not None:
-        records = load_h3_jsonl_records(dataset.video_jsonl_file, task, video_only=video_only)
-        if len(records) != len(dataset.datasource.data):
-            raise ValueError("MiniMax-H3 JSONL record count changed while building the dataset")
-        for data, record in zip(dataset.datasource.data, records):
-            data["video_path"] = str(record.video_path)
-            data["caption"] = record.caption
-        return records
-    if task == "ref2va":
-        raise ValueError("MiniMax-H3 Ref2VA requires video_jsonl_file")
-    records = []
-    canonical_paths = []
-    for index in range(len(dataset.datasource)):
-        video_path, caption = dataset.datasource.get_caption(index)
-        record = make_h3_directory_record(video_path, caption, video_only=video_only)
-        records.append(record)
-        canonical_paths.append(str(record.video_path))
-    dataset.datasource.video_paths = canonical_paths
-    return records
+        raise ValueError("MiniMax-H3 does not use the shared control-video fields")
 
 
-def warn_missing_target_audio(
-    records: Sequence[H3Record],
-    *,
-    video_only: bool,
-    limit: int = 10,
-) -> None:
-    if video_only:
-        return
-    if limit < 0:
-        raise ValueError("MiniMax-H3 missing-audio warning limit must be nonnegative")
-    missing = [record for record in records if record.target_audio is None]
-    for record in missing[:limit]:
-        logger.warning(
-            "MiniMax-H3 target has no audio; caching an unsupervised silence placeholder: %s",
-            record.video_path,
-        )
+def dataset_cache_dir_key(cache_directory: str) -> str:
+    return os.path.normpath(os.path.abspath(cache_directory))
 
 
-def log_target_audio_summary(policy_counts: Mapping[str, int]) -> None:
-    unknown = set(policy_counts) - TARGET_AUDIO_POLICIES
-    if unknown or any(not isinstance(count, int) or count < 0 for count in policy_counts.values()):
-        raise ValueError(f"Invalid MiniMax-H3 target-audio policy counts: {dict(policy_counts)}")
-    real_audio = policy_counts.get("real-supervised", 0)
-    missing_audio = policy_counts.get("missing-unsupervised", 0)
-    video_only_count = policy_counts.get("video-only-unsupervised", 0)
-    total = real_audio + missing_audio + video_only_count
-    supervised_fraction = real_audio / total if total else 0.0
+def item_cache_dir_key(item: ItemInfo) -> str:
+    return dataset_cache_dir_key(os.path.dirname(item.latent_cache_path))
+
+
+def item_record_inputs(item: ItemInfo) -> tuple[int, int]:
+    """Returns (datasource_index, crop_start_frame) with presence validation."""
+    if item.datasource_index is None or item.frame_pos is None:
+        raise ValueError(f"MiniMax-H3 cache item is missing datasource provenance: {item.item_key}")
+    return item.datasource_index, item.frame_pos
+
+
+def log_audio_presence_summary(presence_counts: Mapping[bool, int]) -> None:
+    real_audio = presence_counts.get(True, 0)
+    missing_audio = presence_counts.get(False, 0)
+    total = real_audio + missing_audio
+    fraction = real_audio / total if total else 0.0
     logger.info(
-        "MiniMax-H3 target-audio cache summary: real_audio=%d missing_audio=%d video_only=%d supervised_audio_fraction=%.6f",
+        "MiniMax-H3 target-audio cache summary: real_audio=%d missing_audio=%d supervised_audio_fraction=%.6f",
         real_audio,
         missing_audio,
-        video_only_count,
-        supervised_fraction,
+        fraction,
     )
-
-
-def record_for_item(item: ItemInfo, records: Sequence[H3Record]) -> tuple[H3Record, int]:
-    item_path = Path(item.item_key).resolve()
-    for record in records:
-        target = record.video_path
-        if item_path.parent != target.parent or item_path.suffix.lower() != target.suffix.lower():
-            continue
-        pattern = rf"^{re.escape(target.stem)}_(\d+)-(\d+)$"
-        match = re.fullmatch(pattern, item_path.stem)
-        if match is None:
-            continue
-        crop_start = int(match.group(1))
-        encoded_count = int(match.group(2))
-        if item.frame_count != encoded_count:
-            raise ValueError(
-                f"MiniMax-H3 crop item frame count mismatch for {item.item_key}: item={item.frame_count}, key={encoded_count}"
-            )
-        return record, crop_start
-    raise ValueError(f"MiniMax-H3 cache item has no canonical media record: {item.item_key}")
-
-
-def install_h3_video_decoder(dataset: VideoDataset, decoder: PyAVH3MediaDecoder) -> None:
-    def get_video_data_from_path(
-        datasource,
-        video_path,
-        start_frame=None,
-        end_frame=None,
-        bucket_selector=None,
-    ):
-        if bucket_selector is None:
-            bucket_selector = datasource.bucket_selector
-        return decoder.decode_target_video(video_path, start_frame, end_frame, bucket_selector)
-
-    dataset.datasource.get_video_data_from_path = MethodType(get_video_data_from_path, dataset.datasource)
 
 
 def setup_parser() -> argparse.ArgumentParser:
@@ -736,11 +489,6 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--audio_vae", type=str, required=True, help="MiniMax-H3 audio VAE safetensors path or directory")
     parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), required=True)
     parser.add_argument("--cache_seed", type=int, default=0, help="seed used for reproducible target-video posterior samples")
-    parser.add_argument(
-        "--h3_video_only",
-        action="store_true",
-        help="ignore all target audio and cache unsupervised Audio-VAE silence placeholders",
-    )
     parser.add_argument(
         "--allow_experimental_duration",
         action="store_true",
@@ -760,18 +508,18 @@ def main() -> None:
     logger.info("Loading dataset config from %s", args.dataset_config)
     user_config = config_utils.load_user_config(args.dataset_config)
     blueprint = blueprint_generator.generate(user_config, args, architecture=ARCHITECTURE_MINIMAX_H3)
-    dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group)
+    dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group, audio_spec=H3_AUDIO_SPEC)
     datasets = dataset_group.datasets
     if not all(isinstance(dataset, VideoDataset) for dataset in datasets):
         raise ValueError("MiniMax-H3 latent caching accepts only video datasets")
 
-    decoder = PyAVH3MediaDecoder()
-    records = []
+    records_by_dir: dict[str, list[H3Record]] = {}
+    audio_sources_by_dir: dict[str, list] = {}
     for dataset in datasets:
-        dataset_records = records_for_dataset(dataset, args.task, video_only=args.h3_video_only)
-        install_h3_video_decoder(dataset, decoder)
-        records.extend(dataset_records)
-    warn_missing_target_audio(records, video_only=args.h3_video_only)
+        validate_h3_dataset(dataset)
+        key = dataset_cache_dir_key(dataset.cache_directory)
+        records_by_dir[key] = h3_records_from_datasource(dataset.datasource, args.task)
+        audio_sources_by_dir[key] = dataset.datasource.audio_sources
 
     if args.debug_mode is not None:
         cache_latents.show_datasets(
@@ -787,7 +535,14 @@ def main() -> None:
     logger.info("Fingerprinting MiniMax-H3 VAE checkpoints")
     video_vae_fingerprint = fingerprint_checkpoint(args.video_vae)
     audio_vae_fingerprint = fingerprint_checkpoint(args.audio_vae)
-    media_fingerprints = {path: fingerprint_file(path) for record in records for path in record_media_paths(record)}
+    media_fingerprints: dict[Path, str] = {}
+    for key, records in records_by_dir.items():
+        for record in records:
+            for path in record_media_paths(record):
+                media_fingerprints[path] = fingerprint_file(path)
+        for source in audio_sources_by_dir[key]:
+            if source is not None:
+                media_fingerprints[source.path] = fingerprint_file(source.path)
 
     logger.info("Loading MiniMax-H3 video VAE from %s", args.video_vae)
     video_vae = load_video_vae(
@@ -799,15 +554,24 @@ def main() -> None:
     logger.info("Loading MiniMax-H3 audio VAE from %s", args.audio_vae)
     audio_vae = load_audio_vae(args.audio_vae, device=device, dtype=torch.float32, disable_mmap=args.disable_mmap)
 
+    decoder = PyAVH3MediaDecoder()
     skip_matching_cache = args.skip_existing
     args.skip_existing = False
-    cache_policy_counts: Counter[str] = Counter()
+    presence_counts: Counter[bool] = Counter()
 
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:
-            record, crop_start = record_for_item(item, records)
-            cache_policy_counts[_target_audio_policy(record, video_only=args.h3_video_only)] += 1
+            key = item_cache_dir_key(item)
+            datasource_index, crop_start = item_record_inputs(item)
+            record = records_by_dir[key][datasource_index]
+            audio_source = audio_sources_by_dir[key][datasource_index]
+            if item.audio_content is None or item.audio_present is None:
+                raise ValueError(f"MiniMax-H3 cache item is missing its audio window: {item.item_key}")
+            presence_counts[item.audio_present] += 1
+
             record_fingerprints = {path: media_fingerprints[path] for path in record_media_paths(record)}
+            if audio_source is not None:
+                record_fingerprints[audio_source.path] = media_fingerprints[audio_source.path]
             frame_count, height, width = item.content.shape[:3]
             expected_metadata = build_latent_metadata(
                 record=record,
@@ -817,10 +581,10 @@ def main() -> None:
                 height=height,
                 width=width,
                 cache_seed=args.cache_seed,
+                audio_present=item.audio_present,
                 video_vae_fingerprint=video_vae_fingerprint,
                 audio_vae_fingerprint=audio_vae_fingerprint,
                 media_fingerprints=record_fingerprints,
-                video_only=args.h3_video_only,
             )
             if skip_matching_cache and Path(item.latent_cache_path).is_file():
                 if cache_metadata_matches(item.latent_cache_path, expected_metadata):
@@ -831,6 +595,8 @@ def main() -> None:
                 record=record,
                 task=args.task,
                 target_frames=item.content,
+                target_waveform=item.audio_content,
+                audio_present=item.audio_present,
                 crop_start_frame=crop_start,
                 video_vae=video_vae,
                 audio_vae=audio_vae,
@@ -840,13 +606,12 @@ def main() -> None:
                 audio_vae_fingerprint=audio_vae_fingerprint,
                 media_fingerprints=record_fingerprints,
                 allow_experimental_duration=args.allow_experimental_duration,
-                video_only=args.h3_video_only,
             )
             logger.info("Saving MiniMax-H3 latent cache for %s to %s", item.item_key, item.latent_cache_path)
             save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
 
     cache_latents.encode_datasets(datasets, encode, args)
-    log_target_audio_summary(cache_policy_counts)
+    log_audio_presence_summary(presence_counts)
 
 
 if __name__ == "__main__":

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -24,14 +24,15 @@ from musubi_tuner.minimax_h3.text_encoder import (
     presentation_fingerprint,
     processor_fingerprint,
 )
+from musubi_tuner.minimax_h3.media import h3_records_from_datasource
 from musubi_tuner.minimax_h3_cache_latents import (
     PyAVH3MediaDecoder,
     cache_metadata_matches,
+    dataset_cache_dir_key,
     fingerprint_checkpoint,
     fingerprint_file,
-    install_h3_video_decoder,
-    record_for_item,
-    records_for_dataset,
+    item_record_inputs,
+    validate_h3_dataset,
 )
 from musubi_tuner.utils.model_utils import dtype_to_str
 
@@ -152,14 +153,15 @@ def main() -> None:
         raise ValueError("MiniMax-H3 text caching accepts only video datasets")
 
     decoder = PyAVH3MediaDecoder()
-    records = []
+    records_by_dir = {}
     for dataset in datasets:
-        dataset_records = records_for_dataset(dataset, args.task)
-        install_h3_video_decoder(dataset, decoder)
-        records.extend(dataset_records)
+        validate_h3_dataset(dataset)
+        records_by_dir[dataset_cache_dir_key(dataset.cache_directory)] = h3_records_from_datasource(dataset.datasource, args.task)
 
     all_cache_files, all_cache_paths = cache_text_encoder_outputs.prepare_cache_files_and_paths(datasets)
-    text_paths = {path for record in records for path in _text_media_paths(record, args.task)}
+    text_paths = {
+        path for records in records_by_dir.values() for record in records for path in _text_media_paths(record, args.task)
+    }
     media_fingerprints = {path: fingerprint_file(path) for path in text_paths}
 
     logger.info("Loading MiniMax-H3 Qwen3-VL processor from %s", args.processor)
@@ -182,7 +184,9 @@ def main() -> None:
 
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:
-            record, crop_start = record_for_item(item, records)
+            records = records_by_dir[dataset_cache_dir_key(str(Path(item.text_encoder_output_cache_path).parent))]
+            datasource_index, crop_start = item_record_inputs(item)
+            record = records[datasource_index]
             visuals = _build_visuals(record, args.task, item, decoder, decoded_reference_cache)
             presentation = build_presentation(record, args.task, visuals)
             record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-from collections import Counter
 import gc
 import logging
 import re
@@ -15,7 +14,6 @@ from typing import Any
 
 import torch
 from accelerate import Accelerator
-from safetensors import safe_open
 from tqdm.auto import tqdm
 
 from musubi_tuner.dataset.architectures import (
@@ -33,7 +31,7 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     load_generation_record,
     module_device_dtype,
 )
-from musubi_tuner.minimax_h3.media import audio_latent_frames, video_latent_frames
+from musubi_tuner.minimax_h3.media import H3_AUDIO_SPEC, audio_latent_frames, video_latent_frames
 from musubi_tuner.minimax_h3.model import load_h3_transformer
 from musubi_tuner.minimax_h3.packing import (
     H3PackedLayout,
@@ -56,7 +54,13 @@ from musubi_tuner.minimax_h3.text_encoder import (
     load_h3_text_encoder,
 )
 from musubi_tuner.minimax_h3.video_vae import VIDEO_VAE_DECODE_DTYPE, VIDEO_VAE_ENCODE_DTYPE, load_video_vae
-from musubi_tuner.minimax_h3_cache_latents import PyAVH3MediaDecoder, TARGET_AUDIO_POLICIES
+from musubi_tuner.minimax_h3_cache_latents import PyAVH3MediaDecoder
+from musubi_tuner.training.audio_loss import (
+    add_audio_train_args,
+    effective_audio_loss_weights,
+    log_audio_supervision_summary,
+    scan_audio_supervised_fraction,
+)
 from musubi_tuner.training.parser_common import read_config_from_file, setup_parser_common
 from musubi_tuner.training.sampling_prompts import load_prompts
 from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
@@ -170,62 +174,11 @@ def validate_h3_dataset_batch_size(dataset_group) -> None:
             )
 
 
-def _read_h3_audio_supervision(path: Path) -> float:
-    with safe_open(str(path), framework="pt", device="cpu") as handle:
-        metadata = handle.metadata() or {}
-        tensor_keys = set(handle.keys())
-        policy = metadata.get("target_audio_policy")
-        has_scalar = "mmh3_audio_loss_weight_float32" in tensor_keys
-
-        if policy is None and not has_scalar:
-            return 1.0
-        if policy is None:
-            raise ValueError(f"MiniMax-H3 cache {path} has an audio loss scalar without target_audio_policy metadata")
-        if not has_scalar:
-            raise ValueError(f"MiniMax-H3 cache {path} has target_audio_policy metadata without an audio loss scalar")
-        if policy not in TARGET_AUDIO_POLICIES:
-            raise ValueError(f"MiniMax-H3 cache {path} has invalid target_audio_policy {policy!r}")
-
-        scalar = handle.get_tensor("mmh3_audio_loss_weight_float32")
-        if scalar.shape != torch.Size([]) or scalar.dtype != torch.float32:
-            raise ValueError(f"MiniMax-H3 cache {path} audio loss weight must be a scalar float32 tensor")
-        value = scalar.item()
-        if not torch.isfinite(scalar).item() or value not in {0.0, 1.0}:
-            raise ValueError(f"MiniMax-H3 cache {path} audio loss weight must be exactly 0.0 or 1.0")
-        expected = 1.0 if policy == "real-supervised" else 0.0
-        if value != expected:
-            raise ValueError(
-                f"MiniMax-H3 cache {path} has contradictory target_audio_policy={policy!r} and audio loss weight={value}"
-            )
-        return value
-
-
-def inspect_h3_audio_supervision(dataset_group) -> float:
-    cache_counts: Counter[Path] = Counter()
-    for dataset in dataset_group.datasets:
-        for bucket in dataset.batch_manager.buckets.values():
-            for item in bucket:
-                cache_path = getattr(item, "latent_cache_path", None)
-                if not cache_path:
-                    raise ValueError("MiniMax-H3 training item is missing latent_cache_path")
-                cache_counts[Path(cache_path).resolve()] += 1
-    if not cache_counts:
-        raise ValueError("MiniMax-H3 audio supervision scan found no latent cache files")
-
-    supervised = 0
-    total = sum(cache_counts.values())
-    for path, repeats in cache_counts.items():
-        supervised += repeats * int(_read_h3_audio_supervision(path))
-    return supervised / total
-
-
-def _validate_audio_loss_weight(value: Any) -> torch.Tensor:
-    if value is None:
-        return torch.tensor([1.0], dtype=torch.float32)
-    if not isinstance(value, torch.Tensor) or value.shape != (1,) or value.dtype != torch.float32:
-        raise ValueError("MiniMax-H3 audio loss weight must be a float32 tensor with shape [1]")
-    if not torch.isfinite(value).all().item() or value.item() not in {0.0, 1.0}:
-        raise ValueError("MiniMax-H3 audio loss weight must be exactly 0.0 or 1.0")
+def _validate_audio_present(value: Any, batch_size: int) -> torch.Tensor:
+    if not isinstance(value, torch.Tensor) or value.shape != (batch_size,) or value.dtype != torch.float32:
+        raise ValueError("MiniMax-H3 batch requires a float32 audio_present tensor with shape [B]; re-run latent caching")
+    if not torch.isfinite(value).all().item() or not ((value == 0.0) | (value == 1.0)).all().item():
+        raise ValueError("MiniMax-H3 audio_present must be exactly 0.0 or 1.0 per sample")
     return value
 
 
@@ -236,7 +189,7 @@ class _H3RuntimeBatch:
     text_token_tags: torch.Tensor
     visual_conditions: tuple[torch.Tensor, ...]
     audio_conditions: tuple[torch.Tensor, ...]
-    audio_loss_weight: torch.Tensor
+    audio_present: torch.Tensor
 
 
 def _stack_single_text_rows(value, label: str) -> torch.Tensor:
@@ -261,7 +214,7 @@ def _runtime_batch_plan(batch: dict[str, Any], video_latents: torch.Tensor) -> _
         raise ValueError(f"MiniMax-H3 target audio latents must be [B,32,2,A], got {shape}")
     if audio_latents.shape[0] != batch_size:
         raise ValueError("MiniMax-H3 target video and audio batch sizes differ")
-    audio_loss_weight = _validate_audio_loss_weight(batch.get("mmh3_audio_loss_weight"))
+    audio_present = _validate_audio_present(batch.get("audio_present"), batch_size)
 
     hidden_states = _stack_single_text_rows(batch.get("mmh3_hidden_states"), "text hidden states")
     token_tags = _stack_single_text_rows(batch.get("mmh3_token_tags"), "text token tags")
@@ -349,7 +302,7 @@ def _runtime_batch_plan(batch: dict[str, Any], video_latents: torch.Tensor) -> _
         text_token_tags=token_tags,
         visual_conditions=tuple(visual_conditions),
         audio_conditions=tuple(audio_conditions),
-        audio_loss_weight=audio_loss_weight,
+        audio_present=audio_present,
     )
 
 
@@ -398,6 +351,8 @@ def _augment_conditions(
 
 
 class MiniMaxH3NetworkTrainer(NetworkTrainer):
+    audio_spec = H3_AUDIO_SPEC
+
     @property
     def architecture(self) -> str:
         return ARCHITECTURE_MINIMAX_H3
@@ -428,6 +383,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             value = float(getattr(args, name))
             if not 0.0 <= value <= 1.0:
                 raise ValueError(f"--{name} must be in [0.0,1.0], got {value}")
+        if args.audio_loss_weight < 0:
+            raise ValueError(f"--audio_loss_weight must be nonnegative, got {args.audio_loss_weight}")
         if args.blocks_to_swap is not None and args.blocks_to_swap > 48:
             raise ValueError("--blocks_to_swap for MiniMax-H3 must be <= 48")
         if getattr(args, "fp8_base", False) or getattr(args, "fp8_scaled", False):
@@ -444,8 +401,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
     def _build_dataset(self, args):
         dataset_group, collator, current_epoch = super()._build_dataset(args)
         validate_h3_dataset_batch_size(dataset_group)
-        self._supervised_audio_fraction = inspect_h3_audio_supervision(dataset_group)
-        logger.info("MiniMax-H3 supervised_audio_fraction=%.6f", self._supervised_audio_fraction)
+        self._supervised_audio_fraction = scan_audio_supervised_fraction(dataset_group)
+        log_audio_supervision_summary(self._supervised_audio_fraction, args)
         return dataset_group, collator, current_epoch
 
     def _prepare_sampling(self, args, accelerator, vae_dtype):
@@ -773,11 +730,13 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             "ss_minimax_h3_shift_audio": args.h3_shift_audio,
             "ss_minimax_h3_visual_cond_clean": args.h3_visual_cond_clean,
             "ss_minimax_h3_audio_cond_clean": args.h3_audio_cond_clean,
-            "ss_minimax_h3_loss_policy": "video_mean_plus_optional_audio_mean",
-            "ss_minimax_h3_audio_supervision": "per_sample_binary_cache_weight",
+            "ss_minimax_h3_loss_policy": "video_mean_plus_weighted_audio_mean",
+            "ss_minimax_h3_audio_supervision": "presence_gated_training_weight",
             "ss_minimax_h3_supervised_audio_fraction": getattr(self, "_supervised_audio_fraction", 1.0),
+            "ss_minimax_h3_audio_loss_weight": args.audio_loss_weight,
+            "ss_minimax_h3_video_only": args.video_only,
             "ss_minimax_h3_target_modules": "attn.qkv_proj,attn.out_proj,mlp.fc1,mlp.fc2",
-            "ss_minimax_h3_latent_cache_version": "1",
+            "ss_minimax_h3_latent_cache_version": "2",
             "ss_minimax_h3_text_cache_version": "1",
         }
 
@@ -836,6 +795,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         model_t_audio = kwargs.pop("model_t_audio")
         visual_conditions = kwargs.pop("visual_conditions")
         audio_conditions = kwargs.pop("audio_conditions")
+        audio_loss_weight = kwargs.pop("audio_loss_weight")
         if kwargs:
             raise TypeError(f"Unexpected MiniMax-H3 call_dit arguments: {sorted(kwargs)}")
 
@@ -867,7 +827,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             extra={
                 "audio_pred": prediction.audio,
                 "audio_target": audio_latents - audio_noise,
-                "audio_loss_weight": runtime.audio_loss_weight,
+                "audio_loss_weight": audio_loss_weight,
             },
         )
 
@@ -941,6 +901,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             model_t_audio=model_t_audio,
             visual_conditions=visual_conditions,
             audio_conditions=audio_conditions,
+            audio_loss_weight=effective_audio_loss_weights(runtime.audio_present, args),
         )
         return self.compute_loss(args, output, base, noise_scheduler, dit_dtype, network_dtype, global_step)
 
@@ -960,8 +921,16 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             output.target.to(network_dtype),
             reduction="mean",
         )
-        audio_loss_weight = _validate_audio_loss_weight(output.extra.get("audio_loss_weight"))
-        if audio_loss_weight.item() == 0.0:
+        audio_loss_weight = output.extra.get("audio_loss_weight")
+        if (
+            not isinstance(audio_loss_weight, torch.Tensor)
+            or audio_loss_weight.shape != (1,)
+            or not torch.isfinite(audio_loss_weight).all().item()
+            or audio_loss_weight.item() < 0.0
+        ):
+            raise ValueError("MiniMax-H3 audio loss weight must be a finite nonnegative float32 tensor with shape [1]")
+        weight = audio_loss_weight.item()
+        if weight == 0.0:
             audio_loss = video_loss.detach().new_zeros(())
         else:
             audio_loss = torch.nn.functional.mse_loss(
@@ -969,7 +938,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 output.extra["audio_target"].to(network_dtype),
                 reduction="mean",
             )
-        return video_loss + audio_loss, {
+        return video_loss + weight * audio_loss, {
             "loss/video": video_loss.detach(),
             "loss/audio": audio_loss.detach(),
         }
@@ -983,6 +952,7 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         network_module="networks.lora_minimax_h3",
     )
     parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), default=None, help="MiniMax-H3 training task")
+    add_audio_train_args(parser)
     parser.add_argument("--h3_shift_video", type=float, default=12.0, help="MiniMax-H3 target-video flow shift")
     parser.add_argument("--h3_shift_audio", type=float, default=3.0, help="MiniMax-H3 target-audio flow shift")
     parser.add_argument(

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -101,6 +101,11 @@ class DiTOutput:
 
 
 class NetworkTrainer:
+    # audio-capable architectures override this class attribute with their AudioSpec so that
+    # dataset construction enables audio (class attribute because _build_dataset runs before
+    # handle_model_specific_args)
+    audio_spec = None
+
     def __init__(self):
         self.blocks_to_swap = None
         self.timestep_range_pool = []
@@ -1462,7 +1467,11 @@ class NetworkTrainer:
         user_config = config_utils.load_user_config(args.dataset_config)
         blueprint = blueprint_generator.generate(user_config, args, architecture=self.architecture)
         train_dataset_group = config_utils.generate_dataset_group_by_blueprint(
-            blueprint.dataset_group, training=True, num_timestep_buckets=self.num_timestep_buckets, shared_epoch=current_epoch
+            blueprint.dataset_group,
+            training=True,
+            num_timestep_buckets=self.num_timestep_buckets,
+            shared_epoch=current_epoch,
+            audio_spec=self.audio_spec,
         )
 
         if train_dataset_group.num_train_items == 0:

--- a/tests/test_audio_dataset_seam.py
+++ b/tests/test_audio_dataset_seam.py
@@ -33,7 +33,6 @@ from musubi_tuner.dataset.cache_io import (
 from musubi_tuner.dataset.datasources import VideoJsonlDatasource
 from musubi_tuner.dataset.image_video_dataset import VideoDataset
 from musubi_tuner.dataset.media_utils import load_video, resample_frame_indices
-from musubi_tuner.minimax_h3_cache_latents import resample_frame_indices as h3_resample_frame_indices
 from musubi_tuner.training.audio_loss import (
     add_audio_train_args,
     effective_audio_loss_weights,
@@ -225,12 +224,20 @@ def test_decode_audio_roundtrips_wav(tmp_path: Path):
     assert torch.allclose(waveform, torch.from_numpy(samples), atol=1e-3)
 
 
-def test_resample_frame_indices_matches_h3_implementation():
-    for fps, frames in ((30, 21), (24, 48), (60, 30), (12, 7)):
-        timestamps = [index / fps for index in range(frames)]
-        common = resample_frame_indices(timestamps, source_frame_duration=1.0 / fps, target_fps=24)
-        h3 = h3_resample_frame_indices(timestamps, source_frame_duration=1.0 / fps, target_fps=24)
-        assert common == h3
+def test_resample_frame_indices_nearest_frame_selection():
+    # 30 fps source resampled to 24 fps: nearest-source-frame per target tick
+    timestamps = [index / 30 for index in range(21)]
+    indices = resample_frame_indices(timestamps, source_frame_duration=1.0 / 30, target_fps=24)
+    assert len(indices) == 17  # 0.7 seconds at 24 fps
+    assert indices[0] == 0
+    assert indices == sorted(indices)
+    assert max(indices) <= 20
+
+    # 12 fps source upsampled to 24 fps repeats frames
+    timestamps = [index / 12 for index in range(7)]
+    indices = resample_frame_indices(timestamps, source_frame_duration=1.0 / 12, target_fps=24)
+    assert len(indices) == 14
+    assert indices == [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6]
 
 
 def test_load_video_timestamps_mode_resamples_to_target_fps(tmp_path: Path):

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -2,7 +2,6 @@ import json
 import logging
 from pathlib import Path
 import sys
-from types import SimpleNamespace
 
 import pytest
 from safetensors.torch import save_file
@@ -17,24 +16,21 @@ from musubi_tuner.minimax_h3.media import (
     H3Record,
     H3Reference,
     audio_latent_frames,
+    h3_records_from_datasource,
     load_h3_jsonl_records,
-    make_h3_directory_record,
     video_latent_frames,
     waveform_samples,
 )
 from musubi_tuner.minimax_h3_cache_latents import (
-    assemble_audio_chunks,
     build_latent_tensors,
     cache_metadata_matches,
-    install_h3_video_decoder,
-    log_target_audio_summary,
+    log_audio_presence_summary,
     record_media_paths,
-    resample_frame_indices,
     setup_parser,
-    warn_missing_target_audio,
 )
 from musubi_tuner.dataset.bucket import BucketBatchManager
 from musubi_tuner.dataset.cache_io import (
+    AUDIO_PRESENT_KEY,
     save_latent_cache_minimax_h3,
     save_text_encoder_output_cache_minimax_h3,
 )
@@ -69,38 +65,8 @@ def _touch(path: Path) -> Path:
     return path.resolve()
 
 
-def test_h3_decoder_patch_preserves_the_datasource_bucket_selector_fallback():
-    selector = object()
-    datasource = SimpleNamespace(bucket_selector=selector)
-    dataset = SimpleNamespace(datasource=datasource)
-    seen = {}
-
-    class Decoder:
-        def decode_target_video(self, video_path, start_frame, end_frame, bucket_selector):
-            seen.update(
-                video_path=video_path,
-                start_frame=start_frame,
-                end_frame=end_frame,
-                bucket_selector=bucket_selector,
-            )
-            return "decoded"
-
-    install_h3_video_decoder(dataset, Decoder())
-
-    result = datasource.get_video_data_from_path("clip.mp4", 2, 7)
-
-    assert result == "decoded"
-    assert seen == {
-        "video_path": "clip.mp4",
-        "start_frame": 2,
-        "end_frame": 7,
-        "bucket_selector": selector,
-    }
-
-
 def test_ref2va_jsonl_preserves_reference_order_and_canonicalizes_paths(tmp_path: Path):
     video = _touch(tmp_path / "target.mp4")
-    target_audio = _touch(tmp_path / "target.wav")
     image = _touch(tmp_path / "refs" / "face.png")
     reference_video = _touch(tmp_path / "refs" / "motion.mp4")
     reference_audio = _touch(tmp_path / "refs" / "motion.wav")
@@ -112,7 +78,6 @@ def test_ref2va_jsonl_preserves_reference_order_and_canonicalizes_paths(tmp_path
             {
                 "video_path": "target.mp4",
                 "caption": "scene and sound",
-                "audio_path": "target.wav",
                 "references": [
                     {"type": "image", "path": "refs/face.png"},
                     {"type": "video", "path": "refs/motion.mp4", "audio_path": "refs/motion.wav"},
@@ -123,7 +88,6 @@ def test_ref2va_jsonl_preserves_reference_order_and_canonicalizes_paths(tmp_path
     )
     media = {
         video: H3MediaInfo(has_audio=False, duration_seconds=8.0),
-        target_audio: H3MediaInfo(has_audio=True, duration_seconds=8.0),
         image: H3MediaInfo(has_audio=False, duration_seconds=None),
         reference_video: H3MediaInfo(has_audio=True, duration_seconds=6.0),
         reference_audio: H3MediaInfo(has_audio=True, duration_seconds=6.0),
@@ -135,8 +99,6 @@ def test_ref2va_jsonl_preserves_reference_order_and_canonicalizes_paths(tmp_path
     assert len(records) == 1
     record = records[0]
     assert record.video_path == video
-    assert record.target_audio.path == target_audio
-    assert record.target_audio.embedded is False
     assert [reference.type for reference in record.references] == ["image", "video", "audio"]
     assert [reference.path for reference in record.references] == [image, reference_video, voice]
     assert record.references[1].audio is not None
@@ -144,126 +106,44 @@ def test_ref2va_jsonl_preserves_reference_order_and_canonicalizes_paths(tmp_path
     assert record.references[1].audio.embedded is False
     assert record.references[2].audio is not None
     assert record.references[2].audio.path == voice
+    assert record_media_paths(record) == {video, image, reference_video, reference_audio, voice}
 
 
-def test_target_audio_resolution_prefers_one_same_stem_sidecar(tmp_path: Path):
-    video = _touch(tmp_path / "clip.mp4")
-    sidecar = _touch(tmp_path / "clip.wav")
+def test_records_from_jsonl_datasource_share_the_parsed_data(tmp_path: Path):
+    video = _touch(tmp_path / "target.mp4")
     jsonl = tmp_path / "data.jsonl"
-    _write_jsonl(jsonl, [{"video_path": "clip.mp4", "caption": "caption"}])
-    media = {
-        video: H3MediaInfo(has_audio=True, duration_seconds=5.0),
-        sidecar: H3MediaInfo(has_audio=True, duration_seconds=5.0),
-    }
+    _write_jsonl(jsonl, [{"video_path": "target.mp4", "caption": "caption"}])
 
-    record = load_h3_jsonl_records(jsonl, "t2va", media.__getitem__)[0]
+    from musubi_tuner.dataset.datasources import VideoJsonlDatasource
 
-    assert record.target_audio.path == sidecar
-    assert record.target_audio.embedded is False
+    datasource = VideoJsonlDatasource(str(jsonl))
+    records = h3_records_from_datasource(datasource, "t2va", lambda path: H3MediaInfo(has_audio=False, duration_seconds=5.0))
+
+    assert len(records) == len(datasource.data) == 1
+    assert records[0].video_path == video
+    assert records[0].caption == "caption"
+    assert records[0].references == ()
 
 
-def test_directory_record_uses_the_same_audio_resolution(tmp_path: Path):
+def test_records_from_directory_datasource_use_captions_and_resolved_paths(tmp_path: Path):
     video = _touch(tmp_path / "clip.mp4")
-    sidecar = _touch(tmp_path / "clip.wav")
 
-    record = make_h3_directory_record(
-        video,
-        "caption",
-        lambda path: H3MediaInfo(has_audio=path == sidecar, duration_seconds=5.0),
-    )
+    class FakeDirectoryDatasource:
+        def __len__(self):
+            return 1
 
-    assert record.video_path == video
-    assert record.caption == "caption"
-    assert record.target_audio == H3AudioSource(path=sidecar, embedded=False)
-    assert record.references == ()
+        def get_caption(self, idx):
+            return str(video), "caption"
 
+    records = h3_records_from_datasource(FakeDirectoryDatasource(), "t2va")
 
-def test_target_audio_resolution_rejects_ambiguous_sidecars(tmp_path: Path):
-    video = _touch(tmp_path / "clip.mp4")
-    _touch(tmp_path / "clip.wav")
-    _touch(tmp_path / "clip.flac")
-    jsonl = tmp_path / "data.jsonl"
-    _write_jsonl(jsonl, [{"video_path": "clip.mp4", "caption": "caption"}])
+    assert records == [H3Record(video_path=video, caption="caption", references=(), jsonl_line=0)]
 
-    with pytest.raises(ValueError, match="Multiple same-stem audio sidecars"):
-        load_h3_jsonl_records(
-            jsonl,
-            "t2va",
-            lambda path: H3MediaInfo(has_audio=path == video, duration_seconds=5.0),
-        )
+    with pytest.raises(ValueError, match="Ref2VA requires video_jsonl_file"):
+        h3_records_from_datasource(FakeDirectoryDatasource(), "ref2va")
 
 
-def test_explicit_target_audio_decode_failure_does_not_fall_back(tmp_path: Path):
-    video = _touch(tmp_path / "clip.mp4")
-    explicit = _touch(tmp_path / "broken.wav")
-    _touch(tmp_path / "clip.wav")
-    jsonl = tmp_path / "data.jsonl"
-    _write_jsonl(
-        jsonl,
-        [{"video_path": "clip.mp4", "caption": "caption", "audio_path": "broken.wav"}],
-    )
-
-    def probe(path: Path) -> H3MediaInfo:
-        if path == explicit:
-            raise ValueError("decode failed")
-        return H3MediaInfo(has_audio=path == video, duration_seconds=5.0)
-
-    with pytest.raises(ValueError, match="Explicit target audio.*decode failed"):
-        load_h3_jsonl_records(jsonl, "t2va", probe)
-
-
-def test_missing_target_audio_is_an_unsupervised_record(tmp_path: Path):
-    video = _touch(tmp_path / "clip.mp4")
-    jsonl = tmp_path / "data.jsonl"
-    _write_jsonl(jsonl, [{"video_path": "clip.mp4", "caption": "caption"}])
-
-    record = load_h3_jsonl_records(
-        jsonl,
-        "t2va",
-        lambda path: H3MediaInfo(has_audio=False, duration_seconds=5.0),
-    )[0]
-
-    assert record.target_audio is None
-    assert record_media_paths(record) == {video}
-
-
-def test_video_only_jsonl_bypasses_all_target_audio_discovery(tmp_path: Path):
-    video = _touch(tmp_path / "clip.mp4")
-    _touch(tmp_path / "clip.wav")
-    _touch(tmp_path / "clip.flac")
-    jsonl = tmp_path / "data.jsonl"
-    _write_jsonl(
-        jsonl,
-        [{"video_path": "clip.mp4", "caption": "caption", "audio_path": "does-not-exist.wav"}],
-    )
-
-    record = load_h3_jsonl_records(
-        jsonl,
-        "t2va",
-        lambda path: pytest.fail(f"video-only target audio must not probe {path}"),
-        video_only=True,
-    )[0]
-
-    assert record.target_audio is None
-    assert record_media_paths(record) == {video}
-
-
-def test_video_only_directory_record_bypasses_sidecars_and_probing(tmp_path: Path):
-    video = _touch(tmp_path / "clip.mp4")
-    _touch(tmp_path / "clip.wav")
-    _touch(tmp_path / "clip.flac")
-
-    record = make_h3_directory_record(
-        video,
-        "caption",
-        lambda path: pytest.fail(f"video-only target audio must not probe {path}"),
-        video_only=True,
-    )
-
-    assert record.target_audio is None
-
-
-def test_video_only_keeps_ref2va_reference_audio_validation(tmp_path: Path):
+def test_ref2va_reference_audio_resolution_and_media_paths(tmp_path: Path):
     video = _touch(tmp_path / "target.mp4")
     reference_video = _touch(tmp_path / "reference.mp4")
     reference_audio = _touch(tmp_path / "reference.wav")
@@ -274,7 +154,6 @@ def test_video_only_keeps_ref2va_reference_audio_validation(tmp_path: Path):
             {
                 "video_path": "target.mp4",
                 "caption": "caption",
-                "audio_path": "ignored-missing.wav",
                 "references": [{"type": "video", "path": "reference.mp4", "audio_path": "reference.wav"}],
             }
         ],
@@ -285,58 +164,19 @@ def test_video_only_keeps_ref2va_reference_audio_validation(tmp_path: Path):
         probed.append(path)
         return H3MediaInfo(has_audio=path == reference_audio, duration_seconds=5.0)
 
-    record = load_h3_jsonl_records(jsonl, "ref2va", probe, video_only=True)[0]
+    record = load_h3_jsonl_records(jsonl, "ref2va", probe)[0]
 
-    assert record.target_audio is None
     assert probed == [reference_video, reference_audio]
-    assert record.references[0].audio == H3AudioSource(reference_audio, embedded=False)
+    assert record.references[0].audio == H3AudioSource(path=reference_audio, embedded=False)
     assert record_media_paths(record) == {video, reference_video, reference_audio}
 
 
-def test_missing_audio_warnings_are_capped_and_summary_is_aggregated(caplog, tmp_path: Path):
-    records = [
-        H3Record(
-            video_path=tmp_path / f"clip-{index}.mp4",
-            caption="caption",
-            target_audio=None,
-            references=(),
-            jsonl_line=index + 1,
-        )
-        for index in range(12)
-    ]
+def test_audio_presence_summary_is_aggregated(caplog):
     caplog.set_level(logging.INFO)
 
-    warn_missing_target_audio(records, video_only=False, limit=10)
-    log_target_audio_summary(
-        {
-            "real-supervised": 0,
-            "missing-unsupervised": 12,
-            "video-only-unsupervised": 0,
-        }
-    )
+    log_audio_presence_summary({True: 3, False: 9})
 
-    missing_warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
-    assert len(missing_warnings) == 10
-    assert "clip-0.mp4" in missing_warnings[0].getMessage()
-    assert "clip-9.mp4" in missing_warnings[-1].getMessage()
-    assert "real_audio=0 missing_audio=12 video_only=0 supervised_audio_fraction=0.000000" in caplog.text
-
-
-def test_explicit_video_only_emits_no_missing_audio_warning(caplog, tmp_path: Path):
-    records = [H3Record(tmp_path / "clip.mp4", "caption", None, (), 1)]
-    caplog.set_level(logging.INFO)
-
-    warn_missing_target_audio(records, video_only=True)
-    log_target_audio_summary(
-        {
-            "real-supervised": 0,
-            "missing-unsupervised": 0,
-            "video-only-unsupervised": 1,
-        }
-    )
-
-    assert not [record for record in caplog.records if record.levelno == logging.WARNING]
-    assert "real_audio=0 missing_audio=0 video_only=1 supervised_audio_fraction=0.000000" in caplog.text
+    assert "real_audio=3 missing_audio=9 supervised_audio_fraction=0.250000" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -350,7 +190,6 @@ def test_explicit_video_only_emits_no_missing_audio_warning(caplog, tmp_path: Pa
 )
 def test_ref2va_reference_limits_fail_before_model_work(tmp_path: Path, references: list[dict], message: str):
     _touch(tmp_path / "target.mp4")
-    _touch(tmp_path / "target.wav")
     for reference in references:
         _touch(tmp_path / reference["path"])
     jsonl = tmp_path / "data.jsonl"
@@ -359,7 +198,6 @@ def test_ref2va_reference_limits_fail_before_model_work(tmp_path: Path, referenc
         [
             {
                 "video_path": "target.mp4",
-                "audio_path": "target.wav",
                 "caption": "caption",
                 "references": references,
             }
@@ -376,7 +214,6 @@ def test_ref2va_reference_limits_fail_before_model_work(tmp_path: Path, referenc
 
 def test_ref2va_requires_a_visual_reference(tmp_path: Path):
     _touch(tmp_path / "target.mp4")
-    _touch(tmp_path / "target.wav")
     _touch(tmp_path / "voice.wav")
     jsonl = tmp_path / "data.jsonl"
     _write_jsonl(
@@ -384,7 +221,6 @@ def test_ref2va_requires_a_visual_reference(tmp_path: Path):
         [
             {
                 "video_path": "target.mp4",
-                "audio_path": "target.wav",
                 "caption": "caption",
                 "references": [{"type": "audio", "path": "voice.wav"}],
             }
@@ -402,7 +238,6 @@ def test_ref2va_requires_a_visual_reference(tmp_path: Path):
 @pytest.mark.parametrize("duration", [1.99, 15.01])
 def test_ref2va_video_reference_duration_is_two_through_fifteen_seconds(tmp_path: Path, duration: float):
     _touch(tmp_path / "target.mp4")
-    _touch(tmp_path / "target.wav")
     reference_video = _touch(tmp_path / "reference.mp4")
     jsonl = tmp_path / "data.jsonl"
     _write_jsonl(
@@ -410,7 +245,6 @@ def test_ref2va_video_reference_duration_is_two_through_fifteen_seconds(tmp_path
         [
             {
                 "video_path": "target.mp4",
-                "audio_path": "target.wav",
                 "caption": "caption",
                 "references": [{"type": "video", "path": "reference.mp4"}],
             }
@@ -444,7 +278,7 @@ def test_h3_cache_keys_round_trip_through_existing_bucket_collator(tmp_path: Pat
     latent_tensors = {
         "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
         "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-        "mmh3_audio_loss_weight_float32": torch.tensor(1.0, dtype=torch.float32),
+        AUDIO_PRESENT_KEY: torch.tensor(1.0, dtype=torch.float32),
         "latents_first_1x4x4_float16": torch.ones(24, 1, 4, 4, dtype=torch.float16),
     }
     text_tensors = {
@@ -454,7 +288,7 @@ def test_h3_cache_keys_round_trip_through_existing_bucket_collator(tmp_path: Pat
     save_latent_cache_minimax_h3(
         item,
         latent_tensors,
-        {"task": "fl2va", "target_audio_policy": "real-supervised"},
+        {"task": "fl2va", "audio_present": "1"},
     )
     save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "fl2va"})
 
@@ -463,7 +297,7 @@ def test_h3_cache_keys_round_trip_through_existing_bucket_collator(tmp_path: Pat
 
     assert batch["latents"].shape == (1, 24, 2, 4, 4)
     assert batch["latents_audio"].shape == (1, 32, 2, 8)
-    torch.testing.assert_close(batch["mmh3_audio_loss_weight"], torch.tensor([1.0]))
+    torch.testing.assert_close(batch["audio_present"], torch.tensor([1.0]))
     assert batch["latents_first"].shape == (1, 24, 1, 4, 4)
     assert isinstance(batch["mmh3_hidden_states"], list)
     assert batch["mmh3_hidden_states"][0].shape == (3, 5120)
@@ -482,15 +316,15 @@ def test_h3_latent_writer_rejects_transposed_audio_layout(tmp_path: Path):
         save_latent_cache_minimax_h3(item, tensors)
 
 
-def test_h3_latent_writer_requires_binary_float32_audio_loss_scalar(tmp_path: Path):
+def test_h3_latent_writer_requires_binary_float32_audio_present_scalar(tmp_path: Path):
     item = _h3_item(tmp_path)
     base = {
         "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
         "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
     }
 
-    with pytest.raises(ValueError, match="audio loss weight"):
-        save_latent_cache_minimax_h3(item, base)
+    with pytest.raises(ValueError, match=AUDIO_PRESENT_KEY):
+        save_latent_cache_minimax_h3(item, base, {"task": "t2va", "audio_present": "1"})
 
     invalid = (
         torch.tensor([1.0], dtype=torch.float32),
@@ -499,29 +333,26 @@ def test_h3_latent_writer_requires_binary_float32_audio_loss_scalar(tmp_path: Pa
         torch.tensor(0.5, dtype=torch.float32),
     )
     for scalar in invalid:
-        with pytest.raises(ValueError, match="audio loss weight"):
+        with pytest.raises(ValueError, match=AUDIO_PRESENT_KEY):
             save_latent_cache_minimax_h3(
                 item,
-                {**base, "mmh3_audio_loss_weight_float32": scalar},
+                {**base, AUDIO_PRESENT_KEY: scalar},
+                {"task": "t2va", "audio_present": "1"},
             )
 
 
-def test_h3_latent_writer_requires_policy_metadata_consistent_with_scalar(tmp_path: Path):
+def test_h3_latent_writer_requires_presence_metadata_consistent_with_tensor(tmp_path: Path):
     item = _h3_item(tmp_path)
     tensors = {
         "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
         "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-        "mmh3_audio_loss_weight_float32": torch.tensor(1.0, dtype=torch.float32),
+        AUDIO_PRESENT_KEY: torch.tensor(1.0, dtype=torch.float32),
     }
 
-    with pytest.raises(ValueError, match="target_audio_policy"):
+    with pytest.raises(ValueError, match="audio_present metadata"):
         save_latent_cache_minimax_h3(item, tensors, {"task": "t2va"})
     with pytest.raises(ValueError, match="contradictory"):
-        save_latent_cache_minimax_h3(
-            item,
-            tensors,
-            {"task": "t2va", "target_audio_policy": "missing-unsupervised"},
-        )
+        save_latent_cache_minimax_h3(item, tensors, {"task": "t2va", "audio_present": "0"})
 
 
 @pytest.mark.parametrize(
@@ -590,20 +421,19 @@ class _FakeH3MediaDecoder:
 
 def _cache_record(tmp_path: Path, references=()) -> H3Record:
     video = _touch(tmp_path / "target.mp4")
-    audio = _touch(tmp_path / "target.wav")
     return H3Record(
         video_path=video,
         caption="scene and sound",
-        target_audio=H3AudioSource(path=audio, embedded=False),
         references=tuple(references),
         jsonl_line=1,
     )
 
 
-def test_build_fl2va_latents_uses_exact_audio_window_and_target_crop(tmp_path: Path):
+def test_build_fl2va_latents_encodes_the_provided_audio_window(tmp_path: Path):
     record = _cache_record(tmp_path)
     frames = torch.zeros(5, 64, 64, 3, dtype=torch.uint8)
     frames[-1] = 255
+    waveform = torch.linspace(-0.5, 0.5, 2 * 6400).reshape(2, 6400)
     video_vae = _FakeH3VideoVAE()
     audio_vae = _FakeH3AudioVAE()
     decoder = _FakeH3MediaDecoder()
@@ -612,6 +442,8 @@ def test_build_fl2va_latents_uses_exact_audio_window_and_target_crop(tmp_path: P
         record=record,
         task="fl2va",
         target_frames=frames,
+        target_waveform=waveform,
+        audio_present=True,
         crop_start_frame=3,
         video_vae=video_vae,
         audio_vae=audio_vae,
@@ -619,21 +451,23 @@ def test_build_fl2va_latents_uses_exact_audio_window_and_target_crop(tmp_path: P
         media_decoder=decoder,
         video_vae_fingerprint="video-fingerprint",
         audio_vae_fingerprint="audio-fingerprint",
-        media_fingerprints={record.video_path: "target-video", record.target_audio.path: "target-audio"},
+        media_fingerprints={record.video_path: "target-video"},
         allow_experimental_duration=True,
     )
 
     assert set(payload.tensors) == {
         "latents_2x4x4_float32",
         "latents_audio_32x2x8_float32",
-        "mmh3_audio_loss_weight_float32",
+        AUDIO_PRESENT_KEY,
         "latents_first_1x4x4_float32",
         "latents_last_1x4x4_float32",
     }
-    assert payload.tensors["mmh3_audio_loss_weight_float32"].shape == torch.Size([])
-    assert payload.tensors["mmh3_audio_loss_weight_float32"].dtype == torch.float32
-    assert payload.tensors["mmh3_audio_loss_weight_float32"].item() == 1.0
-    assert decoder.audio_calls == [(record.target_audio, 4000, 6400, True)]
+    assert payload.tensors[AUDIO_PRESENT_KEY].shape == torch.Size([])
+    assert payload.tensors[AUDIO_PRESENT_KEY].dtype == torch.float32
+    assert payload.tensors[AUDIO_PRESENT_KEY].item() == 1.0
+    assert decoder.audio_calls == []
+    assert len(audio_vae.calls) == 1
+    torch.testing.assert_close(audio_vae.calls[0], waveform.unsqueeze(0))
     assert [call.shape for call in video_vae.calls] == [
         (1, 3, 5, 64, 64),
         (1, 3, 1, 64, 64),
@@ -646,25 +480,13 @@ def test_build_fl2va_latents_uses_exact_audio_window_and_target_crop(tmp_path: P
     assert payload.metadata["audio_start_seconds"] == "1/8"
     assert payload.metadata["video_vae_fingerprint"] == "video-fingerprint"
     assert payload.metadata["audio_vae_fingerprint"] == "audio-fingerprint"
-    assert payload.metadata["target_audio_policy"] == "real-supervised"
+    assert payload.metadata["audio_present"] == "1"
     assert payload.metadata["posterior_policy"] == "video_vae=fp32;target=seeded;conditions=seed42-fp16;audio=mode"
-    assert json.loads(payload.metadata["media_fingerprints"]) == {
-        str(record.target_audio.path): "target-audio",
-        str(record.video_path): "target-video",
-    }
+    assert json.loads(payload.metadata["media_fingerprints"]) == {str(record.video_path): "target-video"}
 
 
-@pytest.mark.parametrize(
-    ("video_only", "expected_policy"),
-    [(False, "missing-unsupervised"), (True, "video-only-unsupervised")],
-)
-def test_missing_or_ignored_target_audio_encodes_unsupervised_silence(
-    tmp_path: Path,
-    video_only: bool,
-    expected_policy: str,
-):
-    real_record = _cache_record(tmp_path)
-    record = real_record if video_only else H3Record(real_record.video_path, real_record.caption, None, (), 1)
+def test_missing_target_audio_encodes_silence_with_presence_zero(tmp_path: Path):
+    record = _cache_record(tmp_path)
     video_vae = _FakeH3VideoVAE()
     audio_vae = _FakeH3AudioVAE()
     decoder = _FakeH3MediaDecoder()
@@ -673,6 +495,8 @@ def test_missing_or_ignored_target_audio_encodes_unsupervised_silence(
         record=record,
         task="t2va",
         target_frames=torch.zeros(5, 64, 64, 3, dtype=torch.uint8),
+        target_waveform=torch.zeros(2, 6400),
+        audio_present=False,
         crop_start_frame=0,
         video_vae=video_vae,
         audio_vae=audio_vae,
@@ -682,22 +506,58 @@ def test_missing_or_ignored_target_audio_encodes_unsupervised_silence(
         audio_vae_fingerprint="audio-fingerprint",
         media_fingerprints={record.video_path: "target-video"},
         allow_experimental_duration=True,
-        video_only=video_only,
     )
 
     assert decoder.audio_calls == []
     assert len(audio_vae.calls) == 1
     assert audio_vae.calls[0].shape == (1, 2, 6400)
-    assert audio_vae.calls[0].dtype == torch.float32
     assert torch.count_nonzero(audio_vae.calls[0]) == 0
-    assert payload.tensors["mmh3_audio_loss_weight_float32"].item() == 0.0
-    assert payload.metadata["target_audio_policy"] == expected_policy
+    assert payload.tensors[AUDIO_PRESENT_KEY].item() == 0.0
+    assert payload.metadata["audio_present"] == "0"
 
 
-def test_h3_timestamp_resampling_duplicates_low_fps_frames_to_24fps():
-    indices = resample_frame_indices([0.0, 1 / 12, 2 / 12], source_frame_duration=1 / 12, target_fps=24)
+def test_silence_placeholder_must_be_all_zeros(tmp_path: Path):
+    record = _cache_record(tmp_path)
 
-    assert indices == [0, 0, 1, 1, 2, 2]
+    with pytest.raises(ValueError, match="all zeros"):
+        build_latent_tensors(
+            record=record,
+            task="t2va",
+            target_frames=torch.zeros(5, 64, 64, 3, dtype=torch.uint8),
+            target_waveform=torch.ones(2, 6400),
+            audio_present=False,
+            crop_start_frame=0,
+            video_vae=_FakeH3VideoVAE(),
+            audio_vae=_FakeH3AudioVAE(),
+            cache_seed=0,
+            media_decoder=_FakeH3MediaDecoder(),
+            video_vae_fingerprint="video-fingerprint",
+            audio_vae_fingerprint="audio-fingerprint",
+            media_fingerprints={record.video_path: "target-video"},
+            allow_experimental_duration=True,
+        )
+
+
+def test_target_waveform_length_must_match_the_crop(tmp_path: Path):
+    record = _cache_record(tmp_path)
+
+    with pytest.raises(ValueError, match=r"must be \[2,6400\]"):
+        build_latent_tensors(
+            record=record,
+            task="t2va",
+            target_frames=torch.zeros(5, 64, 64, 3, dtype=torch.uint8),
+            target_waveform=torch.zeros(2, 6000),
+            audio_present=True,
+            crop_start_frame=0,
+            video_vae=_FakeH3VideoVAE(),
+            audio_vae=_FakeH3AudioVAE(),
+            cache_seed=0,
+            media_decoder=_FakeH3MediaDecoder(),
+            video_vae_fingerprint="video-fingerprint",
+            audio_vae_fingerprint="audio-fingerprint",
+            media_fingerprints={record.video_path: "target-video"},
+            allow_experimental_duration=True,
+        )
 
 
 def test_h3_skip_existing_requires_all_cache_identity_metadata(tmp_path: Path):
@@ -705,45 +565,14 @@ def test_h3_skip_existing_requires_all_cache_identity_metadata(tmp_path: Path):
     save_file(
         {"latents_2x4x4_float32": torch.zeros(24, 2, 4, 4)},
         cache_path,
-        metadata={"task": "t2va", "video_vae_fingerprint": "old"},
+        metadata={"task": "t2va", "video_vae_fingerprint": "old", "audio_present": "0"},
     )
 
     assert cache_metadata_matches(cache_path, {"task": "t2va", "video_vae_fingerprint": "old"})
     assert not cache_metadata_matches(cache_path, {"task": "t2va", "video_vae_fingerprint": "new"})
     assert not cache_metadata_matches(cache_path, {"task": "t2va", "audio_vae_fingerprint": "missing"})
-
-
-def test_h3_skip_existing_compares_derived_audio_supervision_not_raw_provenance(tmp_path: Path):
-    cache_path = tmp_path / "cache.safetensors"
-    save_file(
-        {
-            "latents_2x4x4_float32": torch.zeros(24, 2, 4, 4),
-            "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-            "mmh3_audio_loss_weight_float32": torch.tensor(0.0),
-        },
-        cache_path,
-        metadata={
-            "task": "t2va",
-            "media_fingerprints": '{"target.mp4":"same-video"}',
-            "target_audio_policy": "missing-unsupervised",
-        },
-    )
-
-    common = {"task": "t2va", "media_fingerprints": '{"target.mp4":"same-video"}'}
-    assert cache_metadata_matches(cache_path, {**common, "target_audio_policy": "video-only-unsupervised"})
-    assert not cache_metadata_matches(cache_path, {**common, "target_audio_policy": "real-supervised"})
-
-
-def test_h3_skip_existing_treats_complete_legacy_policy_absence_as_supervised(tmp_path: Path):
-    cache_path = tmp_path / "legacy.safetensors"
-    save_file(
-        {"latents_2x4x4_float32": torch.zeros(24, 2, 4, 4)},
-        cache_path,
-        metadata={"task": "t2va"},
-    )
-
-    assert cache_metadata_matches(cache_path, {"task": "t2va", "target_audio_policy": "real-supervised"})
-    assert not cache_metadata_matches(cache_path, {"task": "t2va", "target_audio_policy": "missing-unsupervised"})
+    assert cache_metadata_matches(cache_path, {"audio_present": "0"})
+    assert not cache_metadata_matches(cache_path, {"audio_present": "1"})
 
 
 def test_h3_latent_cache_parser_exposes_only_the_two_explicit_vae_paths():
@@ -751,23 +580,9 @@ def test_h3_latent_cache_parser_exposes_only_the_two_explicit_vae_paths():
 
     assert "--video_vae" in help_text
     assert "--audio_vae" in help_text
-    assert "--h3_video_only" in help_text
+    assert "--h3_video_only" not in help_text
     assert "--vae VAE" not in help_text
     assert "--vae_dtype" not in help_text
-
-
-def test_h3_audio_chunk_assembly_rejects_discontinuous_timestamps():
-    contiguous = assemble_audio_chunks(
-        [(100, torch.zeros(2, 4)), (104, torch.ones(2, 4))],
-        timestamp_tolerance_samples=2,
-    )
-
-    assert contiguous.shape == (2, 8)
-    with pytest.raises(ValueError, match="discontinuous"):
-        assemble_audio_chunks(
-            [(100, torch.zeros(2, 4)), (107, torch.ones(2, 4))],
-            timestamp_tolerance_samples=2,
-        )
 
 
 def test_build_ref2va_latents_preserves_ordered_numbered_roles(tmp_path: Path):
@@ -805,6 +620,8 @@ def test_build_ref2va_latents_preserves_ordered_numbered_roles(tmp_path: Path):
         record=record,
         task="ref2va",
         target_frames=torch.zeros(5, 64, 64, 3, dtype=torch.uint8),
+        target_waveform=torch.zeros(2, 6400),
+        audio_present=True,
         crop_start_frame=0,
         video_vae=video_vae,
         audio_vae=audio_vae,
@@ -812,29 +629,22 @@ def test_build_ref2va_latents_preserves_ordered_numbered_roles(tmp_path: Path):
         media_decoder=decoder,
         video_vae_fingerprint="video-fingerprint",
         audio_vae_fingerprint="audio-fingerprint",
-        media_fingerprints={
-            path: path.name
-            for path in {record.video_path, record.target_audio.path, image, reference_video, reference_video_audio, voice}
-        },
+        media_fingerprints={path: path.name for path in {record.video_path, image, reference_video, reference_video_audio, voice}},
         allow_experimental_duration=True,
     )
 
     assert set(payload.tensors) == {
         "latents_2x4x4_float32",
         "latents_audio_32x2x8_float32",
-        "mmh3_audio_loss_weight_float32",
+        AUDIO_PRESENT_KEY,
         "latents_ref_000_image_1x2x4_float32",
         "latents_ref_001_video_2x4x2_float32",
         "latents_ref_001_audio_32x2x8_float32",
         "latents_ref_002_audio_32x2x2_float32",
     }
-    assert [call[0].path for call in decoder.audio_calls] == [
-        record.target_audio.path,
-        reference_video_audio,
-        voice,
-    ]
-    assert decoder.audio_calls[1][1:] == (0, 6400, True)
-    assert decoder.audio_calls[2][1:] == (0, 6400, False)
+    assert [call[0].path for call in decoder.audio_calls] == [reference_video_audio, voice]
+    assert decoder.audio_calls[0][1:] == (0, 6400, True)
+    assert decoder.audio_calls[1][1:] == (0, 6400, False)
     assert json.loads(payload.metadata["reference_kinds"]) == ["image", "video+audio", "audio"]
 
 
@@ -850,6 +660,8 @@ def test_build_ref2va_revalidates_limits_before_any_model_work(tmp_path: Path):
             record=record,
             task="ref2va",
             target_frames=torch.zeros(5, 64, 64, 3, dtype=torch.uint8),
+            target_waveform=torch.zeros(2, 6400),
+            audio_present=True,
             crop_start_frame=0,
             video_vae=video_vae,
             audio_vae=audio_vae,

--- a/tests/test_minimax_h3_dataset.py
+++ b/tests/test_minimax_h3_dataset.py
@@ -29,11 +29,11 @@ def test_h3_architecture_and_bucket_step():
     assert BucketSelector.ARCHITECTURE_STEPS_MAP[ARCHITECTURE_MINIMAX_H3] == 32
 
 
-def test_h3_documented_dataset_fps_values_are_toml_floats():
+def test_h3_documentation_does_not_ask_users_to_set_source_fps():
     documentation = (ROOT / "docs" / "minimax_h3.md").read_text(encoding="utf-8")
 
-    assert documentation.count("source_fps = 24.0") == 2
-    assert "source_fps = 24\n" not in documentation
+    assert "source_fps = " not in documentation
+    assert "`source_fps` is not needed" in documentation
 
 
 @pytest.mark.parametrize(

--- a/tests/test_minimax_h3_dataset.py
+++ b/tests/test_minimax_h3_dataset.py
@@ -1,5 +1,6 @@
 import inspect
 from pathlib import Path
+import pickle
 import sys
 from types import SimpleNamespace
 
@@ -57,6 +58,30 @@ def test_frame_helper_requires_stride_and_preserves_stride_one():
 
     assert round_down_frame_count(8, ARCHITECTURE_KREA2, 1) == 8
     assert round_down_frame_count(8, ARCHITECTURE_QWEN_IMAGE, 1) == 8
+
+
+def test_h3_audio_dataset_survives_dataloader_worker_pickling(tmp_path: Path):
+    # spawned DataLoader workers (Windows/macOS) pickle the dataset, including the AudioSpec
+    from musubi_tuner.minimax_h3.media import H3_AUDIO_SPEC
+
+    restored_spec = pickle.loads(pickle.dumps(H3_AUDIO_SPEC))
+    assert restored_spec.samples_per_crop(22) == H3_AUDIO_SPEC.samples_per_crop(22) == 29600
+
+    dataset = VideoDataset(
+        resolution=(64, 64),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=True,
+        bucket_no_upscale=False,
+        target_frames=[5],
+        video_directory=str(tmp_path),
+        cache_directory=str(tmp_path),
+        architecture=ARCHITECTURE_MINIMAX_H3,
+        audio_spec=H3_AUDIO_SPEC,
+    )
+    restored_dataset = pickle.loads(pickle.dumps(dataset))
+    assert restored_dataset.audio_spec.samples_per_crop(5) == 6400
 
 
 def test_h3_video_dataset_uses_24_fps_and_preserves_valid_target_frames(tmp_path: Path):

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -26,7 +26,6 @@ def _record(tmp_path: Path, references=()) -> H3Record:
     return H3Record(
         video_path=tmp_path / "target.mp4",
         caption="A bright scene with clear sound.",
-        target_audio=H3AudioSource(tmp_path / "target.wav", embedded=False),
         references=tuple(references),
         jsonl_line=1,
     )

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -16,12 +16,13 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from musubi_tuner.minimax_h3.model import MiniMaxH3Config, MiniMaxH3Model
 from musubi_tuner.minimax_h3.packing import H3ReferenceGeometry, H3VideoGeometry, build_h3_layout
+from musubi_tuner.dataset.cache_io import AUDIO_PRESENT_KEY
 from musubi_tuner.minimax_h3_train_network import (
     MiniMaxH3NetworkTrainer,
-    inspect_h3_audio_supervision,
     minimax_h3_setup_parser,
     validate_h3_dataset_batch_size,
 )
+from musubi_tuner.training.audio_loss import scan_audio_supervised_fraction
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.networks import lora_minimax_h3
 from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
@@ -42,16 +43,15 @@ def test_h3_dataset_rejects_real_batches_and_points_to_gradient_accumulation():
         validate_h3_dataset_batch_size(_dataset_group(1, 2))
 
 
-def _policy_cache(path: Path, *, policy: str | None, scalar: torch.Tensor | None) -> Path:
+def _presence_cache(path: Path, *, present: torch.Tensor | None) -> Path:
     tensors = {"latents_2x4x4_float32": torch.zeros(24, 2, 4, 4)}
-    if scalar is not None:
-        tensors["mmh3_audio_loss_weight_float32"] = scalar
-    metadata = {} if policy is None else {"target_audio_policy": policy}
-    save_file(tensors, path, metadata=metadata)
+    if present is not None:
+        tensors[AUDIO_PRESENT_KEY] = present
+    save_file(tensors, path)
     return path.resolve()
 
 
-def _audio_policy_dataset_group(entries: list[Path]):
+def _audio_presence_dataset_group(entries: list[Path]):
     items = [SimpleNamespace(latent_cache_path=str(path)) for path in entries]
     manager = SimpleNamespace(batch_size=1, buckets={(64, 64, 5): items})
     dataset = SimpleNamespace(batch_manager=manager)
@@ -59,73 +59,53 @@ def _audio_policy_dataset_group(entries: list[Path]):
 
 
 def test_audio_supervision_scan_counts_repeats_and_opens_each_unique_cache_once(monkeypatch, tmp_path: Path):
-    import musubi_tuner.minimax_h3_train_network as train
+    from musubi_tuner.training import audio_loss
 
-    supervised = _policy_cache(
-        tmp_path / "supervised.safetensors",
-        policy="real-supervised",
-        scalar=torch.tensor(1.0, dtype=torch.float32),
-    )
-    unsupervised = _policy_cache(
-        tmp_path / "unsupervised.safetensors",
-        policy="missing-unsupervised",
-        scalar=torch.tensor(0.0, dtype=torch.float32),
-    )
-    dataset_group = _audio_policy_dataset_group([supervised, supervised, unsupervised])
+    supervised = _presence_cache(tmp_path / "supervised.safetensors", present=torch.tensor(1.0, dtype=torch.float32))
+    unsupervised = _presence_cache(tmp_path / "unsupervised.safetensors", present=torch.tensor(0.0, dtype=torch.float32))
+    dataset_group = _audio_presence_dataset_group([supervised, supervised, unsupervised])
     opened = []
-    real_safe_open = train.safe_open
+    real_safe_open = audio_loss.safe_open
 
     def counted_safe_open(path, *args, **kwargs):
         opened.append(Path(path).resolve())
         return real_safe_open(path, *args, **kwargs)
 
-    monkeypatch.setattr(train, "safe_open", counted_safe_open)
+    monkeypatch.setattr(audio_loss, "safe_open", counted_safe_open)
 
-    fraction = inspect_h3_audio_supervision(dataset_group)
+    fraction = scan_audio_supervised_fraction(dataset_group)
 
     assert fraction == pytest.approx(2 / 3)
     assert opened.count(supervised) == 1
     assert opened.count(unsupervised) == 1
 
 
-def test_audio_supervision_scan_accepts_complete_legacy_absence_as_real_audio(tmp_path: Path):
-    legacy = _policy_cache(tmp_path / "legacy.safetensors", policy=None, scalar=None)
+def test_audio_supervision_scan_rejects_pre_audio_present_caches(tmp_path: Path):
+    legacy = _presence_cache(tmp_path / "legacy.safetensors", present=None)
 
-    assert inspect_h3_audio_supervision(_audio_policy_dataset_group([legacy])) == 1.0
+    with pytest.raises(ValueError, match="re-run latent caching"):
+        scan_audio_supervised_fraction(_audio_presence_dataset_group([legacy]))
 
 
 @pytest.mark.parametrize(
-    ("policy", "scalar", "message"),
+    "present",
     [
-        (None, torch.tensor(0.0, dtype=torch.float32), "scalar.*policy"),
-        ("missing-unsupervised", None, "policy.*scalar"),
-        ("real-supervised", torch.tensor(0.0, dtype=torch.float32), "contradict"),
-        ("unknown", torch.tensor(1.0, dtype=torch.float32), "policy"),
-        ("missing-unsupervised", torch.tensor([0.0], dtype=torch.float32), "scalar float32"),
-        ("missing-unsupervised", torch.tensor(0.0, dtype=torch.float64), "scalar float32"),
-        ("missing-unsupervised", torch.tensor(float("nan"), dtype=torch.float32), "0.0 or 1.0"),
-        ("missing-unsupervised", torch.tensor(0.5, dtype=torch.float32), "0.0 or 1.0"),
+        torch.tensor([0.0], dtype=torch.float32),
+        torch.tensor(0.0, dtype=torch.float64),
+        torch.tensor(float("nan"), dtype=torch.float32),
+        torch.tensor(0.5, dtype=torch.float32),
     ],
 )
-def test_audio_supervision_scan_rejects_partial_invalid_or_contradictory_caches(
-    tmp_path: Path,
-    policy: str | None,
-    scalar: torch.Tensor | None,
-    message: str,
-):
-    path = _policy_cache(tmp_path / "invalid.safetensors", policy=policy, scalar=scalar)
+def test_audio_supervision_scan_rejects_invalid_presence_entries(tmp_path: Path, present: torch.Tensor):
+    path = _presence_cache(tmp_path / "invalid.safetensors", present=present)
 
-    with pytest.raises(ValueError, match=message):
-        inspect_h3_audio_supervision(_audio_policy_dataset_group([path]))
+    with pytest.raises(ValueError, match="audio_present"):
+        scan_audio_supervised_fraction(_audio_presence_dataset_group([path]))
 
 
 def test_h3_dataset_build_scans_audio_supervision_before_returning(monkeypatch, tmp_path: Path, caplog):
-    path = _policy_cache(
-        tmp_path / "unsupervised.safetensors",
-        policy="video-only-unsupervised",
-        scalar=torch.tensor(0.0, dtype=torch.float32),
-    )
-    dataset_group = _audio_policy_dataset_group([path])
+    path = _presence_cache(tmp_path / "unsupervised.safetensors", present=torch.tensor(0.0, dtype=torch.float32))
+    dataset_group = _audio_presence_dataset_group([path])
     sentinel_collator = object()
     sentinel_epoch = object()
     monkeypatch.setattr(
@@ -180,6 +160,8 @@ def _trainer_args(**overrides):
         "sample_prompts": None,
         "gradient_checkpointing": False,
         "task": "t2va",
+        "video_only": False,
+        "audio_loss_weight": 1.0,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -188,7 +170,7 @@ def _trainer_args(**overrides):
 def _training_batch(batch_size: int = 1, *, text_length: int = 3):
     return {
         "latents_audio": torch.full((batch_size, 32, 2, 8), 4.0),
-        "mmh3_audio_loss_weight": torch.ones(batch_size, dtype=torch.float32),
+        "audio_present": torch.ones(batch_size, dtype=torch.float32),
         "mmh3_hidden_states": [torch.full((text_length, 12), float(index)) for index in range(batch_size)],
         "mmh3_token_tags": [torch.tensor([1, 0, 1][:text_length], dtype=torch.int64) for _ in range(batch_size)],
         "timesteps": None,
@@ -208,6 +190,8 @@ def test_h3_parser_defaults_to_the_only_supported_training_coordinates():
     assert args.h3_visual_cond_clean == 0.999
     assert args.h3_audio_cond_clean == 1.0
     assert args.network_module == "networks.lora_minimax_h3"
+    assert args.video_only is False
+    assert args.audio_loss_weight == 1.0
     assert "--h3_video_only" not in parser.format_help()
 
 
@@ -658,13 +642,13 @@ def test_process_batch_preserves_the_released_fp32_audio_cache_dtype(monkeypatch
     assert transformer.calls[0]["audio_latents"].dtype == torch.float32
 
 
-def test_process_batch_uses_zero_cache_weight_for_video_only_loss(monkeypatch):
+def test_process_batch_uses_zero_weight_for_silence_placeholder_items(monkeypatch):
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args()
     trainer.handle_model_specific_args(args)
     transformer = _RecordingTransformer(audio_prediction=float("nan"))
     batch = _training_batch()
-    batch["mmh3_audio_loss_weight"] = torch.tensor([0.0], dtype=torch.float32)
+    batch["audio_present"] = torch.tensor([0.0], dtype=torch.float32)
     video_latents = torch.zeros(1, 24, 2, 4, 4)
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
@@ -686,6 +670,37 @@ def test_process_batch_uses_zero_cache_weight_for_video_only_loss(monkeypatch):
 
     assert torch.isfinite(loss)
     assert metrics["loss/audio"] == 0.0
+
+
+def test_process_batch_video_only_disables_audio_loss_even_with_real_audio(monkeypatch):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(video_only=True)
+    trainer.handle_model_specific_args(args)
+    transformer = _RecordingTransformer(audio_prediction=float("nan"))
+    batch = _training_batch()
+    video_latents = torch.zeros(1, 24, 2, 4, 4)
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
+
+    loss, metrics = trainer.process_batch(
+        args,
+        _Accelerator(),
+        transformer,
+        None,
+        batch,
+        video_latents,
+        torch.zeros_like(video_latents),
+        None,
+        torch.bfloat16,
+        torch.float32,
+        None,
+        0,
+    )
+
+    # the transformer still sees the (noised) real audio latents as attention context
+    assert torch.isfinite(loss)
+    assert metrics["loss/audio"] == 0.0
+    assert torch.count_nonzero(transformer.calls[0]["audio_latents"]) > 0
 
 
 def _cpu_noise(shape, seed):
@@ -780,7 +795,7 @@ def test_runtime_rejects_more_than_one_timestep_for_the_single_item():
 
 
 @pytest.mark.parametrize(
-    "weight",
+    "present",
     [
         torch.tensor(1.0, dtype=torch.float32),
         torch.tensor([1.0], dtype=torch.float64),
@@ -789,16 +804,16 @@ def test_runtime_rejects_more_than_one_timestep_for_the_single_item():
         torch.tensor([0.0, 1.0], dtype=torch.float32),
     ],
 )
-def test_runtime_rejects_invalid_audio_loss_weight_before_transformer(weight: torch.Tensor):
+def test_runtime_rejects_invalid_audio_present_before_transformer(present: torch.Tensor):
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args()
     trainer.handle_model_specific_args(args)
     batch = _training_batch()
-    batch["mmh3_audio_loss_weight"] = weight
+    batch["audio_present"] = present
     transformer = _RecordingTransformer()
     video_latents = torch.zeros(1, 24, 2, 4, 4)
 
-    with pytest.raises(ValueError, match="audio loss weight"):
+    with pytest.raises(ValueError, match="audio_present"):
         trainer.process_batch(
             args,
             _Accelerator(),
@@ -869,26 +884,43 @@ def test_t2va_does_not_advance_the_condition_seed_stream(monkeypatch):
     )
 
 
-def test_compute_loss_is_plain_video_plus_audio_mean_mse():
+def test_compute_loss_is_video_mean_plus_weighted_audio_mean_mse():
     trainer = MiniMaxH3NetworkTrainer()
-    output = DiTOutput(
-        pred=torch.tensor([1.0, 5.0]),
-        target=torch.tensor([3.0, 1.0]),
-        extra={"audio_pred": torch.tensor([0.0, 2.0]), "audio_target": torch.tensor([2.0, 2.0])},
-    )
 
-    loss, metrics = trainer.compute_loss(
-        _trainer_args(),
-        output,
-        torch.tensor(0.25),
-        object(),
-        torch.bfloat16,
-        torch.float32,
-        7,
-    )
+    def output():
+        return DiTOutput(
+            pred=torch.tensor([1.0, 5.0]),
+            target=torch.tensor([3.0, 1.0]),
+            extra={
+                "audio_pred": torch.tensor([0.0, 2.0]),
+                "audio_target": torch.tensor([2.0, 2.0]),
+                "audio_loss_weight": torch.tensor([1.0], dtype=torch.float32),
+            },
+        )
+
+    loss, metrics = trainer.compute_loss(_trainer_args(), output(), torch.tensor(0.25), object(), torch.bfloat16, torch.float32, 7)
 
     assert loss.item() == pytest.approx(12.0)
     assert metrics == {"loss/video": pytest.approx(10.0), "loss/audio": pytest.approx(2.0)}
+
+    weighted = output()
+    weighted.extra["audio_loss_weight"] = torch.tensor([0.5], dtype=torch.float32)
+    loss, metrics = trainer.compute_loss(_trainer_args(), weighted, torch.tensor(0.25), object(), torch.bfloat16, torch.float32, 7)
+
+    assert loss.item() == pytest.approx(11.0)
+    assert metrics["loss/audio"] == pytest.approx(2.0)
+
+
+def test_compute_loss_requires_the_audio_weight_tensor():
+    trainer = MiniMaxH3NetworkTrainer()
+    output = DiTOutput(
+        pred=torch.tensor([1.0]),
+        target=torch.tensor([3.0]),
+        extra={"audio_pred": torch.tensor([0.0]), "audio_target": torch.tensor([2.0])},
+    )
+
+    with pytest.raises(ValueError, match="audio loss weight"):
+        trainer.compute_loss(_trainer_args(), output, torch.tensor(0.25), object(), torch.bfloat16, torch.float32, 7)
 
 
 def test_compute_loss_skips_audio_expression_and_gradient_for_zero_weight():
@@ -923,32 +955,29 @@ def test_compute_loss_skips_audio_expression_and_gradient_for_zero_weight():
     assert audio_pred.grad is None
 
 
-def test_process_batch_uses_legacy_missing_audio_weight_as_supervised(monkeypatch):
+def test_process_batch_rejects_caches_without_audio_present():
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args()
     trainer.handle_model_specific_args(args)
     batch = _training_batch()
-    del batch["mmh3_audio_loss_weight"]
+    del batch["audio_present"]
     video_latents = torch.zeros(1, 24, 2, 4, 4)
-    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
-    monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
 
-    _, metrics = trainer.process_batch(
-        args,
-        _Accelerator(),
-        _RecordingTransformer(),
-        None,
-        batch,
-        video_latents,
-        torch.zeros_like(video_latents),
-        None,
-        torch.bfloat16,
-        torch.float32,
-        None,
-        0,
-    )
-
-    assert metrics["loss/audio"] > 0
+    with pytest.raises(ValueError, match="audio_present.*re-run latent caching"):
+        trainer.process_batch(
+            args,
+            _Accelerator(),
+            _RecordingTransformer(),
+            None,
+            batch,
+            video_latents,
+            torch.zeros_like(video_latents),
+            None,
+            torch.bfloat16,
+            torch.float32,
+            None,
+            0,
+        )
 
 
 def test_h3_training_metadata_records_task_scheduler_and_target_policy():
@@ -964,11 +993,13 @@ def test_h3_training_metadata_records_task_scheduler_and_target_policy():
         "ss_minimax_h3_shift_audio": 3.0,
         "ss_minimax_h3_visual_cond_clean": 0.999,
         "ss_minimax_h3_audio_cond_clean": 1.0,
-        "ss_minimax_h3_loss_policy": "video_mean_plus_optional_audio_mean",
-        "ss_minimax_h3_audio_supervision": "per_sample_binary_cache_weight",
+        "ss_minimax_h3_loss_policy": "video_mean_plus_weighted_audio_mean",
+        "ss_minimax_h3_audio_supervision": "presence_gated_training_weight",
         "ss_minimax_h3_supervised_audio_fraction": 0.25,
+        "ss_minimax_h3_audio_loss_weight": 1.0,
+        "ss_minimax_h3_video_only": False,
         "ss_minimax_h3_target_modules": "attn.qkv_proj,attn.out_proj,mlp.fc1,mlp.fc2",
-        "ss_minimax_h3_latent_cache_version": "1",
+        "ss_minimax_h3_latent_cache_version": "2",
         "ss_minimax_h3_text_cache_version": "1",
     }
 


### PR DESCRIPTION
## Overview

Part 2 of 2 (part 1: #1020). Migrates MiniMax-H3 onto the shared audio dataset seam and removes the architecture-local workarounds it replaces. Draft until end-to-end validation (real caching + training smoke run) passes; merge order is #1020 first, then this PR (base will be retargeted to dev automatically).

## Changes

- **Shared dataset now decodes target media for H3.** Strict 24 fps timestamp resampling replaces the `MethodType` datasource monkey-patch, and per-crop audio windows come from `H3_AUDIO_SPEC` (32 kHz stereo, 17n+5 audio latent grid). `source_fps` is no longer needed in dataset configs.
- **Records come from the datasource's parsed data.** `h3_records_from_datasource` replaces the duplicate JSONL parse; `ItemInfo.datasource_index` / `frame_pos` replace the item-key regex re-derivation of crop windows.
- **Cache stores facts, training decides policy.** The `target_audio_policy` / `mmh3_audio_loss_weight_float32` entries are replaced by the common `audio_present` convention. `--h3_video_only` is removed; the new training arguments `--video_only` and `--audio_loss_weight` control supervision, gated per sample by cached presence so silence placeholders are never supervised. Training with `--video_only` keeps real audio latents as attention context, matching the inference-time distribution.
- `PyAVH3MediaDecoder` is reduced to reference media and reimplemented on the shared decode helpers; `H3Record` drops `target_audio`.
- `trainer_base` gains an `audio_spec` class attribute so audio-capable trainers enable audio during dataset construction.
- Docs updated (dataset section, supervision arguments, metadata names, re-cache notice).

## Breaking change

MiniMax-H3 **latent caches must be re-created** (the pre-release audio-policy cache format is not read). Text encoder caches are unaffected.

## Tests

284 passed (full suite). H3 cache-contract / training / dataset / text-encoder tests updated to the new contract; net -439 lines thanks to the removed duplication.

## Validation plan before undraft

- [x] Latent + text encoder caching on real H3 data (t2va / fl2va / ref2va)
- [x] Training smoke run; `--video_only` and `--audio_loss_weight` behavior
- [x] `--skip_existing` rebuild/skip behavior with the new metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)