### PR TITLE
Resolve JSONL relative paths against the working directory first

### DIFF
--- a/docs/dataset_config.md
+++ b/docs/dataset_config.md
@@ -240,7 +240,7 @@ JSONL file format for metadata:
 
 `video_path` can be a directory containing multiple images.
 
-Relative paths in the JSONL (`video_path`, `control_path`, `audio_path`) are resolved against the directory containing the JSONL file when the target exists there; otherwise they are treated as relative to the working directory as before.
+Relative paths in the JSONL (`video_path`, `control_path`, `audio_path`) are resolved against the working directory first (the historical behavior); when the file is not found there, they are resolved against the directory containing the JSONL file. If both locations contain the file, the working-directory match is used and a warning is logged.
 
 For audio-capable architectures, each record may also have an optional `audio_path` field pointing to the audio file for the video. If `audio_path` is omitted, the audio source is resolved automatically: a same-stem audio sidecar file (e.g. `video1.wav` next to `video1.mp4`; `.aac`/`.flac`/`.m4a`/`.mp3`/`.ogg`/`.opus`/`.wav`) is used if present (multiple candidates are an error), otherwise the audio track embedded in the video container is used. If none is found, the item is cached as audio-less (a silence placeholder with `audio_present=0`, excluded from audio supervision during training). Architectures without audio support ignore `audio_path`.
 
@@ -250,7 +250,7 @@ metadata jsonl ファイルを使用する場合、caption_extension は必要�
 
 `video_path`は、複数の画像を含むディレクトリのパスでも構いません。
 
-JSONL 内の相対パス（`video_path`、`control_path`、`audio_path`）は、JSONL ファイルのあるディレクトリを基準に解決されます（該当ファイルが存在する場合。存在しない場合は従来どおり作業ディレクトリ基準）。
+JSONL 内の相対パス（`video_path`、`control_path`、`audio_path`）は、まず作業ディレクトリ基準で解決されます（従来どおりの挙動）。そこにファイルが存在しない場合は、JSONL ファイルのあるディレクトリ基準で解決されます。両方に存在する場合は作業ディレクトリ側が使用され、warning が出力されます。
 
 audio 対応アーキテクチャでは、各レコードに任意の `audio_path` フィールドを指定できます。省略した場合は、同名の音声サイドカーファイル（例: `video1.mp4` と同じ場所の `video1.wav`。複数候補がある場合はエラー）、次に動画コンテナ内の音声トラックの順で自動解決されます。どちらも無い場合は音声なしとしてキャッシュされ（無音プレースホルダ、`audio_present=0`）、学習時の audio 教師からは除外されます。audio 非対応のアーキテクチャでは `audio_path` は無視されます。
 

--- a/src/musubi_tuner/dataset/datasources.py
+++ b/src/musubi_tuner/dataset/datasources.py
@@ -683,17 +683,26 @@ class VideoJsonlDatasource(VideoDatasource):
                 self.data.append(data)
         logger.info(f"loaded {len(self.data)} videos")
 
-        # resolve relative paths against the JSONL's own directory when the target exists
-        # there; otherwise keep the original (working-directory relative) path
+        # resolve relative paths against the working directory first (the historical behavior),
+        # then against the JSONL's own directory. Whichever location matches is rewritten to an
+        # absolute path so downstream consumers (e.g. MiniMax-H3 record building) never
+        # re-resolve the value against a different base.
         base_directory = os.path.dirname(os.path.abspath(self.video_jsonl_file))
         for data in self.data:
             for key in VideoJsonlDatasource.PATH_KEYS:
                 value = data.get(key)
                 if not isinstance(value, str) or not value or os.path.isabs(value):
                     continue
-                candidate = os.path.join(base_directory, value)
-                if os.path.exists(candidate):
-                    data[key] = candidate
+                jsonl_candidate = os.path.join(base_directory, value)
+                if os.path.exists(value):
+                    data[key] = os.path.abspath(value)
+                    if os.path.exists(jsonl_candidate) and not os.path.samefile(value, jsonl_candidate):
+                        logger.warning(
+                            f"{key} {value!r} exists both relative to the working directory and to the JSONL directory; "
+                            f"using the working-directory match {data[key]}"
+                        )
+                elif os.path.exists(jsonl_candidate):
+                    data[key] = jsonl_candidate
 
         # Check if there are control paths in the JSONL
         self.has_control = any("control_path" in item for item in self.data)

--- a/tests/test_audio_dataset_seam.py
+++ b/tests/test_audio_dataset_seam.py
@@ -269,19 +269,32 @@ def test_jsonl_datasource_resolves_explicit_audio_path(tmp_path: Path):
     assert datasource.audio_sources == [AudioSource(path=wav_path.resolve(), embedded=False)]
 
 
-def test_jsonl_datasource_resolves_relative_paths_against_jsonl_directory(tmp_path: Path):
-    _write_video(tmp_path / "clip.mp4", frames=4)
-    _write_wav(tmp_path / "narration.wav", _sine_stereo(SAMPLE_RATE // 4))
+def test_jsonl_datasource_resolves_relative_paths_cwd_first_then_jsonl_directory(tmp_path: Path, monkeypatch):
+    jsonl_dir = tmp_path / "ds"
+    working_dir = tmp_path / "cwd"
+    jsonl_dir.mkdir()
+    working_dir.mkdir()
+    monkeypatch.chdir(working_dir)
 
-    jsonl_path = tmp_path / "data.jsonl"
+    _write_video(jsonl_dir / "clip.mp4", frames=4)
+    _write_wav(jsonl_dir / "narration.wav", _sine_stereo(SAMPLE_RATE // 4))
+
+    jsonl_path = jsonl_dir / "data.jsonl"
     record = {"video_path": "clip.mp4", "caption": "caption", "audio_path": "narration.wav"}
     jsonl_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
 
+    # absent from the working directory, paths fall back to the JSONL's own directory
     datasource = VideoJsonlDatasource(str(jsonl_path))
-    assert datasource.data[0]["video_path"] == str(tmp_path / "clip.mp4")
-    assert datasource.data[0]["audio_path"] == str(tmp_path / "narration.wav")
+    assert datasource.data[0]["video_path"] == str(jsonl_dir / "clip.mp4")
+    assert datasource.data[0]["audio_path"] == str(jsonl_dir / "narration.wav")
 
-    # nonexistent relative paths are kept as-is (working-directory relative)
+    # a working-directory match wins over the JSONL-directory match
+    _write_video(working_dir / "clip.mp4", frames=4)
+    datasource = VideoJsonlDatasource(str(jsonl_path))
+    assert datasource.data[0]["video_path"] == str(working_dir / "clip.mp4")
+    assert datasource.data[0]["audio_path"] == str(jsonl_dir / "narration.wav")
+
+    # nonexistent relative paths are kept as-is
     jsonl_path.write_text(json.dumps({"video_path": "missing.mp4", "caption": "c"}) + "\n", encoding="utf-8")
     datasource = VideoJsonlDatasource(str(jsonl_path))
     assert datasource.data[0]["video_path"] == "missing.mp4"


### PR DESCRIPTION
## Summary

Adjusts the relative-path resolution for `video_jsonl_file` entries introduced with the audio dataset seam (#1020), before it ships in a release.

- Relative `video_path` / `control_path` / `audio_path` values now resolve against the **working directory first** (the historical, pre-#1020 behavior), falling back to the JSONL's own directory only when the file is not found there. #1020 used the opposite priority (JSONL directory first), which could silently repoint a pre-existing config to a different file when the same relative path happened to exist next to the JSONL — a plausible layout, since JSONL files often live inside the dataset tree. With CWD-first, any config that worked before the seam resolves to exactly the same file.
- If both locations contain the file and they differ, the working-directory match is used and a **warning is logged** (`os.path.samefile` suppresses the warning when the two locations are the same file, e.g. when the working directory *is* the JSONL directory).
- Whichever location matches is now rewritten to an **absolute path**. This also fixes a real inconsistency: a relative path that existed only working-directory-side previously stayed relative, loaded fine through the common pipeline, but failed MiniMax-H3 record building because `media.py` re-resolved the still-relative value against the JSONL directory and raised "does not exist".

Out of scope (unchanged by design): MiniMax-H3 `references[].path` remains JSONL-relative only, and the generation-side `--reference_jsonl` (which does not go through the datasource) keeps strict JSONL-relative resolution.

Docs (`dataset_config.md`, EN/JA) updated to describe the new priority.

## Testing

- `test_audio_dataset_seam.py` path-resolution test reworked with separated working/JSONL directories, covering: JSONL-directory fallback, working-directory match winning over the JSONL-directory match, and not-found paths kept as-is.
- 70 tests pass across `test_audio_dataset_seam.py`, `test_minimax_h3_dataset.py`, `test_minimax_h3_cache_contract.py`; `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)