### PR TITLE
Lighten MiniMax-H3 cache fingerprints and slim cache metadata

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -116,7 +116,9 @@ The cache stores only this fact about the data. Whether and how strongly audio i
 
 `--audio_vae` is always required. H3 always includes target-audio rows, and the released Audio VAE encoding of a zero waveform is not guaranteed to be an all-zero latent. Each cache stores its own small silence latent: at `F=124`, it is about 52 KB versus about 7.16 MB for the BF16 video latent, so no shared-silence or deduplication mechanism is used.
 
-Latent caches created before the `audio_present` contract (releases with `target_audio_policy` metadata) are not compatible; re-run latent caching. Text encoder caches are unaffected.
+`--skip_existing` compares the stored cache metadata (task, cache seed, crop start, cache format version, and fingerprints of the media files and VAE checkpoints) and rebuilds any cache that no longer matches. Fingerprints are lightweight file identities (size + mtime), not content hashes: re-copying or re-downloading a file changes its identity and triggers a one-time re-cache.
+
+Latent caches created before the `audio_present` contract (releases with `target_audio_policy` metadata) are not compatible; re-run latent caching. Caches written with the earlier metadata format remain trainable but are treated as stale by `--skip_existing` and rebuilt once.
 
 ## Cache Text Encoder Outputs
 
@@ -248,7 +250,7 @@ For Ref2VA, use the Ref2VA BF16 base and an ordered JSONL record:
 
 The Ref2VA generation JSONL intentionally uses the same validated schema as training, including target `video_path`, optional target audio, caption, and references. The target media identifies the record but is not used as a generation target. `--prompt` may override the record caption when encoding fresh text conditioning.
 
-T2VA and Ref2VA generation may use `--text_cache` instead of `--text_encoder`. The cache must match the requested task, frame count, and exact presentation fingerprint. T2VA still requires `--prompt` so that identity can be verified; Ref2VA uses the selected record caption unless `--prompt` overrides it. FL2VA generation does not accept a dataset text cache because external first/last images cannot be proven identical to the crop presentation that produced that cache.
+T2VA and Ref2VA generation may use `--text_cache` instead of `--text_encoder`. The cache must match the requested task, cache format version, and exact presentation fingerprint (which covers the prompt, frame count, and size+mtime identities of the reference media, so the cache must be used on the machine holding the original files). T2VA still requires `--prompt` so that identity can be verified; Ref2VA uses the selected record caption unless `--prompt` overrides it. FL2VA generation does not accept a dataset text cache because external first/last images cannot be proven identical to the crop presentation that produced that cache.
 
 The native sampler builds one common base grid, derives independent shifted video and audio sigma grids, and advances each modality with its own finite sigma interval. It does not apply CFG, negate the model heads, or apply ComfyUI's single-sampler audio slope adapter. Musubi also adds condition noise before packing, while ComfyUI adds it after packing; the distributions agree but RNG placement does not. These two intentional differences mean the same seed is not bitwise reproducible against ComfyUI. Video and audio are decoded sequentially, trimmed to a common duration, and muxed with PyAV as H.264 plus AAC.
 

--- a/src/musubi_tuner/dataset/cache_io.py
+++ b/src/musubi_tuner/dataset/cache_io.py
@@ -591,14 +591,7 @@ def save_latent_cache_minimax_h3(
         raise ValueError(f"MiniMax-H3 cache requires exactly one target video latent, found {target_count}")
     if audio_count != 1:
         raise ValueError(f"MiniMax-H3 cache requires exactly one target audio latent, found {audio_count}")
-    audio_present = validate_audio_present_entry(normalized)
-    metadata_present = (metadata or {}).get("audio_present")
-    if metadata_present not in {"0", "1"}:
-        raise ValueError(f'MiniMax-H3 cache requires audio_present metadata of "0" or "1", got {metadata_present!r}')
-    if float(metadata_present) != audio_present:
-        raise ValueError(
-            f"MiniMax-H3 cache has contradictory audio_present metadata={metadata_present!r} and tensor value={audio_present}"
-        )
+    validate_audio_present_entry(normalized)
     save_latent_cache_common(item_info, normalized, ARCHITECTURE_MINIMAX_H3_FULL, metadata)
 
 

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -371,14 +371,28 @@ def processor_fingerprint(processor) -> str:
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
 
 
-def presentation_fingerprint(presentation: H3Presentation, media_fingerprints: Mapping[Path, str]) -> str:
+# Bump whenever the cached hidden-state semantics change (hidden-state convention, token-tag
+# algorithm, text layout constants, or the fingerprint formats) so stale caches are rebuilt/rejected.
+TEXT_CACHE_FORMAT = "minimax-h3-text-v2"
+
+
+def presentation_fingerprint(
+    presentation: H3Presentation,
+    media_fingerprints: Mapping[Path, str],
+    *,
+    frame_count: int,
+) -> str:
+    # frame_count is part of the identity because Ref2VA reference videos are resampled to the
+    # target frame count before presentation. The target crop start is deliberately excluded: it
+    # only affects FL2VA visuals, and is guarded by explicit cache metadata instead.
     payload = {
         "text": presentation.text,
         "processor_text": presentation.processor_text,
         "image_shapes": [list(image.shape) for image in presentation.images],
         "video_shapes": [list(video.shape) for video in presentation.videos],
         "media": dict(sorted((str(Path(path).resolve()), value) for path, value in media_fingerprints.items())),
-        "format": "minimax-h3-non-chat-v1",
+        "frame_count": frame_count,
+        "format": "minimax-h3-non-chat-v2",
     }
     encoded = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -253,37 +253,28 @@ def _media_fingerprint_metadata(fingerprints: Mapping[Path, str]) -> str:
     return json.dumps(dict(sorted(normalized.items())), ensure_ascii=True, separators=(",", ":"))
 
 
+# Bump whenever the cached tensor semantics change (posterior policy, normalization constants, key
+# layout, or the fingerprint formats) so --skip_existing rebuilds stale caches.
+LATENT_CACHE_FORMAT = "minimax-h3-latent-v2"
+
+
 def build_latent_metadata(
     *,
-    record: H3Record,
     task: H3Task,
     crop_start_frame: int,
-    frame_count: int,
-    height: int,
-    width: int,
     cache_seed: int,
-    audio_present: bool,
     video_vae_fingerprint: str,
     audio_vae_fingerprint: str,
     media_fingerprints: Mapping[Path, str],
 ) -> dict[str, str]:
-    reference_kinds = [
-        reference.type + ("+audio" if reference.type == "video" and reference.audio is not None else "")
-        for reference in record.references
-    ]
     return {
         "task": task,
         "cache_seed": str(cache_seed),
         "crop_start_frame": str(crop_start_frame),
-        "audio_start_seconds": str(Fraction(crop_start_frame, TARGET_FPS)),
-        "target_geometry": f"{frame_count}x{height}x{width}",
-        "reference_kinds": json.dumps(reference_kinds, ensure_ascii=True, separators=(",", ":")),
-        "posterior_policy": "video_vae=fp32;target=seeded;conditions=seed42-fp16;audio=mode",
-        "normalization": "released-minimax-h3-v1",
+        "cache_format": LATENT_CACHE_FORMAT,
         "video_vae_fingerprint": video_vae_fingerprint,
         "audio_vae_fingerprint": audio_vae_fingerprint,
         "media_fingerprints": _media_fingerprint_metadata(media_fingerprints),
-        "audio_present": "1" if audio_present else "0",
     }
 
 
@@ -394,14 +385,9 @@ def build_latent_tensors(
                 tensors[_audio_key(f"{role_prefix}_audio", audio_latent)] = audio_latent
 
     metadata = build_latent_metadata(
-        record=record,
         task=task,
         crop_start_frame=crop_start_frame,
-        frame_count=frame_count,
-        height=height,
-        width=width,
         cache_seed=cache_seed,
-        audio_present=audio_present,
         video_vae_fingerprint=video_vae_fingerprint,
         audio_vae_fingerprint=audio_vae_fingerprint,
         media_fingerprints=media_fingerprints,
@@ -409,23 +395,10 @@ def build_latent_tensors(
     return H3LatentCachePayload(tensors=tensors, metadata=metadata)
 
 
-_fingerprint_cache: dict[tuple[Path, int, int], str] = {}
-
-
 def fingerprint_file(path: str | Path) -> str:
-    path = Path(path).resolve()
-    stat = path.stat()
-    cache_key = (path, stat.st_size, stat.st_mtime_ns)
-    cached = _fingerprint_cache.get(cache_key)
-    if cached is not None:
-        return cached
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
-            digest.update(chunk)
-    fingerprint = f"sha256:{digest.hexdigest()}"
-    _fingerprint_cache[cache_key] = fingerprint
-    return fingerprint
+    """Lightweight file identity (size + mtime) for cache-staleness checks; deliberately not a content hash."""
+    stat = Path(path).resolve().stat()
+    return f"stat:{stat.st_size}:{stat.st_mtime_ns}"
 
 
 def fingerprint_checkpoint(path: str | Path) -> str:
@@ -532,7 +505,6 @@ def main() -> None:
         )
         return
 
-    logger.info("Fingerprinting MiniMax-H3 VAE checkpoints")
     video_vae_fingerprint = fingerprint_checkpoint(args.video_vae)
     audio_vae_fingerprint = fingerprint_checkpoint(args.audio_vae)
     media_fingerprints: dict[Path, str] = {}
@@ -572,16 +544,10 @@ def main() -> None:
             record_fingerprints = {path: media_fingerprints[path] for path in record_media_paths(record)}
             if audio_source is not None:
                 record_fingerprints[audio_source.path] = media_fingerprints[audio_source.path]
-            frame_count, height, width = item.content.shape[:3]
             expected_metadata = build_latent_metadata(
-                record=record,
                 task=args.task,
                 crop_start_frame=crop_start,
-                frame_count=frame_count,
-                height=height,
-                width=width,
                 cache_seed=args.cache_seed,
-                audio_present=item.audio_present,
                 video_vae_fingerprint=video_vae_fingerprint,
                 audio_vae_fingerprint=audio_vae_fingerprint,
                 media_fingerprints=record_fingerprints,

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -15,8 +15,7 @@ from musubi_tuner.dataset.image_video_dataset import ItemInfo, VideoDataset
 from musubi_tuner.minimax_h3.text_encoder import (
     DEFAULT_PROCESSOR_ID,
     H3TextVisual,
-    MAX_TEXT_ROWS,
-    TEXT_WIDTH,
+    TEXT_CACHE_FORMAT,
     build_presentation,
     encode_h3_presentation,
     load_h3_processor,
@@ -94,24 +93,22 @@ def _text_cache_metadata(
     *,
     task: str,
     crop_start: int,
-    frame_count: int,
     processor_identity: str,
     text_encoder_identity: str,
     presentation_identity: str,
     cache_dtype: str,
 ) -> dict[str, str]:
+    # cache_dtype and crop_start_frame stay so --skip_existing rebuilds when --text_cache_dtype or the
+    # FL2VA crop window changes; frame_count is folded into the presentation fingerprint and the
+    # behavior tags into TEXT_CACHE_FORMAT.
     return {
         "task": task,
         "crop_start_frame": str(crop_start),
-        "frame_count": str(frame_count),
+        "cache_format": TEXT_CACHE_FORMAT,
         "text_encoder_fingerprint": text_encoder_identity,
         "processor_fingerprint": processor_identity,
         "presentation_fingerprint": presentation_identity,
         "cache_dtype": cache_dtype,
-        "hidden_state_convention": "index50-after-50-layers-pre-final-norm",
-        "token_tag_algorithm": "expanded-vision-span-with-flanks-v1",
-        "text_width": str(TEXT_WIDTH),
-        "max_text_rows": str(MAX_TEXT_ROWS),
     }
 
 
@@ -167,7 +164,6 @@ def main() -> None:
     logger.info("Loading MiniMax-H3 Qwen3-VL processor from %s", args.processor)
     processor = load_h3_processor(args.processor, revision=args.processor_revision)
     processor_identity = processor_fingerprint(processor)
-    logger.info("Fingerprinting MiniMax-H3 text encoder checkpoint")
     text_encoder_identity = fingerprint_checkpoint(args.text_encoder)
     logger.info("Loading MiniMax-H3 text encoder from %s", args.text_encoder)
     text_encoder = load_h3_text_encoder(
@@ -190,11 +186,14 @@ def main() -> None:
             visuals = _build_visuals(record, args.task, item, decoder, decoded_reference_cache)
             presentation = build_presentation(record, args.task, visuals)
             record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
-            presentation_identity = presentation_fingerprint(presentation, record_media_fingerprints)
+            presentation_identity = presentation_fingerprint(
+                presentation,
+                record_media_fingerprints,
+                frame_count=item.frame_count,
+            )
             metadata = _text_cache_metadata(
                 task=args.task,
                 crop_start=crop_start,
-                frame_count=item.frame_count,
                 processor_identity=processor_identity,
                 text_encoder_identity=text_encoder_identity,
                 presentation_identity=presentation_identity,

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -35,8 +35,7 @@ from musubi_tuner.minimax_h3.sampling import (
 )
 from musubi_tuner.minimax_h3.text_encoder import (
     DEFAULT_PROCESSOR_ID,
-    MAX_TEXT_ROWS,
-    TEXT_WIDTH,
+    TEXT_CACHE_FORMAT,
     build_presentation,
     encode_h3_presentation,
     load_h3_processor,
@@ -131,7 +130,6 @@ def load_cached_text_conditioning(
     path: str | Path,
     *,
     task: str,
-    frame_count: int | None = None,
     presentation_identity: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     path = Path(path)
@@ -140,20 +138,9 @@ def load_cached_text_conditioning(
         cached_task = metadata.get("task")
         if cached_task != task:
             raise ValueError(f"MiniMax-H3 requested task {task} conflicts with text-cache task {cached_task}")
-        cached_frame_count = metadata.get("frame_count")
-        if frame_count is not None and cached_frame_count != str(frame_count):
-            raise ValueError(
-                f"MiniMax-H3 requested frame count {frame_count} conflicts with text-cache frame count {cached_frame_count}"
-            )
-        expected_metadata = {
-            "hidden_state_convention": "index50-after-50-layers-pre-final-norm",
-            "token_tag_algorithm": "expanded-vision-span-with-flanks-v1",
-            "text_width": str(TEXT_WIDTH),
-            "max_text_rows": str(MAX_TEXT_ROWS),
-        }
-        for key, expected in expected_metadata.items():
-            if metadata.get(key) != expected:
-                raise ValueError(f"MiniMax-H3 text cache metadata {key} must be {expected!r}, got {metadata.get(key)!r}")
+        cached_format = metadata.get("cache_format")
+        if cached_format != TEXT_CACHE_FORMAT:
+            raise ValueError(f"MiniMax-H3 text cache format must be {TEXT_CACHE_FORMAT!r}, got {cached_format!r}")
         cached_presentation = metadata.get("presentation_fingerprint")
         if not cached_presentation:
             raise ValueError("MiniMax-H3 text cache is missing its presentation fingerprint")
@@ -179,11 +166,14 @@ def _encode_text(args, record: H3Record, text_visuals, device: torch.device):
             for reference in record.references
             if reference.type in {"image", "video"}
         }
-        presentation_identity = presentation_fingerprint(presentation, media_fingerprints)
+        presentation_identity = presentation_fingerprint(
+            presentation,
+            media_fingerprints,
+            frame_count=args.frame_count,
+        )
         return load_cached_text_conditioning(
             args.text_cache,
             task=args.task,
-            frame_count=args.frame_count,
             presentation_identity=presentation_identity,
         )
     logger.info("Loading MiniMax-H3 Qwen3-VL text encoder")

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -285,11 +285,7 @@ def test_h3_cache_keys_round_trip_through_existing_bucket_collator(tmp_path: Pat
         "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
         "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
     }
-    save_latent_cache_minimax_h3(
-        item,
-        latent_tensors,
-        {"task": "fl2va", "audio_present": "1"},
-    )
+    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "fl2va"})
     save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "fl2va"})
 
     manager = BucketBatchManager({(64, 64, 5): [item]}, batch_size=1)
@@ -324,7 +320,7 @@ def test_h3_latent_writer_requires_binary_float32_audio_present_scalar(tmp_path:
     }
 
     with pytest.raises(ValueError, match=AUDIO_PRESENT_KEY):
-        save_latent_cache_minimax_h3(item, base, {"task": "t2va", "audio_present": "1"})
+        save_latent_cache_minimax_h3(item, base, {"task": "t2va"})
 
     invalid = (
         torch.tensor([1.0], dtype=torch.float32),
@@ -337,22 +333,8 @@ def test_h3_latent_writer_requires_binary_float32_audio_present_scalar(tmp_path:
             save_latent_cache_minimax_h3(
                 item,
                 {**base, AUDIO_PRESENT_KEY: scalar},
-                {"task": "t2va", "audio_present": "1"},
+                {"task": "t2va"},
             )
-
-
-def test_h3_latent_writer_requires_presence_metadata_consistent_with_tensor(tmp_path: Path):
-    item = _h3_item(tmp_path)
-    tensors = {
-        "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
-        "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-        AUDIO_PRESENT_KEY: torch.tensor(1.0, dtype=torch.float32),
-    }
-
-    with pytest.raises(ValueError, match="audio_present metadata"):
-        save_latent_cache_minimax_h3(item, tensors, {"task": "t2va"})
-    with pytest.raises(ValueError, match="contradictory"):
-        save_latent_cache_minimax_h3(item, tensors, {"task": "t2va", "audio_present": "0"})
 
 
 @pytest.mark.parametrize(
@@ -476,13 +458,21 @@ def test_build_fl2va_latents_encodes_the_provided_audio_window(tmp_path: Path):
     torch.testing.assert_close(video_vae.calls[1], torch.full_like(video_vae.calls[1], -1.0))
     torch.testing.assert_close(video_vae.calls[2], torch.full_like(video_vae.calls[2], 1.0))
     assert payload.metadata["task"] == "fl2va"
+    assert payload.metadata["cache_seed"] == "123"
     assert payload.metadata["crop_start_frame"] == "3"
-    assert payload.metadata["audio_start_seconds"] == "1/8"
+    assert payload.metadata["cache_format"] == "minimax-h3-latent-v2"
     assert payload.metadata["video_vae_fingerprint"] == "video-fingerprint"
     assert payload.metadata["audio_vae_fingerprint"] == "audio-fingerprint"
-    assert payload.metadata["audio_present"] == "1"
-    assert payload.metadata["posterior_policy"] == "video_vae=fp32;target=seeded;conditions=seed42-fp16;audio=mode"
     assert json.loads(payload.metadata["media_fingerprints"]) == {str(record.video_path): "target-video"}
+    assert set(payload.metadata) == {
+        "task",
+        "cache_seed",
+        "crop_start_frame",
+        "cache_format",
+        "video_vae_fingerprint",
+        "audio_vae_fingerprint",
+        "media_fingerprints",
+    }
 
 
 def test_missing_target_audio_encodes_silence_with_presence_zero(tmp_path: Path):
@@ -513,7 +503,6 @@ def test_missing_target_audio_encodes_silence_with_presence_zero(tmp_path: Path)
     assert audio_vae.calls[0].shape == (1, 2, 6400)
     assert torch.count_nonzero(audio_vae.calls[0]) == 0
     assert payload.tensors[AUDIO_PRESENT_KEY].item() == 0.0
-    assert payload.metadata["audio_present"] == "0"
 
 
 def test_silence_placeholder_must_be_all_zeros(tmp_path: Path):
@@ -565,14 +554,14 @@ def test_h3_skip_existing_requires_all_cache_identity_metadata(tmp_path: Path):
     save_file(
         {"latents_2x4x4_float32": torch.zeros(24, 2, 4, 4)},
         cache_path,
-        metadata={"task": "t2va", "video_vae_fingerprint": "old", "audio_present": "0"},
+        metadata={"task": "t2va", "video_vae_fingerprint": "old", "cache_seed": "0"},
     )
 
     assert cache_metadata_matches(cache_path, {"task": "t2va", "video_vae_fingerprint": "old"})
     assert not cache_metadata_matches(cache_path, {"task": "t2va", "video_vae_fingerprint": "new"})
     assert not cache_metadata_matches(cache_path, {"task": "t2va", "audio_vae_fingerprint": "missing"})
-    assert cache_metadata_matches(cache_path, {"audio_present": "0"})
-    assert not cache_metadata_matches(cache_path, {"audio_present": "1"})
+    assert cache_metadata_matches(cache_path, {"cache_seed": "0"})
+    assert not cache_metadata_matches(cache_path, {"cache_seed": "1"})
 
 
 def test_h3_latent_cache_parser_exposes_only_the_two_explicit_vae_paths():
@@ -645,7 +634,9 @@ def test_build_ref2va_latents_preserves_ordered_numbered_roles(tmp_path: Path):
     assert [call[0].path for call in decoder.audio_calls] == [reference_video_audio, voice]
     assert decoder.audio_calls[0][1:] == (0, 6400, True)
     assert decoder.audio_calls[1][1:] == (0, 6400, False)
-    assert json.loads(payload.metadata["reference_kinds"]) == ["image", "video+audio", "audio"]
+    assert json.loads(payload.metadata["media_fingerprints"]) == {
+        str(path): path.name for path in {record.video_path, image, reference_video, reference_video_audio, voice}
+    }
 
 
 def test_build_ref2va_revalidates_limits_before_any_model_work(tmp_path: Path):

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -285,31 +285,27 @@ def test_generation_validation_enforces_task_inputs_and_block_swap_range(tmp_pat
         validate_generation_args(_generation_args(tmp_path, blocks_to_swap=49))
 
 
-def test_cached_text_conditioning_validates_task_width_and_tags(tmp_path):
+def test_cached_text_conditioning_validates_task_format_and_fingerprint(tmp_path):
     path = tmp_path / "conditioning.safetensors"
     hidden = torch.zeros(3, 5120, dtype=torch.bfloat16)
     tags = torch.tensor([1, 0, 1], dtype=torch.int64)
+    tensors = {
+        "varlen_mmh3_hidden_states_bfloat16": hidden,
+        "varlen_mmh3_token_tags_int64": tags,
+    }
     save_file(
-        {
-            "varlen_mmh3_hidden_states_bfloat16": hidden,
-            "varlen_mmh3_token_tags_int64": tags,
-        },
+        tensors,
         str(path),
         metadata={
             "task": "t2va",
-            "frame_count": "124",
+            "cache_format": "minimax-h3-text-v2",
             "presentation_fingerprint": "sha256:presentation",
-            "hidden_state_convention": "index50-after-50-layers-pre-final-norm",
-            "token_tag_algorithm": "expanded-vision-span-with-flanks-v1",
-            "text_width": "5120",
-            "max_text_rows": "32768",
         },
     )
 
     actual_hidden, actual_tags = load_cached_text_conditioning(
         path,
         task="t2va",
-        frame_count=124,
         presentation_identity="sha256:presentation",
     )
 
@@ -318,14 +314,21 @@ def test_cached_text_conditioning_validates_task_width_and_tags(tmp_path):
     assert torch.equal(actual_tags, tags)
     with pytest.raises(ValueError, match=r"task.*ref2va.*t2va"):
         load_cached_text_conditioning(path, task="ref2va")
-    with pytest.raises(ValueError, match=r"frame count.*141.*124"):
-        load_cached_text_conditioning(path, task="t2va", frame_count=141)
     with pytest.raises(ValueError, match="presentation fingerprint"):
         load_cached_text_conditioning(
             path,
             task="t2va",
             presentation_identity="sha256:different",
         )
+
+    stale = tmp_path / "stale.safetensors"
+    save_file(
+        tensors,
+        str(stale),
+        metadata={"task": "t2va", "presentation_fingerprint": "sha256:presentation"},
+    )
+    with pytest.raises(ValueError, match="text cache format"):
+        load_cached_text_conditioning(stale, task="t2va", presentation_identity="sha256:presentation")
 
 
 def test_generation_text_cache_requires_an_identifiable_presentation(tmp_path):

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -167,7 +167,6 @@ def test_text_cache_metadata_distinguishes_requested_storage_dtype():
     common = {
         "task": "t2va",
         "crop_start": 0,
-        "frame_count": 22,
         "processor_identity": "processor",
         "text_encoder_identity": "encoder",
         "presentation_identity": "presentation",
@@ -178,4 +177,14 @@ def test_text_cache_metadata_distinguishes_requested_storage_dtype():
 
     assert bf16["cache_dtype"] == "bf16"
     assert float32["cache_dtype"] == "float32"
+    assert bf16["cache_format"] == "minimax-h3-text-v2"
     assert bf16 != float32
+    assert set(bf16) == {
+        "task",
+        "crop_start_frame",
+        "cache_format",
+        "text_encoder_fingerprint",
+        "processor_fingerprint",
+        "presentation_fingerprint",
+        "cache_dtype",
+    }


### PR DESCRIPTION
## Summary

Follow-up dataset cleanup for MiniMax-H3 (#1018) ahead of R2, reducing cache-command startup cost and trimming cache metadata to what actually drives correctness.

### Lightweight fingerprints

- `fingerprint_file` now returns a `stat:{size}:{mtime_ns}` identity instead of a full-content SHA256, eliminating the full read of every media file and VAE/TE checkpoint at cache-command startup (the in-process hash cache is no longer needed). `fingerprint_checkpoint` keeps its structure (file names + per-file identities hashed together), now effectively free.
- Trade-off: re-copying or re-downloading a file changes its identity and triggers a one-time re-cache, and generation-time `--text_cache` must be used on the machine holding the original reference files. Documented in `docs/minimax_h3.md`.

### Slimmed cache metadata

- **Latent caches** keep `task` / `cache_seed` / `crop_start_frame` / `cache_format` / `video_vae_fingerprint` / `audio_vae_fingerprint` / `media_fingerprints`. Dropped: `target_geometry` (already in tensor keys, validated on save), `audio_start_seconds` (derived), `reference_kinds` (covered by media fingerprints), `audio_present` (tensor entry is the single source of truth; the writer's metadata⇔tensor contradiction check is removed with it).
- **Text caches** keep `task` / `crop_start_frame` / `cache_format` / three fingerprints / `cache_dtype` (guards `--text_cache_dtype` changes under `--skip_existing`). `frame_count` folds into the presentation fingerprint (payload v2) since Ref2VA reference videos are resampled to the target frame count.
- The behavior tag strings (`posterior_policy`, `normalization`, `hidden_state_convention`, `token_tag_algorithm`, `text_width`, `max_text_rows`) collapse into a single `cache_format` version key (`minimax-h3-latent-v2` / `minimax-h3-text-v2`), bumped whenever cached semantics change — one key to remember instead of six strings.
- `crop_start_frame` deliberately stays **out** of the presentation fingerprint: Ref2VA/T2VA presentations do not depend on the target crop, and folding it in would have broken generation-time text-cache reuse (generation never checked it). It remains a metadata key to guard FL2VA staleness.
- `minimax_h3_generate_video.py` text-cache validation simplifies to task + `cache_format` + presentation fingerprint.

### Compatibility

Existing caches remain trainable (training reads tensors, not the slimmed metadata) but are treated as stale by `--skip_existing` and rebuilt once. Verified on a real dataset: rebuild happens as expected and startup wait is substantially shorter.

## Testing

- All 170 MiniMax-H3 tests pass (`test_minimax_h3_*`), including updated cache-contract, sampling, and text-encoder metadata tests plus a new stale-format rejection case.
- `ruff check` / `ruff format --check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)