### PR TITLE
Add ConvRot INT8 support for MiniMax-H3 (training + generation, ComfyUI pre-quantized loading)

### DIFF
--- a/docs/krea2.md
+++ b/docs/krea2.md
@@ -203,6 +203,7 @@ Because the default already targets everything, both `exclude_patterns` and `inc
 - Requires **triton** for the fused kernels (`pip install triton-windows` on Windows, matching your torch version). Without triton, training still works via a dequantized bf16 fallback: VRAM savings remain but there is no speedup.
 - `--convrot_int8_bwd int8` (opt-in) also routes the backward grad_x through the fused int8 GEMM: faster, at the cost of slightly quantized gradients. The default `bf16` dequantizes transiently and is the most accurate.
 - Same scope as fp8: the 28 main blocks only; the quantized layers are still LoRA-trainable (the LoRA branch receives the unrotated input and its gradients are unaffected by the base quantization).
+- ComfyUI pre-quantized ConvRot INT8 checkpoints (`weight` int8 + `weight_scale` + `comfy_quant` tensors) load directly with `--convrot_int8`; the layers the file quantized are used as-is. Load-time LoRA merge requires bf16 base weights (merging into int8 is rejected).
 - Composes with `--blocks_to_swap` and `--gradient_checkpointing`. With `--compile`, the quantized Linears are excluded from compilation automatically. Not supported together with `--turbo_dit` yet. Multi-GPU training is untested.
 
 Reference speed (rough 20-step measurement; LoRA training, 1024x1024, batch size 1, `--flash_attn`, gradient checkpointing):
@@ -224,6 +225,7 @@ Loss curves match the fp8/bf16 baselines closely (both backward modes). `--convr
 - 融合カーネルには **triton** が必要です（Windowsではtorchのバージョンに対応する`pip install triton-windows`）。tritonがなくても逆量子化bf16フォールバックで学習は可能です（VRAM削減は維持、速度向上はなし）。
 - `--convrot_int8_bwd int8`（opt-in）を指定すると、backwardのgrad_xも融合int8 GEMMを通ります。高速ですが勾配がわずかに量子化されます。デフォルトの`bf16`は一時的に逆量子化する方式で、最も高精度です。
 - 適用範囲はfp8と同じく28個のメインブロックのみです。量子化された層もLoRA学習可能です（LoRA枝には回転前の入力が渡され、その勾配はbase量子化の影響を受けません）。
+- ComfyUI配布の事前量子化済みConvRot INT8チェックポイント（`weight` int8＋`weight_scale`＋`comfy_quant`）も`--convrot_int8`でそのまま読み込めます（ファイル側で量子化された層をそのまま使用）。ロード時LoRAマージにはbf16のbase重みが必要です（int8へのマージはエラーになります）。
 - `--blocks_to_swap`、`--gradient_checkpointing`と併用できます。`--compile`使用時は量子化されたLinearは自動的にコンパイル対象から除外されます。`--turbo_dit`との併用は現時点では未対応です。マルチGPU学習は未検証です。
 
 参考速度（20ステップの粗い計測。LoRA学習、1024x1024、batch size 1、`--flash_attn`、gradient checkpointing使用）:

--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -209,6 +209,19 @@ FL2VA entries additionally use `first_frame` and `last_frame`; the common `image
 
 Sample geometry must be 32-pixel aligned. Frame counts of at least 5 are rounded down to the nearest `17*n+5` value, matching the shared training-sample convention. Released durations are 5-15 seconds; `--h3_allow_experimental_sample_duration` permits shorter smoke samples. H3 sampling does not accept negative prompts, CFG, or a per-prompt generic flow shift.
 
+## ConvRot INT8 Quantized Base Weights
+
+`--convrot_int8` quantizes the frozen DiT base weights to int8 with ConvRot ([arXiv:2512.03673](https://arxiv.org/abs/2512.03673)), the same scheme as Krea 2 (see `docs/krea2.md` for the mechanism and backward modes). It is supported for both LoRA training and generation, and accepts either base artifact:
+
+- **BF16 checkpoints** are quantized on the fly at load time.
+- **ComfyUI pre-quantized ConvRot INT8 checkpoints** (`weight` int8 + `weight_scale` + `comfy_quant` tensors) are converted to the Musubi layout during the same streaming load. Both routes produce bit-identical models: Musubi's dynamic quantization reproduces the published ComfyUI INT8 ConvRot distribution exactly, layer by layer.
+
+The quantization scope mirrors the ComfyUI distribution: the five Linears in each of the 50 main DiT blocks (`attn.qkv_proj`, `attn.out_proj`, `mlp.fc1`, `mlp.fc2`, and `adaln_proj.linear`). `adaln_proj` uses ConvRot group size 64 (its input width 2688 is not a multiple of 256); the rest use 256. The token refiner, final layer, embedders, and heads stay BF16/FP32. The base checkpoint shrinks from ~66 GB (BF16) to ~34 GB of weights.
+
+Training flags match Krea 2: `--convrot_int8` plus optional `--convrot_int8_bwd {bf16,int8}` (default `bf16`). The LoRA trains in BF16 on top of the int8 base as usual, and block swap (including `--block_swap_h2d_only`) combines with quantization — quantization runs on the accelerator while the weights load to CPU. `--fp8_base`/`--fp8_scaled` remain unsupported for H3. Triton (`triton-windows` on Windows) is required for the fused int8 kernels; without it the forward falls back to a slower transient dequantization (the memory saving remains). `torch.compile` excludes the patched Linears automatically.
+
+For generation, add `--convrot_int8` to `minimax_h3_generate_video.py`. With `--lora_weight`, the LoRA is merged into the BF16 weights during the streaming load and the merged result is then quantized, so LoRA generation requires the BF16 base checkpoint; merging into a pre-quantized int8 checkpoint is rejected with an explicit error.
+
 ## Generation
 
 T2VA generation with the FL2VA BF16 base:
@@ -256,9 +269,9 @@ The native sampler builds one common base grid, derives independent shifted vide
 
 ## R1 Limitations
 
-- BF16 FL2VA/Ref2VA transformer bases only.
+- BF16 or ConvRot INT8 FL2VA/Ref2VA transformer bases only.
 - BF16 Qwen3-VL text encoder only.
-- No ConvRot INT8, pruned AdaLN, FP8, or NVFP4/AWQ artifact loading.
+- No pruned AdaLN, FP8, or NVFP4/AWQ artifact loading.
 - No CFG or negative prompt.
 - No numbered reference-directory convention.
 - Dataset `batch_size` is fixed to 1; use gradient accumulation for larger effective batches.

--- a/src/musubi_tuner/krea2/krea2_utils.py
+++ b/src/musubi_tuner/krea2/krea2_utils.py
@@ -102,6 +102,9 @@ def load_krea2_dit(
         # quantizes the per-block Linears (scaled fp8 or ConvRot int8). Targets/excludes only
         # apply when quantizing; without quantization the weights are merged and cast to
         # ``dtype`` as-is.
+        quantizer = (
+            ConvRotInt8Quantizer(KREA2_FP8_OPTIMIZATION_TARGET_KEYS, KREA2_FP8_OPTIMIZATION_EXCLUDE_KEYS) if convrot_int8 else None
+        )
         sd = load_safetensors_with_lora_and_fp8(
             model_files=dit_path,
             lora_weights_list=lora_weights,
@@ -112,16 +115,12 @@ def load_krea2_dit(
             dit_weight_dtype=None if quantized else dtype,
             target_keys=KREA2_FP8_OPTIMIZATION_TARGET_KEYS if fp8_scaled else None,
             exclude_keys=KREA2_FP8_OPTIMIZATION_EXCLUDE_KEYS if fp8_scaled else None,
-            quantizer=(
-                ConvRotInt8Quantizer(KREA2_FP8_OPTIMIZATION_TARGET_KEYS, KREA2_FP8_OPTIMIZATION_EXCLUDE_KEYS)
-                if convrot_int8
-                else None
-            ),
+            quantizer=quantizer,
         )
         if fp8_scaled:
             apply_fp8_monkey_patch(dit, sd, use_scaled_mm=False)
         elif convrot_int8:
-            apply_convrot_int8_monkey_patch(dit, sd, bwd_mode=convrot_int8_bwd)
+            apply_convrot_int8_monkey_patch(dit, sd, bwd_mode=convrot_int8_bwd, groupsize_map=quantizer.module_groupsizes)
             # int8 tensors cannot be wrapped as Parameters with requires_grad=True (only
             # floating dtypes can require grad), and load_state_dict(assign=True) re-wraps
             # incoming tensors with the meta params' requires_grad (default True). The base

--- a/src/musubi_tuner/minimax_h3/checkpoint.py
+++ b/src/musubi_tuner/minimax_h3/checkpoint.py
@@ -121,7 +121,10 @@ def load_safetensors_module(
         with MemoryEfficientSafeOpen(str(path), disable_numpy_memmap=disable_mmap) as handle:
             raw_keys = handle.keys()
             if any(key.endswith((".weight_scale", ".comfy_quant")) for key in raw_keys):
-                raise ValueError(f"Quantized MiniMax-H3 artifacts are deferred to R2: {path}")
+                raise ValueError(
+                    f"Pre-quantized MiniMax-H3 checkpoint: {path}. Pass --convrot_int8 to load ConvRot INT8"
+                    " transformer weights; other quantized formats (fp8/NVFP4) are not supported."
+                )
             for raw_key in raw_keys:
                 key = _normalize_checkpoint_key(raw_key, key_prefixes)
                 if key_transform is not None:

--- a/src/musubi_tuner/minimax_h3/model.py
+++ b/src/musubi_tuner/minimax_h3/model.py
@@ -142,10 +142,14 @@ _PUBLISHED_CONFIG_FIELDS = {
 }
 
 
-def parse_h3_transformer_config(metadata: Mapping[str, str]) -> MiniMaxH3Config:
+def parse_h3_transformer_config(metadata: Mapping[str, str], *, allow_convrot_int8: bool = False) -> MiniMaxH3Config:
     artifact_markers = " ".join(f"{key}={value}" for key, value in metadata.items() if key != "config").lower()
-    if any(marker in artifact_markers for marker in ("convrot", "int8", "fp8", "quantized")):
-        raise ValueError("Quantized or ConvRot MiniMax-H3 artifacts are deferred to R2")
+    blocked_markers = ("fp8", "nvfp4") if allow_convrot_int8 else ("convrot", "int8", "fp8", "nvfp4", "quantized")
+    if any(marker in artifact_markers for marker in blocked_markers):
+        raise ValueError(
+            "Unsupported quantized MiniMax-H3 checkpoint. Pass --convrot_int8 for ConvRot INT8 checkpoints;"
+            " other quantized formats (fp8/NVFP4) are not supported."
+        )
     raw_config = metadata.get("config")
     if raw_config is None:
         raise ValueError("MiniMax-H3 transformer checkpoint is missing config metadata")
@@ -833,6 +837,72 @@ class MiniMaxH3Model(nn.Module):
         return MiniMaxH3Output(video=video.to(video_dtype), audio=audio.to(audio_dtype))
 
 
+# ConvRot INT8 scope mirrors the ComfyUI distribution: the five per-block Linears
+# (attn qkv/out, mlp fc1/fc2, adaln_proj). token_refiner blocks and the final layer
+# stay BF16. adaln_proj's in_features (2688) is not a multiple of 256, so the group
+# size falls back to 64 there — the same choice ComfyUI publishes in `comfy_quant`.
+H3_CONVROT_INT8_TARGET_KEYS = ["attn.qkv_proj", "attn.out_proj", "mlp.fc1", "mlp.fc2", "adaln_proj.linear"]
+H3_CONVROT_INT8_EXCLUDE_KEYS = ["token_refiner.", "final_layer."]
+H3_CONVROT_INT8_ALLOWED_GROUPSIZES = (256, 64)
+
+
+def _load_h3_transformer_convrot_int8(
+    files: list[Path],
+    config: MiniMaxH3Config,
+    *,
+    device: torch.device,
+    quant_device: torch.device,
+    bwd_mode: str,
+    attn_mode: str,
+    split_attn: bool,
+    disable_mmap: bool,
+    lora_weights: list[dict] | None = None,
+    lora_multipliers: list[float] | None = None,
+) -> MiniMaxH3Model:
+    """Load the transformer with ConvRot INT8 base weights.
+
+    BF16 checkpoints are quantized on the fly on ``quant_device`` (LoRA weights, if any,
+    are merged into the BF16 weights first); ComfyUI pre-quantized checkpoints are
+    converted to the Musubi layout during the same streaming pass. ``device`` is where
+    the weights end up ("cpu" under block swap).
+    """
+    from accelerate import init_empty_weights
+
+    from musubi_tuner.modules.convrot_int8_utils import ConvRotInt8Quantizer, apply_convrot_int8_monkey_patch
+    from musubi_tuner.utils.lora_utils import load_safetensors_with_lora_and_fp8
+
+    with init_empty_weights():
+        model = MiniMaxH3Model(config, attn_mode=attn_mode, split_attn=split_attn, dtype=torch.bfloat16)
+
+    quantizer = ConvRotInt8Quantizer(
+        H3_CONVROT_INT8_TARGET_KEYS,
+        H3_CONVROT_INT8_EXCLUDE_KEYS,
+        allowed_groupsizes=H3_CONVROT_INT8_ALLOWED_GROUPSIZES,
+    )
+    sd = load_safetensors_with_lora_and_fp8(
+        model_files=[str(path) for path in files],
+        lora_weights_list=lora_weights,
+        lora_multipliers=lora_multipliers,
+        fp8_optimization=False,
+        calc_device=quant_device,
+        move_to_device=(device == quant_device),
+        dit_weight_dtype=None,
+        disable_numpy_memmap=disable_mmap,
+        quantizer=quantizer,
+    )
+    apply_convrot_int8_monkey_patch(model, sd, bwd_mode=bwd_mode, groupsize_map=quantizer.module_groupsizes)
+    # int8 tensors cannot require grad, and load_state_dict(assign=True) re-wraps incoming
+    # tensors with the meta params' requires_grad (default True); the base is frozen anyway.
+    model.requires_grad_(False)
+    if device.type != "cpu":
+        for key in sd.keys():
+            sd[key] = sd[key].to(device)
+    # strict load keeps the R1 key verification: missing/unexpected keys raise
+    model.load_state_dict(sd, strict=True, assign=True)
+    model.eval()
+    return model
+
+
 def load_h3_transformer(
     checkpoint_path: str | Path,
     *,
@@ -841,11 +911,32 @@ def load_h3_transformer(
     attn_mode: str = "torch",
     split_attn: bool = False,
     disable_mmap: bool = False,
+    convrot_int8: bool = False,
+    convrot_int8_bwd: str = "bf16",
+    quant_device: torch.device | str | None = None,
+    lora_weights: list[dict] | None = None,
+    lora_multipliers: list[float] | None = None,
 ) -> MiniMaxH3Model:
     if dtype != torch.bfloat16:
-        raise ValueError("MiniMax-H3 R1 accepts only BF16 transformer checkpoints")
+        raise ValueError("MiniMax-H3 accepts only BF16 transformer checkpoints")
     files = resolve_safetensors_files(checkpoint_path)
-    config = parse_h3_transformer_config(load_safetensors_metadata(files))
+    config = parse_h3_transformer_config(load_safetensors_metadata(files), allow_convrot_int8=convrot_int8)
+    if convrot_int8:
+        device = torch.device(device)
+        return _load_h3_transformer_convrot_int8(
+            files,
+            config,
+            device=device,
+            quant_device=device if quant_device is None else torch.device(quant_device),
+            bwd_mode=convrot_int8_bwd,
+            attn_mode=attn_mode,
+            split_attn=split_attn,
+            disable_mmap=disable_mmap,
+            lora_weights=lora_weights,
+            lora_multipliers=lora_multipliers,
+        )
+    if lora_weights:
+        raise ValueError("MiniMax-H3 load-time LoRA merge is only wired for the ConvRot INT8 path")
     return load_safetensors_module(
         lambda: MiniMaxH3Model(config, attn_mode=attn_mode, split_attn=split_attn, dtype=dtype),
         files,

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -193,6 +193,18 @@ def _encode_text(args, record: H3Record, text_visuals, device: torch.device):
     return hidden_states.to(torch.bfloat16).unsqueeze(0).cpu(), token_tags.cpu()
 
 
+def _load_lora_state_dicts(args) -> list[dict]:
+    """Load and filter LoRA state dicts for the load-time merge (ConvRot INT8 path)."""
+    includes = args.include_patterns or []
+    excludes = args.exclude_patterns or []
+    state_dicts = []
+    for index, path in enumerate(args.lora_weight or []):
+        include = includes[index] if index < len(includes) else None
+        exclude = excludes[index] if index < len(excludes) else None
+        state_dicts.append(filter_lora_state_dict(load_file(path), include, exclude))
+    return state_dicts
+
+
 def _merge_lora_weights(transformer, args) -> None:
     weights = args.lora_weight or []
     multipliers = args.lora_multiplier or []
@@ -218,7 +230,19 @@ def _merge_lora_weights(transformer, args) -> None:
 def setup_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), required=True)
-    parser.add_argument("--dit", required=True, help="MiniMax-H3 BF16 transformer safetensors path or directory")
+    parser.add_argument(
+        "--dit",
+        required=True,
+        help="MiniMax-H3 transformer safetensors path or directory (BF16, or ConvRot INT8 with --convrot_int8)",
+    )
+    parser.add_argument(
+        "--convrot_int8",
+        action="store_true",
+        help="use ConvRot INT8 for the DiT base weights: quantizes BF16 weights at load time or loads ComfyUI "
+        "pre-quantized ConvRot INT8 checkpoints directly (requires triton for the fused kernels; falls back to "
+        "slower dequantized bf16 matmul without it). LoRA weights are merged before quantization, so LoRA "
+        "requires BF16 base weights.",
+    )
     parser.add_argument("--video_vae", required=True, help="MiniMax-H3 video VAE safetensors path or directory")
     parser.add_argument("--audio_vae", required=True, help="MiniMax-H3 audio VAE safetensors path or directory")
     parser.add_argument("--text_encoder", default=None, help="MiniMax-H3 Qwen3-VL BF16 safetensors path")
@@ -364,8 +388,11 @@ def run_generation(args: argparse.Namespace) -> Path:
         device=device,
     )
 
-    load_on_cpu = bool(args.blocks_to_swap or args.lora_weight)
-    logger.info("Loading MiniMax-H3 BF16 transformer")
+    # ConvRot INT8 merges LoRA during the streaming load (merge into BF16, then quantize),
+    # so the post-load CPU merge path is only used for the plain BF16 route.
+    load_on_cpu = bool(args.blocks_to_swap or (args.lora_weight and not args.convrot_int8))
+    lora_weights, lora_multipliers = (_load_lora_state_dicts(args), args.lora_multiplier) if args.convrot_int8 else (None, None)
+    logger.info("Loading MiniMax-H3 transformer%s", " (ConvRot INT8)" if args.convrot_int8 else "")
     transformer = load_h3_transformer(
         args.dit,
         device="cpu" if load_on_cpu else device,
@@ -373,8 +400,12 @@ def run_generation(args: argparse.Namespace) -> Path:
         attn_mode="torch" if args.attn_mode == "sdpa" else args.attn_mode,
         split_attn=args.split_attn,
         disable_mmap=args.disable_numpy_memmap,
+        convrot_int8=args.convrot_int8,
+        quant_device=device,
+        lora_weights=lora_weights,
+        lora_multipliers=lora_multipliers,
     )
-    if args.lora_weight:
+    if args.lora_weight and not args.convrot_int8:
         _merge_lora_weights(transformer, args)
     if args.blocks_to_swap:
         swap_config = BlockSwapConfig(

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -388,7 +388,9 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         if args.blocks_to_swap is not None and args.blocks_to_swap > 48:
             raise ValueError("--blocks_to_swap for MiniMax-H3 must be <= 48")
         if getattr(args, "fp8_base", False) or getattr(args, "fp8_scaled", False):
-            raise ValueError("MiniMax-H3 R1 accepts only a BF16 transformer base; quantized bases are deferred to R2")
+            raise ValueError("MiniMax-H3 does not support fp8 transformer bases; use --convrot_int8 for a quantized base")
+        if args.convrot_int8_bwd == "int8" and not args.convrot_int8:
+            raise ValueError("--convrot_int8_bwd int8 requires --convrot_int8.")
         if getattr(args, "dit_dtype", None) not in {None, "bfloat16", "bf16"}:
             raise ValueError("MiniMax-H3 R1 requires --dit_dtype bfloat16")
         if (
@@ -736,6 +738,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             "ss_minimax_h3_audio_loss_weight": args.audio_loss_weight,
             "ss_minimax_h3_video_only": args.video_only,
             "ss_minimax_h3_target_modules": "attn.qkv_proj,attn.out_proj,mlp.fc1,mlp.fc2",
+            "ss_minimax_h3_convrot_int8": args.convrot_int8,
             "ss_minimax_h3_latent_cache_version": "2",
             "ss_minimax_h3_text_cache_version": "1",
         }
@@ -750,9 +753,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         loading_device: str,
         dit_weight_dtype: torch.dtype | None,
     ):
-        del accelerator
         if dit_weight_dtype not in {None, torch.bfloat16}:
-            raise ValueError("MiniMax-H3 R1 transformer weights must stay BF16")
+            raise ValueError("MiniMax-H3 transformer weights must stay BF16")
         return load_h3_transformer(
             dit_path,
             device=loading_device,
@@ -760,14 +762,21 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             attn_mode=attn_mode,
             split_attn=split_attn,
             disable_mmap=getattr(args, "disable_numpy_memmap", False),
+            convrot_int8=args.convrot_int8,
+            convrot_int8_bwd=args.convrot_int8_bwd,
+            # quantization runs on the accelerator device even when the weights load to CPU
+            # for block swap (cf. the Krea 2 calc-device fix in #1008)
+            quant_device=accelerator.device,
         )
 
     def compile_transformer(self, args, transformer):
+        # ConvRot int8 Linears are excluded from compile: the custom autograd.Function +
+        # autotuned Triton kernels are not dynamo-traceable (cf. krea2_train_network).
         return model_utils.compile_transformer(
             args,
             transformer,
             [transformer.blocks],
-            disable_linear=bool(self.blocks_to_swap),
+            disable_linear=bool(self.blocks_to_swap) or args.convrot_int8,
         )
 
     def scale_shift_latents(self, latents):
@@ -998,6 +1007,22 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         help="allow training samples outside the released 5-15 second duration range",
     )
     parser.add_argument("--dit_dtype", type=str, default=None, help="MiniMax-H3 DiT dtype; R1 requires bfloat16")
+    parser.add_argument(
+        "--convrot_int8",
+        action="store_true",
+        help="use ConvRot INT8 for the DiT base weights. Quantizes the per-block Linears (attn/mlp/adaln_proj) at "
+        "load time with Hadamard rotation + int8, or loads ComfyUI pre-quantized ConvRot INT8 checkpoints directly; "
+        "forward runs fused Triton int8 GEMM (requires triton / triton-windows; falls back to slower "
+        "dequantized bf16 matmul without it).",
+    )
+    parser.add_argument(
+        "--convrot_int8_bwd",
+        type=str,
+        default="bf16",
+        choices=["bf16", "int8"],
+        help="backward mode for --convrot_int8. bf16 (default): transient dequantized matmul, most accurate. "
+        "int8: reuse the fused int8 GEMM for grad_x (faster, quantizes gradients slightly, requires triton).",
+    )
     return parser
 
 

--- a/src/musubi_tuner/modules/convrot_int8_kernels.py
+++ b/src/musubi_tuner/modules/convrot_int8_kernels.py
@@ -155,11 +155,16 @@ def quantize_int8_rowwise(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
 def quantize_int8_convrot_weight(weight: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor]:
     """Offline ConvRot weight rotation followed by row-wise INT8 quantization.
 
+    The rotation is computed in float32 regardless of the weight dtype: rotating in
+    bf16 loses enough precision to shift ~9% of the int8 codes by ±1-2, while fp32
+    rotation reproduces ComfyUI's published pre-quantized checkpoints bit-exactly
+    (verified against the MiniMax-H3 INT8 ConvRot distribution).
+
     Returns:
         Tuple of (rotated quantized weight int8 [N, K], scale float32 [N, 1]).
     """
-    h = _build_hadamard(group_size, device=weight.device, dtype=weight.dtype)
-    weight_rot = _rotate_weight(weight, h, group_size)
+    h = _build_hadamard(group_size, device=weight.device, dtype=torch.float32)
+    weight_rot = _rotate_weight(weight.to(torch.float32), h, group_size)
     return quantize_int8_rowwise(weight_rot)
 
 

--- a/src/musubi_tuner/modules/convrot_int8_utils.py
+++ b/src/musubi_tuner/modules/convrot_int8_utils.py
@@ -15,8 +15,10 @@ LoRA targets modules by class name "Linear", block swap streams ``module.weight.
 of Linear-named modules, and compile exclusion also keys on the class name.
 """
 
+import json
+import math
 import os
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import torch
 import torch.nn as nn
@@ -41,8 +43,32 @@ logging.basicConfig(level=logging.INFO)
 
 CONVROT_GROUPSIZE = 256
 
+# ComfyUI pre-quantized checkpoint key suffixes: `.weight` (int8, rotated basis) +
+# `.weight_scale` (fp32 [N, 1]) + `.comfy_quant` (uint8 bytes of a JSON spec).
+COMFY_QUANT_SUFFIX = ".comfy_quant"
+COMFY_WEIGHT_SCALE_SUFFIX = ".weight_scale"
+COMFY_QUANT_FORMAT_INT8 = "int8_tensorwise"
 
-def quantize_weight_convrot(key: str, tensor: torch.Tensor, groupsize: int = CONVROT_GROUPSIZE):
+
+def _is_power_of_4(value: int) -> bool:
+    return value >= 4 and (value & (value - 1)) == 0 and math.log(value, 4) % 1 == 0
+
+
+def select_convrot_groupsize(in_features: int, allowed_groupsizes: Sequence[int]) -> Optional[int]:
+    """Pick the largest allowed group size that divides ``in_features``, or None.
+
+    The regular Hadamard construction only exists for power-of-4 sizes, so allowing a
+    smaller fallback (e.g. 64) extends coverage to layers whose in_features is not a
+    multiple of 256 (H3's adaln_proj: 2688 = 42 * 64). This rule reproduces ComfyUI's
+    published group size choices exactly.
+    """
+    for groupsize in sorted(allowed_groupsizes, reverse=True):
+        if in_features % groupsize == 0:
+            return groupsize
+    return None
+
+
+def quantize_weight_convrot(key: str, tensor: torch.Tensor, allowed_groupsizes: Sequence[int] = (CONVROT_GROUPSIZE,)):
     """Quantize a single weight tensor with ConvRot INT8, or return None if not applicable.
 
     The quantization is always done with the eager implementation: it is deterministic
@@ -50,16 +76,47 @@ def quantize_weight_convrot(key: str, tensor: torch.Tensor, groupsize: int = CON
     across environments.
 
     Returns:
-        (quantized int8 [N, K] in rotated basis, scale float32 [N, 1]), or None if the
-        tensor is not a 2D weight or its in_features is not divisible by groupsize.
+        (quantized int8 [N, K] in rotated basis, scale float32 [N, 1], groupsize), or
+        None if the tensor is not a 2D weight or its in_features is not divisible by
+        any allowed groupsize.
     """
     if tensor.ndim != 2:
         logger.info(f"Skipping ConvRot INT8 for {key}: not a 2D weight (ndim={tensor.ndim})")
         return None
-    if tensor.shape[1] % groupsize != 0:
-        logger.info(f"Skipping ConvRot INT8 for {key}: in_features {tensor.shape[1]} not divisible by {groupsize}")
+    groupsize = select_convrot_groupsize(tensor.shape[1], allowed_groupsizes)
+    if groupsize is None:
+        logger.info(f"Skipping ConvRot INT8 for {key}: in_features {tensor.shape[1]} not divisible by any of {allowed_groupsizes}")
         return None
-    return quantize_int8_convrot_weight(tensor, groupsize)
+    quantized_weight, scale_tensor = quantize_int8_convrot_weight(tensor, groupsize)
+    return quantized_weight, scale_tensor, groupsize
+
+
+def parse_comfy_quant_spec(key: str, tensor: torch.Tensor) -> dict:
+    """Decode and validate a ``.comfy_quant`` JSON spec tensor (uint8 bytes).
+
+    Only ConvRot INT8 (``int8_tensorwise`` + ``convrot``) is supported; other formats
+    (e.g. nvfp4) raise with a clear message.
+    """
+    if tensor.dtype != torch.uint8 or tensor.ndim != 1:
+        raise ValueError(f"Invalid comfy_quant tensor for {key}: expected 1D uint8, got {tensor.dtype} ndim={tensor.ndim}")
+    try:
+        spec = json.loads(bytes(tensor.tolist()).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise ValueError(f"Invalid comfy_quant JSON for {key}: {e}") from e
+    if not isinstance(spec, dict):
+        raise ValueError(f"Invalid comfy_quant spec for {key}: expected a JSON object, got {type(spec).__name__}")
+
+    quant_format = spec.get("format")
+    if quant_format != COMFY_QUANT_FORMAT_INT8 or not spec.get("convrot"):
+        raise ValueError(
+            f"Unsupported comfy_quant format for {key}: {spec}. Only ConvRot INT8"
+            f' ("{COMFY_QUANT_FORMAT_INT8}" with "convrot": true) is supported.'
+            f" / {key} の comfy_quant 形式はサポートされていません。ConvRot INT8 のみ対応しています。"
+        )
+    groupsize = spec.get("convrot_groupsize")
+    if not isinstance(groupsize, int) or not _is_power_of_4(groupsize):
+        raise ValueError(f"Invalid convrot_groupsize for {key}: {groupsize!r} (must be a power of 4, e.g. 64 or 256)")
+    return spec
 
 
 class ConvRotInt8Quantizer:
@@ -67,17 +124,33 @@ class ConvRotInt8Quantizer:
 
     Passed as ``quantizer`` to ``load_safetensors_with_lora_and_fp8``; carries its own
     streaming loader so the fp8 path stays untouched.
+
+    Two sources are supported per tensor, decided on the fly:
+
+    - bf16/fp16/fp32 target weights are dynamically quantized (rotation + row-wise INT8),
+      picking the largest ``allowed_groupsizes`` entry that divides in_features.
+    - Pre-quantized ComfyUI layers (int8 ``.weight`` + ``.weight_scale`` + ``.comfy_quant``)
+      are converted in place: the scale is renamed to ``.scale_weight`` and the group size
+      is taken from the JSON spec. The file dictates which layers these are, independent
+      of the target/exclude patterns.
+
+    ``module_groupsizes`` maps module paths to their group size after loading; pass it to
+    ``apply_convrot_int8_monkey_patch`` so mixed group sizes dispatch correctly.
     """
 
     def __init__(
         self,
         target_layer_keys: Optional[List[str]] = None,
         exclude_layer_keys: Optional[List[str]] = None,
-        groupsize: int = CONVROT_GROUPSIZE,
+        allowed_groupsizes: Sequence[int] = (CONVROT_GROUPSIZE,),
     ):
+        for groupsize in allowed_groupsizes:
+            if not _is_power_of_4(groupsize):
+                raise ValueError(f"ConvRot group sizes must be powers of 4, got {groupsize}")
         self.target_layer_keys = target_layer_keys
         self.exclude_layer_keys = exclude_layer_keys
-        self.groupsize = groupsize
+        self.allowed_groupsizes = tuple(allowed_groupsizes)
+        self.module_groupsizes: Dict[str, int] = {}
 
     def is_target_key(self, key: str) -> bool:
         is_target = (self.target_layer_keys is None or any(pattern in key for pattern in self.target_layer_keys)) and key.endswith(
@@ -98,25 +171,71 @@ class ConvRotInt8Quantizer:
         """Load state dict from safetensors files, quantizing target weights to ConvRot INT8.
 
         Same streaming contract as load_safetensors_with_fp8_optimization: the LoRA merge
-        weight_hook runs on the raw (bf16) weight before quantization.
+        weight_hook runs on the raw (bf16) weight before quantization. Pre-quantized
+        ComfyUI ConvRot layers are converted to the Musubi layout instead; they cannot be
+        combined with a LoRA merge hook (INT8 weights cannot be merged into).
         """
         optimized_count = 0
+        prequantized_count = 0
         state_dict = {}
         for model_file in model_files:
             with MemoryEfficientSafeOpen(model_file, disable_numpy_memmap=disable_numpy_memmap) as original_f:
                 f = TensorWeightAdapter(weight_transform_hooks, original_f) if weight_transform_hooks is not None else original_f
 
                 keys = f.keys()
+
+                # Pre-scan the tiny `.comfy_quant` spec tensors so the per-module group size
+                # is known before the (possibly earlier-iterated) weight/scale keys arrive.
+                prequantized_groupsizes = {}
+                for key in keys:
+                    if key.endswith(COMFY_QUANT_SUFFIX):
+                        module_path = key[: -len(COMFY_QUANT_SUFFIX)]
+                        spec = parse_comfy_quant_spec(key, f.get_tensor(key))
+                        prequantized_groupsizes[module_path] = spec["convrot_groupsize"]
+                if prequantized_groupsizes and weight_hook is not None:
+                    raise ValueError(
+                        f"Cannot merge LoRA weights into pre-quantized ConvRot INT8 checkpoint {model_file}."
+                        " Use the original BF16 weights to merge LoRA at load time, or apply the LoRA at runtime."
+                        f" / 事前量子化済みConvRot INT8チェックポイント {model_file} にはLoRAをマージできません。"
+                        "BF16の元重みを使用してロード時マージするか、LoRAを実行時適用してください。"
+                    )
+
                 for key in tqdm(keys, desc=f"Loading {os.path.basename(model_file)}", unit="key"):
+                    if key.endswith(COMFY_QUANT_SUFFIX):
+                        continue  # consumed in the pre-scan, not a model tensor
+
                     value = f.get_tensor(key)
                     original_device = value.device  # usually cpu
+                    passthrough_device = calc_device if (calc_device is not None and move_to_device) else original_device
+
+                    if key.endswith(COMFY_WEIGHT_SCALE_SUFFIX):
+                        module_path = key[: -len(COMFY_WEIGHT_SCALE_SUFFIX)]
+                        if module_path not in prequantized_groupsizes:
+                            raise ValueError(f"Found {key} without a matching {module_path}{COMFY_QUANT_SUFFIX} spec")
+                        # rename to the Musubi layout; the fp32 [N, 1] shape is shared as-is
+                        state_dict[module_path + ".scale_weight"] = value.to(device=passthrough_device, dtype=torch.float32)
+                        continue
+
+                    module_path = key[: -len(".weight")] if key.endswith(".weight") else None
+                    if module_path is not None and module_path in prequantized_groupsizes:
+                        if value.dtype != torch.int8:
+                            raise ValueError(f"Pre-quantized ConvRot layer {key} must be int8, got {value.dtype}")
+                        groupsize = prequantized_groupsizes[module_path]
+                        if value.shape[1] % groupsize != 0:
+                            raise ValueError(
+                                f"Pre-quantized ConvRot layer {key}: in_features {value.shape[1]} not divisible by"
+                                f" group size {groupsize}"
+                            )
+                        self.module_groupsizes[module_path] = groupsize
+                        state_dict[key] = value.to(passthrough_device)
+                        prequantized_count += 1
+                        continue
 
                     if weight_hook is not None:
                         value = weight_hook(key, value, keep_on_calc_device=(calc_device is not None))
 
                     if not self.is_target_key(key):
-                        target_device = calc_device if (calc_device is not None and move_to_device) else original_device
-                        state_dict[key] = value.to(target_device)
+                        state_dict[key] = value.to(passthrough_device)
                         continue
 
                     if calc_device is not None:
@@ -124,20 +243,21 @@ class ConvRotInt8Quantizer:
 
                     if value.dtype.itemsize == 1:
                         raise ValueError(
-                            f"Layer {key} is already in {value.dtype} format. Loading pre-quantized weights with"
-                            " --convrot_int8 is not supported yet. Please use fp16/bf16/float32 model weights."
-                            + f" / レイヤー {key} は既に{value.dtype}形式です。事前量子化済み重みの --convrot_int8 での"
-                            "読み込みは未対応です。FP16/BF16/Float32のモデル重みを使用してください。"
+                            f"Layer {key} is already in {value.dtype} format but has no {COMFY_QUANT_SUFFIX} spec."
+                            " Only ComfyUI ConvRot INT8 pre-quantized checkpoints or fp16/bf16/float32 weights are"
+                            f" supported. / レイヤー {key} は既に{value.dtype}形式ですが {COMFY_QUANT_SUFFIX} がありません。"
+                            "ComfyUI ConvRot INT8形式の事前量子化済み重み、またはFP16/BF16/Float32の重みを使用してください。"
                         )
 
-                    result = quantize_weight_convrot(key, value, self.groupsize)
+                    result = quantize_weight_convrot(key, value, self.allowed_groupsizes)
                     if result is None:
                         # leave the layer unquantized (bf16)
                         if not move_to_device:
                             value = value.to(original_device)
                         state_dict[key] = value
                         continue
-                    quantized_weight, scale_tensor = result
+                    quantized_weight, scale_tensor, groupsize = result
+                    self.module_groupsizes[module_path] = groupsize
 
                     scale_key = key.replace(".weight", ".scale_weight")
                     assert key != scale_key, "weight key and scale key must be different"
@@ -155,7 +275,10 @@ class ConvRotInt8Quantizer:
                     if calc_device is not None and optimized_count % 10 == 0:
                         clean_memory_on_device(calc_device)
 
-        logger.info(f"Number of ConvRot INT8 optimized Linear layers: {optimized_count}")
+        logger.info(
+            f"Number of ConvRot INT8 Linear layers: {optimized_count} dynamically quantized,"
+            f" {prequantized_count} loaded pre-quantized"
+        )
         return state_dict
 
 
@@ -220,7 +343,13 @@ def convrot_int8_linear_forward_patch(self: nn.Linear, x):
     return ConvRotInt8LinearFn.apply(x, self.weight, self.scale_weight, self.bias, self._convrot_groupsize, self._convrot_bwd_mode)
 
 
-def apply_convrot_int8_monkey_patch(model, optimized_state_dict, bwd_mode: str = "bf16", groupsize: int = CONVROT_GROUPSIZE):
+def apply_convrot_int8_monkey_patch(
+    model,
+    optimized_state_dict,
+    bwd_mode: str = "bf16",
+    groupsize: int = CONVROT_GROUPSIZE,
+    groupsize_map: Optional[Dict[str, int]] = None,
+):
     """
     Apply monkey patching to a model using a ConvRot INT8 optimized state dict.
 
@@ -229,7 +358,10 @@ def apply_convrot_int8_monkey_patch(model, optimized_state_dict, bwd_mode: str =
         optimized_state_dict (dict): state dict produced by ConvRotInt8Quantizer
         bwd_mode (str): "bf16" (transient dequant, safe default) or "int8" (quantizes
             gradients, faster, requires triton)
-        groupsize (int): ConvRot group size
+        groupsize (int): ConvRot group size for modules not listed in ``groupsize_map``
+        groupsize_map (Optional[Dict[str, int]]): per-module group sizes
+            (``ConvRotInt8Quantizer.module_groupsizes``); needed when a checkpoint mixes
+            group sizes (e.g. H3: 256 for attn/mlp, 64 for adaln_proj)
 
     Returns:
         nn.Module: The patched model (same instance, modified in-place)
@@ -259,7 +391,7 @@ def apply_convrot_int8_monkey_patch(model, optimized_state_dict, bwd_mode: str =
         if isinstance(module, nn.Linear) and name in patched_module_paths:
             # register the scale_weight as a buffer to load the state_dict
             module.register_buffer("scale_weight", torch.ones(scale_shape_info[name], dtype=torch.float32))
-            module._convrot_groupsize = groupsize
+            module._convrot_groupsize = groupsize_map.get(name, groupsize) if groupsize_map is not None else groupsize
             module._convrot_bwd_mode = bwd_mode
 
             def new_forward(self, x):

--- a/tests/test_krea2_convrot_int8.py
+++ b/tests/test_krea2_convrot_int8.py
@@ -10,7 +10,6 @@ CPU tests exercise the eager fallback (exact math up to rounding); CUDA tests
 exercise the fused Triton kernels when available.
 """
 
-import os
 from types import SimpleNamespace
 
 import pytest
@@ -59,9 +58,10 @@ def test_quantize_weight_convrot_skips_indivisible_and_non_2d():
     assert quantize_weight_convrot("x.weight", torch.randn(300)) is None  # not 2D
     result = quantize_weight_convrot("x.weight", torch.randn(8, K))
     assert result is not None
-    wq, ws = result
+    wq, ws, gs = result
     assert wq.dtype == torch.int8 and wq.shape == (8, K)
     assert ws.dtype == torch.float32 and ws.shape == (8, 1)
+    assert gs == GS
 
 
 def test_quantize_dequant_roundtrip_error_is_small():

--- a/tests/test_minimax_h3_convrot_int8.py
+++ b/tests/test_minimax_h3_convrot_int8.py
@@ -1,0 +1,301 @@
+"""Tests for MiniMax-H3 ConvRot INT8 base-weight quantization (R2).
+
+Covers the H3-specific pieces on top of tests/test_krea2_convrot_int8.py: the
+per-layer group size selection (256 for attn/mlp, 64 for adaln_proj whose
+in_features is not a multiple of 256), the ComfyUI pre-quantized checkpoint
+conversion (``weight``/``weight_scale``/``comfy_quant`` triplets), and the H3
+transformer loader wiring (quantization scope, strict load, patched forward).
+"""
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import load_file, save_file
+
+from musubi_tuner.minimax_h3.model import (
+    H3_CONVROT_INT8_ALLOWED_GROUPSIZES,
+    H3_CONVROT_INT8_EXCLUDE_KEYS,
+    H3_CONVROT_INT8_TARGET_KEYS,
+    MiniMaxH3Config,
+    MiniMaxH3Model,
+    _load_h3_transformer_convrot_int8,
+)
+from musubi_tuner.minimax_h3.packing import H3VideoGeometry, build_h3_layout
+from musubi_tuner.modules.convrot_int8_utils import (
+    ConvRotInt8Quantizer,
+    parse_comfy_quant_spec,
+    quantize_weight_convrot,
+    select_convrot_groupsize,
+)
+from musubi_tuner.modules.convrot_int8_kernels import quantize_int8_convrot_weight
+
+
+def _convrot_config(num_layers: int = 1) -> MiniMaxH3Config:
+    # hidden_size=256 puts attn/mlp at group size 256 while time_embed_dim=64 puts
+    # adaln_proj at group size 64 — the same mixed layout as the published checkpoint.
+    return MiniMaxH3Config(
+        hidden_size=256,
+        num_layers=num_layers,
+        token_refiner_num_layers=1,
+        num_attention_heads=2,
+        attention_head_dim=128,
+        ffn_hidden_size=256,
+        text_dim=12,
+        timestep_input_dim=4,
+        time_embed_hidden_size=16,
+        time_embed_dim=64,
+        rope_inv_freq_len=16,
+    )
+
+
+def _make_quantizer() -> ConvRotInt8Quantizer:
+    return ConvRotInt8Quantizer(
+        H3_CONVROT_INT8_TARGET_KEYS,
+        H3_CONVROT_INT8_EXCLUDE_KEYS,
+        allowed_groupsizes=H3_CONVROT_INT8_ALLOWED_GROUPSIZES,
+    )
+
+
+def _save_tiny_bf16_checkpoint(path, config: MiniMaxH3Config, seed: int = 0) -> dict:
+    torch.manual_seed(seed)
+    model = MiniMaxH3Model(config, dtype=torch.bfloat16)
+    state = {key: value.contiguous() for key, value in model.state_dict().items()}
+    save_file(state, str(path))
+    return state
+
+
+def _comfy_quant_tensor(groupsize: int) -> torch.Tensor:
+    spec = {"format": "int8_tensorwise", "convrot": True, "convrot_groupsize": groupsize}
+    return torch.tensor(list(json.dumps(spec).encode("utf-8")), dtype=torch.uint8)
+
+
+def _save_comfy_prequantized_checkpoint(path, bf16_state: dict, quantizer: ConvRotInt8Quantizer) -> dict:
+    """Quantize the target layers of a bf16 state dict into the ComfyUI layout."""
+    out = {}
+    for key, value in bf16_state.items():
+        if quantizer.is_target_key(key):
+            result = quantize_weight_convrot(key, value, quantizer.allowed_groupsizes)
+            assert result is not None, key
+            wq, ws, gs = result
+            module_path = key[: -len(".weight")]
+            out[key] = wq
+            out[module_path + ".weight_scale"] = ws
+            out[module_path + ".comfy_quant"] = _comfy_quant_tensor(gs)
+        else:
+            out[key] = value.contiguous()
+    save_file(out, str(path))
+    return out
+
+
+def _load_tiny_convrot(files, config: MiniMaxH3Config) -> MiniMaxH3Model:
+    return _load_h3_transformer_convrot_int8(
+        files,
+        config,
+        device=torch.device("cpu"),
+        quant_device=torch.device("cpu"),
+        bwd_mode="bf16",
+        attn_mode="torch",
+        split_attn=False,
+        disable_mmap=False,
+    )
+
+
+def _t2_inputs(config: MiniMaxH3Config, text_length: int = 3) -> dict:
+    layout = build_h3_layout(
+        task="t2va",
+        text_length=text_length,
+        target_video=H3VideoGeometry(2, 4, 4),
+        target_audio_frames=8,
+    )
+    token_tags = torch.tensor([1, 0, 1][:text_length], dtype=torch.int64)
+    return {
+        "video_latents": torch.randn(1, 24, 2, 4, 4),
+        "audio_latents": torch.randn(1, 32, 2, 8),
+        "text_hidden_states": torch.randn(1, text_length, config.text_dim),
+        "text_token_tags": token_tags.unsqueeze(0),
+        "layout": layout,
+        "model_t_video": torch.full((1,), 0.25),
+        "model_t_audio": torch.full((1,), 0.75),
+    }
+
+
+# ---------------------------------------------------------------------------
+# group size selection / comfy_quant parsing
+# ---------------------------------------------------------------------------
+
+
+def test_select_convrot_groupsize_reproduces_comfyui_choices():
+    allowed = H3_CONVROT_INT8_ALLOWED_GROUPSIZES
+    assert select_convrot_groupsize(5376, allowed) == 256  # qkv_proj / fc1
+    assert select_convrot_groupsize(7168, allowed) == 256  # out_proj
+    assert select_convrot_groupsize(14336, allowed) == 256  # fc2
+    assert select_convrot_groupsize(2688, allowed) == 64  # adaln_proj
+    assert select_convrot_groupsize(300, allowed) is None
+    assert select_convrot_groupsize(2688, (256,)) is None  # Krea 2 default is unchanged
+
+
+def test_quantizer_rejects_non_power_of_4_groupsize():
+    with pytest.raises(ValueError, match="powers of 4"):
+        ConvRotInt8Quantizer(allowed_groupsizes=(128,))
+
+
+def test_parse_comfy_quant_spec_accepts_the_published_layout():
+    spec = parse_comfy_quant_spec("x.comfy_quant", _comfy_quant_tensor(64))
+    assert spec == {"format": "int8_tensorwise", "convrot": True, "convrot_groupsize": 64}
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"format": "nvfp4"},
+        {"format": "int8_tensorwise", "convrot": False, "convrot_groupsize": 256},
+        {"format": "int8_tensorwise", "convrot": True, "convrot_groupsize": 128},
+    ],
+)
+def test_parse_comfy_quant_spec_rejects_unsupported_specs(spec):
+    raw = torch.tensor(list(json.dumps(spec).encode("utf-8")), dtype=torch.uint8)
+    with pytest.raises(ValueError):
+        parse_comfy_quant_spec("x.comfy_quant", raw)
+
+
+def test_parse_comfy_quant_spec_rejects_invalid_json():
+    raw = torch.tensor(list(b"not json"), dtype=torch.uint8)
+    with pytest.raises(ValueError, match="Invalid comfy_quant JSON"):
+        parse_comfy_quant_spec("x.comfy_quant", raw)
+
+
+# ---------------------------------------------------------------------------
+# dynamic quantization of a tiny H3 checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_quantization_covers_the_h3_scope_with_mixed_groupsizes(tmp_path):
+    config = _convrot_config()
+    checkpoint = tmp_path / "tiny_bf16.safetensors"
+    _save_tiny_bf16_checkpoint(checkpoint, config)
+
+    model = _load_tiny_convrot([checkpoint], config)
+
+    block = model.blocks[0]
+    for module, groupsize in (
+        (block.attn.qkv_proj, 256),
+        (block.attn.out_proj, 256),
+        (block.mlp.fc1, 256),
+        (block.mlp.fc2, 256),
+        (block.adaln_proj.linear, 64),
+    ):
+        assert module.weight.dtype == torch.int8
+        assert module.scale_weight.dtype == torch.float32
+        assert module.scale_weight.shape == (module.weight.shape[0], 1)
+        assert module._convrot_groupsize == groupsize
+        assert not module.weight.requires_grad
+
+    # token_refiner and final_layer stay BF16 and unpatched
+    refiner_block = model.token_refiner.blocks[0]
+    assert refiner_block.attn.qkv_proj.weight.dtype == torch.bfloat16
+    assert not hasattr(refiner_block.attn.qkv_proj, "scale_weight")
+    assert model.final_layer.adaln_proj.linear.weight.dtype == torch.bfloat16
+    assert not hasattr(model.final_layer.adaln_proj.linear, "scale_weight")
+
+
+def test_patched_tiny_model_forward_runs_and_stays_close_to_bf16(tmp_path):
+    config = _convrot_config()
+    checkpoint = tmp_path / "tiny_bf16.safetensors"
+    _save_tiny_bf16_checkpoint(checkpoint, config)
+
+    reference = MiniMaxH3Model(config, dtype=torch.bfloat16)
+    reference.load_state_dict(load_file(str(checkpoint)), strict=True, assign=True)
+    reference.eval().requires_grad_(False)
+
+    model = _load_tiny_convrot([checkpoint], config)
+
+    torch.manual_seed(1)
+    inputs = _t2_inputs(config)
+    with torch.no_grad():
+        quantized_out = model(**inputs)
+        reference_out = reference(**inputs)
+
+    for quantized, ref in ((quantized_out.video, reference_out.video), (quantized_out.audio, reference_out.audio)):
+        assert quantized.shape == ref.shape
+        assert torch.isfinite(quantized).all()
+        relerr = ((quantized.float() - ref.float()).norm() / ref.float().norm()).item()
+        assert relerr < 0.15  # int8 weight + activation-free eager path on a random tiny model
+
+
+# ---------------------------------------------------------------------------
+# ComfyUI pre-quantized checkpoints
+# ---------------------------------------------------------------------------
+
+
+def test_prequantized_checkpoint_loads_bit_identical_to_dynamic_quantization(tmp_path):
+    config = _convrot_config()
+    bf16_path = tmp_path / "tiny_bf16.safetensors"
+    prequant_path = tmp_path / "tiny_int8_convrot.safetensors"
+    bf16_state = _save_tiny_bf16_checkpoint(bf16_path, config)
+    _save_comfy_prequantized_checkpoint(prequant_path, bf16_state, _make_quantizer())
+
+    dynamic_model = _load_tiny_convrot([bf16_path], config)
+    prequant_model = _load_tiny_convrot([prequant_path], config)
+
+    dynamic_sd = dynamic_model.state_dict()
+    prequant_sd = prequant_model.state_dict()
+    assert set(dynamic_sd) == set(prequant_sd)
+    for key in dynamic_sd:
+        assert dynamic_sd[key].dtype == prequant_sd[key].dtype, key
+        assert torch.equal(dynamic_sd[key], prequant_sd[key]), key
+
+    block = prequant_model.blocks[0]
+    assert block.adaln_proj.linear._convrot_groupsize == 64
+    assert block.mlp.fc1._convrot_groupsize == 256
+
+
+def test_prequantized_checkpoint_with_lora_merge_hook_raises(tmp_path):
+    config = _convrot_config()
+    bf16_path = tmp_path / "tiny_bf16.safetensors"
+    prequant_path = tmp_path / "tiny_int8_convrot.safetensors"
+    bf16_state = _save_tiny_bf16_checkpoint(bf16_path, config)
+    _save_comfy_prequantized_checkpoint(prequant_path, bf16_state, _make_quantizer())
+
+    with pytest.raises(ValueError, match="Cannot merge LoRA"):
+        _make_quantizer().load_and_quantize(
+            [str(prequant_path)],
+            calc_device=None,
+            weight_hook=lambda key, value, keep_on_calc_device=False: value,
+        )
+
+
+def test_int8_weight_without_comfy_quant_spec_raises(tmp_path):
+    path = tmp_path / "orphan_int8.safetensors"
+    save_file({"blocks.0.mlp.fc1.weight": torch.zeros(8, 256, dtype=torch.int8)}, str(path))
+
+    with pytest.raises(ValueError, match="comfy_quant"):
+        _make_quantizer().load_and_quantize([str(path)], calc_device=None)
+
+
+def test_weight_scale_without_comfy_quant_spec_raises(tmp_path):
+    path = tmp_path / "orphan_scale.safetensors"
+    save_file({"blocks.0.mlp.fc1.weight_scale": torch.ones(8, 1)}, str(path))
+
+    with pytest.raises(ValueError, match="without a matching"):
+        _make_quantizer().load_and_quantize([str(path)], calc_device=None)
+
+
+def test_prequantized_module_groupsizes_follow_the_file_spec(tmp_path):
+    # the file's spec wins even for a layer the dynamic rule would put at 256
+    path = tmp_path / "gs64.safetensors"
+    weight, scale = quantize_int8_convrot_weight(torch.randn(8, 256, dtype=torch.float32), 64)
+    save_file(
+        {
+            "blocks.0.mlp.fc1.weight": weight,
+            "blocks.0.mlp.fc1.weight_scale": scale,
+            "blocks.0.mlp.fc1.comfy_quant": _comfy_quant_tensor(64),
+        },
+        str(path),
+    )
+
+    quantizer = _make_quantizer()
+    state = quantizer.load_and_quantize([str(path)], calc_device=None)
+    assert quantizer.module_groupsizes == {"blocks.0.mlp.fc1": 64}
+    assert set(state) == {"blocks.0.mlp.fc1.weight", "blocks.0.mlp.fc1.scale_weight"}
+    assert state["blocks.0.mlp.fc1.weight"].dtype == torch.int8

--- a/tests/test_minimax_h3_model.py
+++ b/tests/test_minimax_h3_model.py
@@ -135,13 +135,18 @@ def test_published_transformer_metadata_is_parsed_strictly():
     assert actual == MiniMaxH3Config()
     with pytest.raises(ValueError, match=r"hidden_size.*5376.*4096"):
         parse_h3_transformer_config({"config": json.dumps({"transformer": {**released, "hidden_size": 4096}})})
-    with pytest.raises(ValueError, match="deferred to R2"):
+    quantized_metadata = {
+        "config": json.dumps({"transformer": released}),
+        "format": "int8_tensorwise",
+        "convrot": "true",
+    }
+    with pytest.raises(ValueError, match="--convrot_int8"):
+        parse_h3_transformer_config(quantized_metadata)
+    assert parse_h3_transformer_config(quantized_metadata, allow_convrot_int8=True) == MiniMaxH3Config()
+    with pytest.raises(ValueError, match="not supported"):
         parse_h3_transformer_config(
-            {
-                "config": json.dumps({"transformer": released}),
-                "format": "int8_tensorwise",
-                "convrot": "true",
-            }
+            {"config": json.dumps({"transformer": released}), "format": "nvfp4"},
+            allow_convrot_int8=True,
         )
 
 
@@ -528,7 +533,7 @@ def test_checkpoint_loader_rejects_missing_rope_inv_freq(tmp_path: Path):
         )
 
 
-def test_checkpoint_loader_rejects_quantized_weight_pairs_in_r1(tmp_path: Path):
+def test_checkpoint_loader_rejects_quantized_weight_pairs_without_convrot_flag(tmp_path: Path):
     class Tiny(nn.Module):
         def __init__(self):
             super().__init__()
@@ -543,5 +548,5 @@ def test_checkpoint_loader_rejects_quantized_weight_pairs_in_r1(tmp_path: Path):
         checkpoint,
     )
 
-    with pytest.raises(ValueError, match="deferred to R2"):
+    with pytest.raises(ValueError, match="--convrot_int8"):
         load_safetensors_module(Tiny, [checkpoint], device="cpu", dtype=None)

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -261,6 +261,7 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         "h3_audio_cond_clean": 1.0,
         "lora_weight": None,
         "lora_multiplier": None,
+        "convrot_int8": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -162,6 +162,8 @@ def _trainer_args(**overrides):
         "task": "t2va",
         "video_only": False,
         "audio_loss_weight": 1.0,
+        "convrot_int8": False,
+        "convrot_int8_bwd": "bf16",
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -999,6 +1001,7 @@ def test_h3_training_metadata_records_task_scheduler_and_target_policy():
         "ss_minimax_h3_audio_loss_weight": 1.0,
         "ss_minimax_h3_video_only": False,
         "ss_minimax_h3_target_modules": "attn.qkv_proj,attn.out_proj,mlp.fc1,mlp.fc2",
+        "ss_minimax_h3_convrot_int8": False,
         "ss_minimax_h3_latent_cache_version": "2",
         "ss_minimax_h3_text_cache_version": "1",
     }


### PR DESCRIPTION
## Summary

Adds ConvRot INT8 ([arXiv:2512.03673](https://arxiv.org/abs/2512.03673)) quantized base weights to MiniMax-H3, for both LoRA training and generation. This is the first architecture rollout of the ConvRot infrastructure from #1008 (Krea 2), and the first half of the H3 R2 quantization work carried over from #1018 — NVFP4 and text-encoder quantization will follow in a separate PR.

Two base artifacts are accepted, and they produce **bit-identical models**:

- **BF16 checkpoints** — quantized on the fly during the streaming load (~32 s on GPU).
- **ComfyUI pre-quantized ConvRot INT8 checkpoints** (`weight` int8 + `weight_scale` + `comfy_quant` tensors) — converted to the Musubi layout during the same streaming load (~25 s). Musubi's dynamic quantization reproduces the published ComfyUI INT8 ConvRot distribution exactly on all 250 quantized layers (verified bit-for-bit against the real H3 weights).

## Implementation

- `ConvRotInt8Quantizer` gains `allowed_groupsizes` (power-of-4 Hadamard constraint; the largest dividing value is selected) and a per-module `module_groupsizes` map, plus streaming conversion of ComfyUI pre-quantized tensors. `apply_convrot_int8_monkey_patch` accepts a `groupsize_map`.
- Fixed `quantize_int8_convrot_weight` to run the Hadamard rotation in fp32 — with bf16 rotation ~9% of int8 codes were off by ±1–2 vs. the ComfyUI distribution; fp32 makes all 250 layers bit-exact, which is what makes the dynamic and pre-quantized routes interchangeable.
- H3 wiring: `--convrot_int8` / `--convrot_int8_bwd {bf16,int8}` for training, `--convrot_int8` for generation. Quantization scope mirrors the ComfyUI distribution: the 5 Linears per main DiT block (incl. `adaln_proj` at group size 64; others 256). Token refiner / final layer / embedders stay BF16/FP32. Base weights shrink ~66 GB → ~34 GB.
- Generation with `--lora_weight` merges the LoRA into BF16 during the streaming load and quantizes the merged result; merging into a pre-quantized int8 checkpoint is rejected with an explicit bilingual error.
- Krea 2 gains the same pre-quantized ComfyUI checkpoint loading (verified with a real 224-layer file).
- Docs: new ConvRot INT8 section in `docs/minimax_h3.md`, pre-quantized loading note in `docs/krea2.md`.

## Verification

`tests/test_minimax_h3_convrot_int8.py` (14 tests: mixed group sizes on a tiny H3, dynamic↔pre-quantized bit equality, guard paths). Full suite 299 passed + ruff clean.

Real-weight smoke on a 96 GB GPU (t2va, 384x224x39, LoRA dim 16, gradient checkpointing):

| Run | Result |
|---|---|
| Dynamic quantization training (BF16 source) | 250 layers quantized, 1.54 s/it — same speed as the BF16 baseline |
| Pre-quantized training (ComfyUI checkpoint) | 250 layers loaded pre-quantized, loss consistent with dynamic |
| Classic block swap 48 | 12.7 s/it vs 27 s/it BF16 — **~2x faster** |
| `--block_swap_h2d_only` + 32 | ~4.1 s/it vs ~8 s/it BF16 — **~2x faster** |
| `--convrot_int8_bwd int8` | 1.46 s/it, loss matches bf16-backward to 3 digits |
| Dynamic vs pre-quantized generation (same seed) | **byte-identical mp4 output** — end-to-end equivalence gate |
| LoRA generation (streaming merge → quantize) | output clearly diverges from baseline, consistent with training-time samples |
| Pre-quantized + LoRA merge | explicit `ValueError` as designed |

Block swap training is transfer-bound, so halving the weight bytes roughly halves the step time (speedup ratio ~0.47 matches the 34/66 model-size ratio) — INT8 here buys both the memory saving and a ~2x block-swap training speedup.

Quality was validated end-to-end previously (fixed seed/GPU A/B): DiT INT8 ConvRot at 10.8/255 against a ~8/255 measurement noise floor, and full training settings complete on a 24 GB RTX 3090.

## Not in this PR

- NVFP4 artifact loading and text-encoder (Qwen3-VL) quantization — the other half of R2, separate PR.
- Pruned AdaLN, multi-GPU (DDP) validation for ConvRot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)