### PR TITLE
Remove MiniMax-H3 overrides of NetworkTrainer internal methods

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -167,19 +167,19 @@ Two training arguments control audio supervision:
 - `--video_only` disables audio supervision entirely (audio loss weight 0 for all samples). The model still attends to the real audio latents as context, which matches the inference-time distribution where audio tokens are always generated audio, never silence.
 - `--audio_loss_weight` (default 1.0) scales the audio loss term for supervised samples, e.g. to rebalance a small audio loss against the video loss.
 
-The trainer logs the supervised fraction as `supervised_audio_fraction` and saves it as `ss_minimax_h3_supervised_audio_fraction`, along with `ss_minimax_h3_audio_loss_weight` and `ss_minimax_h3_video_only`. It also records `ss_minimax_h3_loss_policy=video_mean_plus_weighted_audio_mean` and `ss_minimax_h3_audio_supervision=presence_gated_training_weight`. H3 enforces uniform base-time sampling, no generic SD3 loss weighting, and independent video/audio shifts of 12 and 3.
+The latent caching script logs the supervised fraction as `supervised_audio_fraction` in its end-of-run summary, and warns when no cached item has real audio. The trainer records the fraction it actually observed during training as `ss_minimax_h3_supervised_audio_fraction` (exact once a full epoch has run), along with `ss_minimax_h3_audio_loss_weight` and `ss_minimax_h3_video_only`, and warns at the end of the first epoch if audio supervision is enabled but no sample with real audio was seen. It also records `ss_minimax_h3_loss_policy=video_mean_plus_weighted_audio_mean` and `ss_minimax_h3_audio_supervision=presence_gated_training_weight`. H3 enforces uniform base-time sampling, no generic SD3 loss weighting, and independent video/audio shifts of 12 and 3.
 
 Zero audio loss does not preserve the base model's audio behavior. H3 is single-stream, and these LoRA targets modify the same attention and MLP weights used by video and audio tokens. A `--video_only` or low-`supervised_audio_fraction` LoRA can therefore produce audio worse than the base model; the risk generally increases with adapter capacity/strength and training exposure, although degradation is not guaranteed to be monotonic. Treat audio from a fully video-only LoRA as unconstrained output.
 
 Block swap supports up to 48 of the 50 main blocks. `--block_swap_h2d_only` is also supported for frozen-base LoRA training and requires `--gradient_checkpointing`.
 
-MiniMax-H3 requires `batch_size = 1` in every H3 dataset. Use Accelerate gradient accumulation for a larger effective batch. The batch-size gate runs immediately after dataset construction and reads no cache files. The supervised-fraction scan then uses the cache paths already stored in the constructed batch managers, counts repeats from those entries, and opens each unique cache once to read its `audio_present` entry; it does not run a second glob or load video/audio latent payloads. The runtime/model repeat the batch-size check for direct API calls. Real packed batching needs text padding, an attention mask, and per-sample structural tensors, so it is deferred to a separate PR.
+MiniMax-H3 requires `batch_size = 1` in every H3 dataset. Use Accelerate gradient accumulation for a larger effective batch. The latent caching script warns when a dataset config sets any other value, and the trainer rejects the first batch whose size is not 1. Real packed batching needs text padding, an attention mask, and per-sample structural tensors, so it is deferred to a separate PR.
 
 Saved `ss_minimax_h3_base_family` names the released transformer family, not the task. T2VA therefore records `ss_minimax_h3_task=t2va` and `ss_minimax_h3_base_family=fl2va`, because T2VA uses the released FL2VA base.
 
 ### Training-time joint AV samples
 
-H3 overrides the shared single-VAE/video-only sampling hook. It samples with the live transformer and current LoRA, decodes the video and audio latents with their own VAEs in sequence, and writes a muxed MP4 under `OUTPUT_DIR/sample`.
+H3 overrides the shared `prepare_sampling` hook (whose default covers single-VAE architectures) and returns both VAEs as its sampling resources. It samples with the live transformer and current LoRA, decodes the video and audio latents with their own VAEs in sequence, and writes a muxed MP4 under `OUTPUT_DIR/sample`.
 
 Add the sampling assets and normal sampling schedule flags to the training command:
 

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -452,6 +452,11 @@ def log_audio_presence_summary(presence_counts: Mapping[bool, int]) -> None:
         missing_audio,
         fraction,
     )
+    if total and real_audio == 0:
+        logger.warning(
+            "No cached item has real audio: training with these caches keeps the audio loss at 0; "
+            "if this is intended, pass --video_only to the trainer explicitly"
+        )
 
 
 def setup_parser() -> argparse.ArgumentParser:
@@ -486,8 +491,15 @@ def main() -> None:
 
     records_by_dir: dict[str, list[H3Record]] = {}
     audio_sources_by_dir: dict[str, list] = {}
-    for dataset in datasets:
+    for dataset_index, dataset in enumerate(datasets):
         validate_h3_dataset(dataset)
+        if int(dataset.batch_size) != 1:
+            logger.warning(
+                "MiniMax-H3 dataset %d has batch_size=%d in the dataset config; training requires batch_size=1 "
+                "(use gradient accumulation for a larger effective batch) and will stop on the first training batch",
+                dataset_index,
+                int(dataset.batch_size),
+            )
         key = dataset_cache_dir_key(dataset.cache_directory)
         records_by_dir[key] = h3_records_from_datasource(dataset.datasource, args.task)
         audio_sources_by_dir[key] = dataset.datasource.audio_sources

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -55,12 +55,7 @@ from musubi_tuner.minimax_h3.text_encoder import (
 )
 from musubi_tuner.minimax_h3.video_vae import VIDEO_VAE_DECODE_DTYPE, VIDEO_VAE_ENCODE_DTYPE, load_video_vae
 from musubi_tuner.minimax_h3_cache_latents import PyAVH3MediaDecoder
-from musubi_tuner.training.audio_loss import (
-    add_audio_train_args,
-    effective_audio_loss_weights,
-    log_audio_supervision_summary,
-    scan_audio_supervised_fraction,
-)
+from musubi_tuner.training.audio_loss import add_audio_train_args, effective_audio_loss_weights
 from musubi_tuner.training.parser_common import read_config_from_file, setup_parser_common
 from musubi_tuner.training.sampling_prompts import load_prompts
 from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
@@ -161,17 +156,6 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
         seed=None if seed is None else int(seed),
     )
     return sample
-
-
-def validate_h3_dataset_batch_size(dataset_group) -> None:
-    """Keep R1 on one real sample per step; gradient accumulation provides batching."""
-    for dataset_index, dataset in enumerate(dataset_group.datasets):
-        batch_size = int(dataset.batch_manager.batch_size)
-        if batch_size != 1:
-            raise ValueError(
-                f"MiniMax-H3 R1 dataset {dataset_index} requires batch_size=1, got batch_size={batch_size}; "
-                "use gradient accumulation for a larger effective batch"
-            )
 
 
 def _validate_audio_present(value: Any, batch_size: int) -> torch.Tensor:
@@ -350,8 +334,23 @@ def _augment_conditions(
     return tuple(augmented)
 
 
+@dataclass(frozen=True)
+class H3SamplingResources:
+    """Training-time sampling payload: H3 decodes samples with two separate VAEs."""
+
+    video_vae: torch.nn.Module
+    audio_vae: torch.nn.Module
+
+
 class MiniMaxH3NetworkTrainer(NetworkTrainer):
     audio_spec = H3_AUDIO_SPEC
+
+    def __init__(self):
+        super().__init__()
+        # per-rank audio-supervision accounting, fed by process_batch; drives the
+        # first-epoch warning and the observed fraction saved in metadata
+        self._audio_items_seen = 0
+        self._audio_supervised_seen = 0
 
     @property
     def architecture(self) -> str:
@@ -418,29 +417,20 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         if is_convrot_int8 and getattr(args, "base_weights", None):
             raise ValueError("MiniMax-H3 --base_weights cannot be merged into a ConvRot INT8 transformer base")
 
-    def _build_dataset(self, args):
-        dataset_group, collator, current_epoch = super()._build_dataset(args)
-        validate_h3_dataset_batch_size(dataset_group)
-        self._supervised_audio_fraction = scan_audio_supervised_fraction(dataset_group)
-        log_audio_supervision_summary(self._supervised_audio_fraction, args)
-        return dataset_group, collator, current_epoch
+    def process_sample_prompts(self, args, accelerator, sample_prompts):
+        # only the default prepare_sampling needs this seam; guard against future
+        # base-side callers silently getting the base NotImplementedError instead
+        raise NotImplementedError(
+            "MiniMax-H3 prepares sample prompts inside prepare_sampling, which returns joint AV sampling resources"
+        )
 
-    def _prepare_sampling(self, args, accelerator, vae_dtype):
-        del vae_dtype
-        self._sampling_video_vae = None
-        self._sampling_audio_vae = None
+    def prepare_sampling(self, args, accelerator, vae_dtype):
+        del vae_dtype  # the H3 video/audio VAE dtypes are fixed per stage
         if not args.sample_prompts:
             return None, None
         for label in ("video_vae", "audio_vae", "text_encoder"):
             _require_sampling_path(getattr(args, label, None), label)
-        return self.process_sample_prompts(args, accelerator, args.sample_prompts), None
-
-    def process_sample_prompts(
-        self,
-        args: argparse.Namespace,
-        accelerator: Accelerator,
-        sample_prompts: str,
-    ):
+        sample_prompts = args.sample_prompts
         logger.info("Preparing MiniMax-H3 joint AV training samples from %s", sample_prompts)
         parameters = [_normalize_h3_sample_parameter(args, item) for item in load_prompts(sample_prompts)]
         if not parameters:
@@ -521,7 +511,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             video_vae.to(device="cpu", dtype=VIDEO_VAE_DECODE_DTYPE)
             gc.collect()
             clean_memory_on_device(device)
-        self._sampling_video_vae = video_vae
 
         logger.info("Loading MiniMax-H3 audio VAE for training samples")
         has_audio_conditions = any(parameter["_h3_has_audio_conditions"] for parameter in parameters)
@@ -552,7 +541,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             audio_vae.to("cpu")
             gc.collect()
             clean_memory_on_device(device)
-        self._sampling_audio_vae = audio_vae
 
         for parameter in parameters:
             references = (
@@ -595,7 +583,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 "_h3_has_audio_conditions",
             ):
                 parameter.pop(key)
-        return parameters
+        return parameters, H3SamplingResources(video_vae=video_vae, audio_vae=audio_vae)
 
     def sample_image_inference(
         self,
@@ -603,17 +591,17 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         args,
         transformer,
         dit_dtype,
-        vae,
+        sample_resources,
         save_dir,
         sample_parameter,
         epoch,
         steps,
     ):
-        del dit_dtype, vae
-        video_vae = getattr(self, "_sampling_video_vae", None)
-        audio_vae = getattr(self, "_sampling_audio_vae", None)
-        if video_vae is None or audio_vae is None:
+        del dit_dtype
+        if not isinstance(sample_resources, H3SamplingResources):
             raise RuntimeError("MiniMax-H3 training sample VAEs were not prepared")
+        video_vae = sample_resources.video_vae
+        audio_vae = sample_resources.audio_vae
         layout = sample_parameter["h3_layout"]
         sample_steps = sample_parameter["sample_steps"]
         frame_count = sample_parameter["frame_count"]
@@ -742,8 +730,19 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             gc.collect()
             clean_memory_on_device(device)
 
+    def on_epoch_end(self, args: argparse.Namespace, accelerator: Accelerator, network, transformer, epoch: int) -> None:
+        del network, transformer
+        if epoch != 1 or args.video_only or args.audio_loss_weight <= 0:
+            return
+        # per-rank observation: under DDP each process only sees its own shard
+        if accelerator.is_main_process and self._audio_items_seen > 0 and self._audio_supervised_seen == 0:
+            logger.warning(
+                "No training item with real audio was seen during the first epoch, so the audio loss is always 0; "
+                "if this is intended, consider passing --video_only explicitly"
+            )
+
     def extra_metadata(self, args: argparse.Namespace) -> dict:
-        return {
+        metadata = {
             "ss_minimax_h3_task": args.task,
             "ss_minimax_h3_base_family": "ref2va" if args.task == "ref2va" else "fl2va",
             "ss_minimax_h3_shift_video": args.h3_shift_video,
@@ -752,7 +751,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             "ss_minimax_h3_audio_cond_clean": args.h3_audio_cond_clean,
             "ss_minimax_h3_loss_policy": "video_mean_plus_weighted_audio_mean",
             "ss_minimax_h3_audio_supervision": "presence_gated_training_weight",
-            "ss_minimax_h3_supervised_audio_fraction": getattr(self, "_supervised_audio_fraction", 1.0),
             "ss_minimax_h3_audio_loss_weight": args.audio_loss_weight,
             "ss_minimax_h3_video_only": args.video_only,
             "ss_minimax_h3_target_modules": "attn.qkv_proj,attn.out_proj,mlp.fc1,mlp.fc2",
@@ -760,6 +758,10 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             "ss_minimax_h3_latent_cache_version": "2",
             "ss_minimax_h3_text_cache_version": "1",
         }
+        if self._audio_items_seen > 0:
+            # fraction observed on this rank so far (exact once a full epoch has run)
+            metadata["ss_minimax_h3_supervised_audio_fraction"] = round(self._audio_supervised_seen / self._audio_items_seen, 6)
+        return metadata
 
     def load_transformer(
         self,
@@ -874,11 +876,14 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         noise_scheduler,
         dit_dtype: torch.dtype,
         network_dtype: torch.dtype,
-        vae,
+        sample_resources,
         global_step: int,
     ) -> tuple[torch.Tensor, dict[str, float]]:
-        del network, vae
+        del network, sample_resources
+        # _runtime_batch_plan rejects batches larger than one item (batch_size=1 rule)
         runtime = _runtime_batch_plan(batch, latents)
+        self._audio_items_seen += int(runtime.audio_present.numel())
+        self._audio_supervised_seen += int(runtime.audio_present.sum().item())
         if runtime.layout.task != args.task:
             raise ValueError(f"MiniMax-H3 --task {args.task} cannot train a {runtime.layout.task.upper()} cache batch")
         device = latents.device

--- a/src/musubi_tuner/training/audio_loss.py
+++ b/src/musubi_tuner/training/audio_loss.py
@@ -1,17 +1,8 @@
 from __future__ import annotations
 
 import argparse
-from collections import Counter
-from pathlib import Path
 
-from safetensors import safe_open
 import torch
-
-from musubi_tuner.dataset.cache_io import AUDIO_PRESENT_KEY, validate_audio_present_entry
-
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 def add_audio_train_args(parser: argparse.ArgumentParser):
@@ -44,42 +35,3 @@ def effective_audio_loss_weights(audio_present: torch.Tensor, args: argparse.Nam
     if args.audio_loss_weight < 0:
         raise ValueError(f"audio_loss_weight must be nonnegative, got {args.audio_loss_weight}")
     return args.audio_loss_weight * audio_present
-
-
-def _read_audio_present(path: Path) -> float:
-    with safe_open(str(path), framework="pt", device="cpu") as handle:
-        if AUDIO_PRESENT_KEY not in handle.keys():
-            raise ValueError(f"Latent cache {path} has no {AUDIO_PRESENT_KEY} entry; re-run latent caching")
-        tensor = handle.get_tensor(AUDIO_PRESENT_KEY)
-    return validate_audio_present_entry({AUDIO_PRESENT_KEY: tensor})
-
-
-def scan_audio_supervised_fraction(dataset_group) -> float:
-    """Fraction of training items (num_repeats-weighted) whose cache holds real audio."""
-    cache_counts: Counter[Path] = Counter()
-    for dataset in dataset_group.datasets:
-        for bucket in dataset.batch_manager.buckets.values():
-            for item in bucket:
-                cache_path = getattr(item, "latent_cache_path", None)
-                if not cache_path:
-                    raise ValueError("Training item is missing latent_cache_path")
-                cache_counts[Path(cache_path).resolve()] += 1
-    if not cache_counts:
-        raise ValueError("Audio supervision scan found no latent cache files")
-
-    supervised = 0
-    total = sum(cache_counts.values())
-    for path, repeats in cache_counts.items():
-        supervised += repeats * int(_read_audio_present(path))
-    return supervised / total
-
-
-def log_audio_supervision_summary(supervised_fraction: float, args: argparse.Namespace):
-    logger.info(f"supervised_audio_fraction={supervised_fraction:.6f}")
-    if args.video_only:
-        logger.info("audio supervision disabled by --video_only")
-    elif args.audio_loss_weight > 0 and supervised_fraction == 0.0:
-        logger.warning(
-            "No training item has real audio, so the audio loss is always 0; "
-            "if this is intended, consider passing --video_only explicitly"
-        )

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -839,7 +839,7 @@ class NetworkTrainer:
                 line += "#" * int(w / max_weighting * CONSOLE_WIDTH)
                 print(line)
 
-    def sample_images(self, accelerator: Accelerator, args, epoch, steps, vae, transformer, sample_parameters, dit_dtype):
+    def sample_images(self, accelerator: Accelerator, args, epoch, steps, sample_resources, transformer, sample_parameters, dit_dtype):
         """architecture independent sample images"""
         if not should_sample_images(args, steps, epoch):
             return
@@ -873,7 +873,7 @@ class NetworkTrainer:
             with torch.no_grad(), accelerator.autocast():
                 for sample_parameter in sample_parameters:
                     self.sample_image_inference(
-                        accelerator, args, transformer, dit_dtype, vae, save_dir, sample_parameter, epoch, steps
+                        accelerator, args, transformer, dit_dtype, sample_resources, save_dir, sample_parameter, epoch, steps
                     )
                     clean_memory_on_device(accelerator.device)
         else:
@@ -887,7 +887,7 @@ class NetworkTrainer:
                 with distributed_state.split_between_processes(per_process_params) as sample_parameter_lists:
                     for sample_parameter in sample_parameter_lists[0]:
                         self.sample_image_inference(
-                            accelerator, args, transformer, dit_dtype, vae, save_dir, sample_parameter, epoch, steps
+                            accelerator, args, transformer, dit_dtype, sample_resources, save_dir, sample_parameter, epoch, steps
                         )
                         clean_memory_on_device(accelerator.device)
 
@@ -1070,6 +1070,11 @@ class NetworkTrainer:
         accelerator: Accelerator,
         sample_prompts: str,
     ):
+        """Parses and encodes ``--sample_prompts`` for the default ``prepare_sampling``.
+
+        Architectures using the default ``prepare_sampling`` must implement this;
+        those overriding ``prepare_sampling`` wholesale may leave it unimplemented.
+        """
         raise NotImplementedError("subclass must implement `process_sample_prompts`")
 
     def do_inference(
@@ -1156,7 +1161,7 @@ class NetworkTrainer:
         noise_scheduler,
         dit_dtype: torch.dtype,
         network_dtype: torch.dtype,
-        vae,
+        sample_resources,
         global_step: int,
     ) -> tuple[torch.Tensor, dict[str, float]]:
         """Compute scalar loss for one training batch (pre-backward).
@@ -1278,8 +1283,45 @@ class NetworkTrainer:
         so subclasses uploading companion files can match the same behaviour.
         """
 
+    def on_epoch_end(
+        self,
+        args: argparse.Namespace,
+        accelerator: Accelerator,
+        network,
+        transformer,
+        epoch: int,
+    ) -> None:
+        """Called once per epoch, after its last inner step and before end-of-epoch saving/sampling.
+
+        ``epoch`` is the 1-based number of the epoch that just finished (the final
+        epoch may be partial when ``--max_train_steps`` ends it early). Use for
+        epoch-level bookkeeping such as dataset-coverage warnings after the first epoch.
+        """
+
+    def prepare_sampling(self, args, accelerator, vae_dtype):
+        """Prepares training-time sampling; returns ``(sample_parameters, sample_resources)``.
+
+        ``sample_resources`` is an architecture-defined payload that the base trainer
+        threads through unchanged to ``sample_image_inference`` and the sample-image
+        hooks. The default implementation covers single-VAE architectures: it parses
+        prompts via ``process_sample_prompts`` and returns the sampling VAE as the
+        resources. Architectures whose sampling needs more (e.g. separate video and
+        audio VAEs) override this wholesale and return their own payload.
+        Both values are None when ``--sample_prompts`` is not set.
+        """
+        sample_parameters = None
+        vae = None
+        if args.sample_prompts:
+            sample_parameters = self.process_sample_prompts(args, accelerator, args.sample_prompts)
+
+            # Load VAE model for sampling images: VAE is loaded to cpu to save gpu memory
+            vae = self.load_vae(args, vae_dtype=vae_dtype, vae_path=args.vae)
+            vae.requires_grad_(False)
+            vae.eval()
+        return sample_parameters, vae
+
     def on_before_sample_images(
-        self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype
+        self, accelerator, args, epoch, steps, sample_resources, transformer, network, sample_parameters, dit_dtype
     ) -> None:
         """Called just before sample image generation begins, while the transformer is still in training mode.
 
@@ -1289,7 +1331,7 @@ class NetworkTrainer:
         pass
 
     def on_after_sample_images(
-        self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype
+        self, accelerator, args, epoch, steps, sample_resources, transformer, network, sample_parameters, dit_dtype
     ) -> None:
         """Called after sample image generation completes and the transformer has been switched back to training mode.
 
@@ -1319,7 +1361,10 @@ class NetworkTrainer:
     def extra_metadata(self, args: argparse.Namespace) -> dict:
         """Returns extra ``ss_*`` metadata keys to embed in saved safetensors.
 
-        Default: empty dict. Override to add extension-specific metadata.
+        Called once when the training metadata is first built and again at every
+        checkpoint save, so values observed during training stay current. It must
+        therefore be cheap and side-effect free. Default: empty dict. Override to
+        add extension-specific metadata.
         """
         return {}
 
@@ -1341,9 +1386,12 @@ class NetworkTrainer:
         session_id, training_started_at = self._init_session(args)
         train_dataset_group, collator, current_epoch = self._build_dataset(args)
         accelerator, weight_dtype, dit_dtype, dit_weight_dtype, vae_dtype = self._prepare_accelerator_and_dtypes(args)
-        sample_parameters, vae = self._prepare_sampling(args, accelerator, vae_dtype)
+        sample_parameters, sample_resources = self.prepare_sampling(args, accelerator, vae_dtype)
         transformer = self._load_dit_and_swap(args, accelerator, dit_weight_dtype)
-        network = self._build_network(args, accelerator, transformer, vae, weight_dtype)
+        # the network factories take a LyCORIS-compatible vae argument; the sampling
+        # resources fill it only when they are a plain module (single-VAE architectures)
+        network_vae = sample_resources if isinstance(sample_resources, torch.nn.Module) else None
+        network = self._build_network(args, accelerator, transformer, network_vae, weight_dtype)
         if network is None:
             return
         (
@@ -1395,7 +1443,7 @@ class NetworkTrainer:
             optimizer_eval_fn,
             lr_scheduler,
             lr_descriptions,
-            vae,
+            sample_resources,
             sample_parameters,
             dit_dtype,
             network_dtype,
@@ -1506,19 +1554,6 @@ class NetworkTrainer:
 
         vae_dtype = torch.float16 if args.vae_dtype is None else model_utils.str_to_dtype(args.vae_dtype)
         return accelerator, weight_dtype, dit_dtype, dit_weight_dtype, vae_dtype
-
-    def _prepare_sampling(self, args, accelerator, vae_dtype):
-        # get embedding for sampling images
-        sample_parameters = None
-        vae = None
-        if args.sample_prompts:
-            sample_parameters = self.process_sample_prompts(args, accelerator, args.sample_prompts)
-
-            # Load VAE model for sampling images: VAE is loaded to cpu to save gpu memory
-            vae = self.load_vae(args, vae_dtype=vae_dtype, vae_path=args.vae)
-            vae.requires_grad_(False)
-            vae.eval()
-        return sample_parameters, vae
 
     def _load_dit_and_swap(self, args, accelerator, dit_weight_dtype):
         # load DiT model
@@ -1812,7 +1847,7 @@ class NetworkTrainer:
         optimizer_eval_fn,
         lr_scheduler,
         lr_descriptions,
-        vae,
+        sample_resources,
         sample_parameters,
         dit_dtype,
         network_dtype,
@@ -1972,6 +2007,9 @@ class NetworkTrainer:
             metadata["ss_training_finished_at"] = str(time.time())
             metadata["ss_steps"] = str(steps)
             metadata["ss_epoch"] = str(epoch_no)
+            # re-evaluated per save so values observed during training (rather than
+            # fixed at startup) are stored current
+            metadata.update({k: str(v) for k, v in self.extra_metadata(args).items()})
 
             metadata_to_save = minimum_metadata if args.no_metadata else metadata
 
@@ -2015,13 +2053,15 @@ class NetworkTrainer:
             if not should_sample_images(args, steps_arg, epoch_arg):
                 return
             self.on_before_sample_images(
-                accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
+                accelerator, args, epoch_arg, steps_arg, sample_resources, transformer, network, sample_parameters, dit_dtype
             )
             try:
-                self.sample_images(accelerator, args, epoch_arg, steps_arg, vae, transformer, sample_parameters, dit_dtype)
+                self.sample_images(
+                    accelerator, args, epoch_arg, steps_arg, sample_resources, transformer, sample_parameters, dit_dtype
+                )
             finally:
                 self.on_after_sample_images(
-                    accelerator, args, epoch_arg, steps_arg, vae, transformer, network, sample_parameters, dit_dtype
+                    accelerator, args, epoch_arg, steps_arg, sample_resources, transformer, network, sample_parameters, dit_dtype
                 )
 
         # For --sample_at_first
@@ -2078,7 +2118,7 @@ class NetworkTrainer:
                         noise_scheduler,
                         dit_dtype,
                         network_dtype,
-                        vae,
+                        sample_resources,
                         global_step,
                     )
 
@@ -2164,6 +2204,8 @@ class NetworkTrainer:
 
                 if global_step >= args.max_train_steps:
                     break
+
+            self.on_epoch_end(args, accelerator, network, transformer, epoch + 1)
 
             if len(accelerator.trackers) > 0:
                 logs = {"loss/epoch": loss_recorder.moving_average}

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -839,7 +839,9 @@ class NetworkTrainer:
                 line += "#" * int(w / max_weighting * CONSOLE_WIDTH)
                 print(line)
 
-    def sample_images(self, accelerator: Accelerator, args, epoch, steps, sample_resources, transformer, sample_parameters, dit_dtype):
+    def sample_images(
+        self, accelerator: Accelerator, args, epoch, steps, sample_resources, transformer, sample_parameters, dit_dtype
+    ):
         """architecture independent sample images"""
         if not should_sample_images(args, steps, epoch):
             return

--- a/tests/test_audio_dataset_seam.py
+++ b/tests/test_audio_dataset_seam.py
@@ -8,7 +8,6 @@ import wave
 import av
 import numpy as np
 import pytest
-from safetensors.torch import save_file
 import torch
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,7 +35,6 @@ from musubi_tuner.dataset.media_utils import load_video, resample_frame_indices
 from musubi_tuner.training.audio_loss import (
     add_audio_train_args,
     effective_audio_loss_weights,
-    scan_audio_supervised_fraction,
 )
 
 
@@ -384,34 +382,6 @@ def test_effective_audio_loss_weights_combines_policy_and_presence():
     args = SimpleNamespace(video_only=False, audio_loss_weight=1.0)
     with pytest.raises(ValueError, match="exactly 0.0 or 1.0"):
         effective_audio_loss_weights(torch.tensor([0.5]), args)
-
-
-def _fake_dataset_group(bucket_items):
-    batch_manager = SimpleNamespace(buckets={"bucket": bucket_items})
-    return SimpleNamespace(datasets=[SimpleNamespace(batch_manager=batch_manager)])
-
-
-def test_scan_audio_supervised_fraction_weights_repeats(tmp_path: Path):
-    supervised_path = tmp_path / "supervised.safetensors"
-    unsupervised_path = tmp_path / "unsupervised.safetensors"
-    save_file({AUDIO_PRESENT_KEY: torch.tensor(1.0, dtype=torch.float32)}, str(supervised_path))
-    save_file({AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32)}, str(unsupervised_path))
-
-    items = [
-        SimpleNamespace(latent_cache_path=str(supervised_path)),
-        SimpleNamespace(latent_cache_path=str(unsupervised_path)),
-        SimpleNamespace(latent_cache_path=str(unsupervised_path)),
-    ]
-    assert scan_audio_supervised_fraction(_fake_dataset_group(items)) == pytest.approx(1.0 / 3.0)
-
-
-def test_scan_audio_supervised_fraction_rejects_missing_entry(tmp_path: Path):
-    legacy_path = tmp_path / "legacy.safetensors"
-    save_file({"latents_1x1x1_float32": torch.zeros(1, 1, 1, dtype=torch.float32)}, str(legacy_path))
-
-    items = [SimpleNamespace(latent_cache_path=str(legacy_path))]
-    with pytest.raises(ValueError, match="re-run latent caching"):
-        scan_audio_supervised_fraction(_fake_dataset_group(items))
 
 
 def test_audio_present_cache_entry_roundtrip():

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from safetensors.torch import save_file
 import torch
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -18,111 +17,81 @@ from musubi_tuner.minimax_h3.model import MiniMaxH3Config, MiniMaxH3Model
 from musubi_tuner.minimax_h3.packing import H3ReferenceGeometry, H3VideoGeometry, build_h3_layout
 from musubi_tuner.modules.convrot_int8_kernels import quantize_int8_convrot_weight
 from musubi_tuner.modules.convrot_int8_utils import apply_convrot_int8_monkey_patch
-from musubi_tuner.dataset.cache_io import AUDIO_PRESENT_KEY
 from musubi_tuner.minimax_h3_train_network import (
+    H3SamplingResources,
     MiniMaxH3NetworkTrainer,
     minimax_h3_setup_parser,
-    validate_h3_dataset_batch_size,
 )
-from musubi_tuner.training.audio_loss import scan_audio_supervised_fraction
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.networks import lora_minimax_h3
-from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
+from musubi_tuner.training.trainer_base import DiTOutput
 
 
-def _dataset_group(*batch_sizes: int):
-    return SimpleNamespace(
-        datasets=[SimpleNamespace(batch_manager=SimpleNamespace(batch_size=batch_size)) for batch_size in batch_sizes]
-    )
+def test_process_batch_accumulates_observed_audio_supervision(monkeypatch):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args()
+    trainer.handle_model_specific_args(args)
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    video_latents = torch.zeros(1, 24, 2, 4, 4)
+
+    for present in (1.0, 0.0):
+        batch = _training_batch()
+        batch["audio_present"] = torch.tensor([present], dtype=torch.float32)
+        trainer.process_batch(
+            args,
+            _Accelerator(),
+            _RecordingTransformer(),
+            None,
+            batch,
+            video_latents,
+            torch.zeros_like(video_latents),
+            None,
+            torch.bfloat16,
+            torch.float32,
+            None,
+            0,
+        )
+
+    assert trainer._audio_items_seen == 2
+    assert trainer._audio_supervised_seen == 1
+    assert trainer.extra_metadata(args)["ss_minimax_h3_supervised_audio_fraction"] == 0.5
 
 
-def test_h3_dataset_accepts_batch_size_one_without_inspecting_cache_items():
-    validate_h3_dataset_batch_size(_dataset_group(1, 1))
+def test_h3_rejects_the_single_vae_prompt_seam_with_a_pointer_to_prepare_sampling():
+    with pytest.raises(NotImplementedError, match="prepare_sampling"):
+        MiniMaxH3NetworkTrainer().process_sample_prompts(_trainer_args(), _Accelerator(), "prompts.json")
 
 
-def test_h3_dataset_rejects_real_batches_and_points_to_gradient_accumulation():
-    with pytest.raises(ValueError, match=r"dataset 1.*batch_size=2.*gradient accumulation"):
-        validate_h3_dataset_batch_size(_dataset_group(1, 2))
+def test_h3_warns_after_the_first_epoch_when_no_real_audio_was_seen(caplog):
+    trainer = MiniMaxH3NetworkTrainer()
+    trainer._audio_items_seen = 3
+    trainer._audio_supervised_seen = 0
+    caplog.set_level("WARNING")
 
+    trainer.on_epoch_end(_trainer_args(), SimpleNamespace(is_main_process=True), None, None, 1)
 
-def _presence_cache(path: Path, *, present: torch.Tensor | None) -> Path:
-    tensors = {"latents_2x4x4_float32": torch.zeros(24, 2, 4, 4)}
-    if present is not None:
-        tensors[AUDIO_PRESENT_KEY] = present
-    save_file(tensors, path)
-    return path.resolve()
-
-
-def _audio_presence_dataset_group(entries: list[Path]):
-    items = [SimpleNamespace(latent_cache_path=str(path)) for path in entries]
-    manager = SimpleNamespace(batch_size=1, buckets={(64, 64, 5): items})
-    dataset = SimpleNamespace(batch_manager=manager)
-    return SimpleNamespace(datasets=[dataset])
-
-
-def test_audio_supervision_scan_counts_repeats_and_opens_each_unique_cache_once(monkeypatch, tmp_path: Path):
-    from musubi_tuner.training import audio_loss
-
-    supervised = _presence_cache(tmp_path / "supervised.safetensors", present=torch.tensor(1.0, dtype=torch.float32))
-    unsupervised = _presence_cache(tmp_path / "unsupervised.safetensors", present=torch.tensor(0.0, dtype=torch.float32))
-    dataset_group = _audio_presence_dataset_group([supervised, supervised, unsupervised])
-    opened = []
-    real_safe_open = audio_loss.safe_open
-
-    def counted_safe_open(path, *args, **kwargs):
-        opened.append(Path(path).resolve())
-        return real_safe_open(path, *args, **kwargs)
-
-    monkeypatch.setattr(audio_loss, "safe_open", counted_safe_open)
-
-    fraction = scan_audio_supervised_fraction(dataset_group)
-
-    assert fraction == pytest.approx(2 / 3)
-    assert opened.count(supervised) == 1
-    assert opened.count(unsupervised) == 1
-
-
-def test_audio_supervision_scan_rejects_pre_audio_present_caches(tmp_path: Path):
-    legacy = _presence_cache(tmp_path / "legacy.safetensors", present=None)
-
-    with pytest.raises(ValueError, match="re-run latent caching"):
-        scan_audio_supervised_fraction(_audio_presence_dataset_group([legacy]))
+    assert "audio loss is always 0" in caplog.text
 
 
 @pytest.mark.parametrize(
-    "present",
+    "overrides, items_seen, supervised_seen, epoch",
     [
-        torch.tensor([0.0], dtype=torch.float32),
-        torch.tensor(0.0, dtype=torch.float64),
-        torch.tensor(float("nan"), dtype=torch.float32),
-        torch.tensor(0.5, dtype=torch.float32),
+        ({}, 3, 1, 1),  # real audio was seen
+        ({}, 3, 0, 2),  # later epochs stay silent
+        ({"video_only": True}, 3, 0, 1),
+        ({"audio_loss_weight": 0.0}, 3, 0, 1),
+        ({}, 0, 0, 1),  # nothing seen (no step ran on this rank)
     ],
 )
-def test_audio_supervision_scan_rejects_invalid_presence_entries(tmp_path: Path, present: torch.Tensor):
-    path = _presence_cache(tmp_path / "invalid.safetensors", present=present)
-
-    with pytest.raises(ValueError, match="audio_present"):
-        scan_audio_supervised_fraction(_audio_presence_dataset_group([path]))
-
-
-def test_h3_dataset_build_scans_audio_supervision_before_returning(monkeypatch, tmp_path: Path, caplog):
-    path = _presence_cache(tmp_path / "unsupervised.safetensors", present=torch.tensor(0.0, dtype=torch.float32))
-    dataset_group = _audio_presence_dataset_group([path])
-    sentinel_collator = object()
-    sentinel_epoch = object()
-    monkeypatch.setattr(
-        NetworkTrainer,
-        "_build_dataset",
-        lambda self, args: (dataset_group, sentinel_collator, sentinel_epoch),
-    )
-    caplog.set_level("INFO")
+def test_h3_epoch_end_stays_silent_unless_audio_supervision_was_expected(caplog, overrides, items_seen, supervised_seen, epoch):
     trainer = MiniMaxH3NetworkTrainer()
+    trainer._audio_items_seen = items_seen
+    trainer._audio_supervised_seen = supervised_seen
+    caplog.set_level("WARNING")
 
-    result = trainer._build_dataset(_trainer_args())
+    trainer.on_epoch_end(_trainer_args(**overrides), SimpleNamespace(is_main_process=True), None, None, epoch)
 
-    assert result == (dataset_group, sentinel_collator, sentinel_epoch)
-    assert trainer._supervised_audio_fraction == 0.0
-    assert "supervised_audio_fraction=0.000000" in caplog.text
+    assert caplog.text == ""
 
 
 class _Accelerator:
@@ -368,8 +337,7 @@ def test_h3_training_sample_uses_the_live_transformer_then_decodes_and_muxes_bot
         lambda decoded, output_path: captured.update(decoded=decoded, output_path=Path(output_path)),
     )
     trainer = train.MiniMaxH3NetworkTrainer()
-    trainer._sampling_video_vae = VideoVAE()
-    trainer._sampling_audio_vae = AudioVAE()
+    sample_resources = train.H3SamplingResources(video_vae=VideoVAE(), audio_vae=AudioVAE())
     layout = build_h3_layout(
         task="t2va",
         text_length=3,
@@ -401,7 +369,7 @@ def test_h3_training_sample_uses_the_live_transformer_then_decodes_and_muxes_bot
         args,
         transformer,
         torch.bfloat16,
-        None,
+        sample_resources,
         str(tmp_path),
         sample_parameter,
         None,
@@ -416,7 +384,7 @@ def test_h3_training_sample_uses_the_live_transformer_then_decodes_and_muxes_bot
     assert transformer.training is True
 
 
-def test_prepare_training_samples_encodes_text_once_and_owns_both_vaes_without_using_the_shared_vae(tmp_path, monkeypatch):
+def test_prepare_training_samples_encodes_text_once_and_returns_both_vaes_as_sampling_resources(tmp_path, monkeypatch):
     import musubi_tuner.minimax_h3_train_network as train
 
     prompt_file = tmp_path / "prompts.json"
@@ -495,12 +463,12 @@ def test_prepare_training_samples_encodes_text_once_and_owns_both_vaes_without_u
     monkeypatch.setattr(train, "clean_memory_on_device", lambda *args, **kwargs: None)
     trainer = train.MiniMaxH3NetworkTrainer()
 
-    sample_parameters, shared_vae = trainer._prepare_sampling(args, _Accelerator(), torch.bfloat16)
+    sample_parameters, sample_resources = trainer.prepare_sampling(args, _Accelerator(), torch.bfloat16)
 
-    assert shared_vae is None
+    assert isinstance(sample_resources, H3SamplingResources)
     assert events == ["load_text_encoder", "encode_text", ("load_video_vae", torch.float16), "load_audio_vae"]
-    assert isinstance(trainer._sampling_video_vae, VideoVAE)
-    assert isinstance(trainer._sampling_audio_vae, AudioVAE)
+    assert isinstance(sample_resources.video_vae, VideoVAE)
+    assert isinstance(sample_resources.audio_vae, AudioVAE)
     assert len(sample_parameters) == 1
     parameter = sample_parameters[0]
     assert parameter["h3_layout"].task == "t2va"
@@ -611,16 +579,15 @@ def test_prepare_ref_training_sample_carries_ordered_visual_and_audio_conditions
     monkeypatch.setattr(train, "clean_memory_on_device", lambda *args, **kwargs: None)
     trainer = train.MiniMaxH3NetworkTrainer()
 
-    sample_parameters, shared_vae = trainer._prepare_sampling(args, _Accelerator(), torch.bfloat16)
+    sample_parameters, sample_resources = trainer.prepare_sampling(args, _Accelerator(), torch.bfloat16)
 
-    assert shared_vae is None
     parameter = sample_parameters[0]
     assert parameter["h3_layout"].task == "ref2va"
     assert parameter["h3_layout"].references == (H3ReferenceGeometry("video", video=H3VideoGeometry(2, 4, 4), audio_frames=8),)
     assert parameter["h3_visual_conditions"] == (visual,)
     assert parameter["h3_audio_conditions"] == (audio,)
     assert video_vae_load_dtypes == [torch.float32]
-    assert trainer._sampling_video_vae.dtype_probe.dtype is torch.float16
+    assert sample_resources.video_vae.dtype_probe.dtype is torch.float16
     assert record_loads == [record]
     assert visual_decodes == [record, record]
     assert audio_frame_counts == [{0: 5}]
@@ -1045,7 +1012,8 @@ def test_process_batch_rejects_caches_without_audio_present():
 
 def test_h3_training_metadata_records_task_scheduler_and_target_policy():
     trainer = MiniMaxH3NetworkTrainer()
-    trainer._supervised_audio_fraction = 0.25
+    trainer._audio_items_seen = 4
+    trainer._audio_supervised_seen = 1
 
     metadata = trainer.extra_metadata(_trainer_args(task="fl2va"))
 
@@ -1073,6 +1041,12 @@ def test_t2va_metadata_distinguishes_task_from_the_fl2va_base_family():
 
     assert metadata["ss_minimax_h3_task"] == "t2va"
     assert metadata["ss_minimax_h3_base_family"] == "fl2va"
+
+
+def test_h3_metadata_omits_the_audio_fraction_until_a_batch_has_been_observed():
+    metadata = MiniMaxH3NetworkTrainer().extra_metadata(_trainer_args())
+
+    assert "ss_minimax_h3_supervised_audio_fraction" not in metadata
 
 
 def _tiny_model(num_layers: int = 2):


### PR DESCRIPTION
## Summary

`MiniMaxH3NetworkTrainer` was the only trainer overriding underscore-prefixed `NetworkTrainer` internals (`_prepare_sampling`, `_build_dataset`). This PR removes both overrides by promoting the sampling seam to a public contract and moving the dataset checks to where the data is already in hand.

### `prepare_sampling` as a public seam (base change)

The base never touched the VAE returned by `_prepare_sampling` — it only threaded it to `sample_image_inference` and the sample-image hooks. The seam is now public as `prepare_sampling`, returning `(sample_parameters, sample_resources)` where the resources are an architecture-defined opaque payload (default: the single sampling VAE, so existing architectures are unchanged). The threading parameters are renamed `vae` → `sample_resources` accordingly; all overrides call positionally, so no other architecture needed changes. The LyCORIS-compatible `vae` argument of the network factories receives the resources only when they are a plain `nn.Module`, preserving today's behavior exactly.

H3 now returns `H3SamplingResources(video_vae, audio_vae)` instead of smuggling both VAEs through `self._sampling_*_vae` and returning `None`. H3 also explicitly rejects `process_sample_prompts` with a `NotImplementedError` pointing at `prepare_sampling`; the base docstring notes that seam is only required by the default `prepare_sampling`.

### `_build_dataset` override removed

- **batch_size=1 rule**: the runtime guard in `_runtime_batch_plan` already covers training; the redundant startup check is removed. The latent caching script now warns when a dataset config sets `batch_size != 1` (read from the dataset's `batch_size` attribute — the `encode()` batch length can be masked by the cache-side `--batch_size` re-split).
- **audio supervision scan**: the startup scan opened every latent cache file (`safe_open` per item — a full disk sweep on large datasets) even though the caching script already counts `audio_present` while writing. The scan and its `audio_loss.py` helpers are deleted. The caching script now warns when no cached item has real audio, and the trainer accumulates observed audio presence per batch, warning at the end of the first epoch when audio supervision is enabled but no real audio was seen (per-rank observation under DDP).

### Supporting base changes

- New `on_epoch_end(args, accelerator, network, transformer, epoch)` hook, called once per epoch after its last inner step (mirrors the existing `network.on_epoch_start` call).
- `extra_metadata` is re-evaluated at each checkpoint save (previously fixed at startup), so `ss_minimax_h3_supervised_audio_fraction` records the observed fraction — exact once a full epoch has run, omitted until the first batch. The docstring now states the seam must be cheap and side-effect free. All existing implementations are pure dict builders.

## Testing

- `pytest tests/` — 356 passed (H3 suite reworked: scan tests removed, new tests for the epoch-end warning, observed-fraction accounting/metadata, sampling-resources contract, and the `process_sample_prompts` rejection)
- `ruff check src/ tests/` — clean
- Import check across all trainer entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)