### PR TITLE
Add MiniMax-H3 NVFP4 pre-quantized text encoder support

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -4,7 +4,7 @@
 
 Musubi Tuner supports MiniMax-H3 text-to-video-with-audio (T2VA), first/last-frame-to-video-with-audio (FL2VA), and reference-to-video-with-audio (Ref2VA) LoRA training and standalone generation.
 
-The implementation follows the released MiniMax-H3 packing, Qwen3-VL conditioning, dual video/audio flow schedules, and two VAE layouts. It supports the published BF16 transformers, the full and pruned ConvRot INT8 transformers, and the ConvRot INT8 Qwen3-VL text encoder.
+The implementation follows the released MiniMax-H3 packing, Qwen3-VL conditioning, dual video/audio flow schedules, and two VAE layouts. It supports the published BF16 transformers, the full and pruned ConvRot INT8 transformers, and the ConvRot INT8 and NVFP4+AWQ Qwen3-VL text encoders.
 
 Read and accept the [MiniMax-H3 Community License](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE) before downloading or using the weights.
 
@@ -22,10 +22,11 @@ Download the following files from [Comfy-Org/MiniMax-H3](https://huggingface.co/
 | Ref2VA pruned ConvRot INT8 transformer | `diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors` |
 | Qwen3-VL-32B text encoder | `text_encoders/qwen3vl_32b_minimax_h3_bf16.safetensors` |
 | Qwen3-VL-32B ConvRot INT8 text encoder | `text_encoders/qwen3vl_32b_minimax_h3_int8_convrot.safetensors` |
+| Qwen3-VL-32B NVFP4+AWQ text encoder | `text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors` |
 | Video VAE | `vae/minimax_h3_video_vae_fp16.safetensors` |
 | Audio VAE | `vae/minimax_h3_audio_vae_fp32.safetensors` |
 
-T2VA uses an FL2VA transformer without first/last conditions. Pre-quantized ConvRot INT8 files (full or pruned, transformer or text encoder) are detected automatically from their tensor structure — no extra flag is needed. FP8, NVFP4/AWQ, and malformed or partial ConvRot files are rejected rather than silently interpreted as BF16. See [ConvRot INT8 Quantized Base Weights](#convrot-int8-quantized-base-weights) for details.
+T2VA uses an FL2VA transformer without first/last conditions. Pre-quantized files (ConvRot INT8 full or pruned, transformer or text encoder; NVFP4+AWQ text encoder) are detected automatically from their tensor structure — no extra flag is needed. FP8, NVFP4 transformers, and malformed or partial quantized files are rejected rather than silently interpreted as BF16. See [ConvRot INT8 Quantized Base Weights](#convrot-int8-quantized-base-weights) and [NVFP4 Text Encoder](#nvfp4-text-encoder) for details.
 
 The Qwen processor/config defaults to `Qwen/Qwen3-VL-32B-Instruct` and is downloaded by Transformers. Pass `--processor` when using a local copy.
 
@@ -136,7 +137,7 @@ python minimax_h3_cache_text_encoder_outputs.py \
   --skip_existing
 ```
 
-The same command accepts the ConvRot INT8 text encoder (`qwen3vl_32b_minimax_h3_int8_convrot.safetensors`); the format is detected automatically. The cache stores the state after the first 50 Qwen layers, before a final language-model norm. `hidden_states[0]` is the embedding output, so this is `hidden_states[50]`. The cache also stores per-row modality tags and presentation fingerprints; stale or structurally incompatible caches are rejected.
+The same command accepts the ConvRot INT8 text encoder (`qwen3vl_32b_minimax_h3_int8_convrot.safetensors`) and the NVFP4+AWQ text encoder (`qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors`); the formats are detected automatically. The cache stores the state after the first 50 Qwen layers, before a final language-model norm. `hidden_states[0]` is the embedding output, so this is `hidden_states[50]`. The cache also stores per-row modality tags and presentation fingerprints; stale or structurally incompatible caches are rejected.
 
 ## LoRA Training
 
@@ -193,7 +194,7 @@ Add the sampling assets and normal sampling schedule flags to the training comma
 
 The text presentations and condition latents are prepared once before the transformer is loaded. The two decode VAEs then remain on CPU and are moved to the accelerator one at a time for each scheduled sample. The shared trainer still owns sampling cadence, distributed prompt assignment, RNG restoration, and the block-swap inference/training transition.
 
-Training-time samples load the selected Qwen3-VL text encoder on the training accelerator before the transformer. The BF16 artifact is approximately 48 GB, so `--sample_prompts` requires roughly 50 GB of available accelerator memory there; the ConvRot INT8 artifact lowers the persistent text-encoder weights to ~25 GB and is selected simply by passing its path. Omit scheduled sampling when the selected encoder does not fit; a text-encoder device override or cached sample conditioning is follow-up scope.
+Training-time samples load the selected Qwen3-VL text encoder on the training accelerator before the transformer. The BF16 artifact is approximately 48 GB, so `--sample_prompts` requires roughly 50 GB of available accelerator memory there; the ConvRot INT8 artifact lowers the persistent text-encoder weights to ~25 GB and the NVFP4+AWQ artifact to ~15 GB, selected simply by passing their paths. Omit scheduled sampling when the selected encoder does not fit; a text-encoder device override or cached sample conditioning is follow-up scope.
 
 All entries in one run use the training `--task`. T2VA JSON entries use the common prompt fields:
 
@@ -233,6 +234,16 @@ The published quantization scope is the five Linears in each of the 50 main DiT 
 
 **Generation.** Pre-quantized checkpoints work as-is; add `--convrot_int8` only to quantize a BF16 checkpoint at load time. With `--lora_weight` the route depends on the base: a BF16 base with `--convrot_int8` merges the LoRA into the BF16 weights during the streaming load and quantizes the merged result (fastest inference); a pre-quantized base attaches each LoRA as a runtime additive branch with its own multiplier for the sampling lifetime — the INT8 base tensors are never modified or requantized, so LoRA generation no longer requires downloading the BF16 checkpoint.
 
+## NVFP4 Text Encoder
+
+The published NVFP4+AWQ Qwen3-VL text encoder (`qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors`, ~14.6 GB) is accepted wherever `--text_encoder` is accepted (TE caching, training-time sampling, generation) and is detected automatically from its tensor structure, like the ConvRot INT8 artifacts.
+
+The artifact quantizes the 350 language-model Linears to NVFP4 (4-bit E2M1 values with FP8 per-16-block scales and an FP32 per-tensor scale) and the token embedding to per-row INT8; norms, biases, and the vision tower stay BF16. The quantization is AWQ-calibrated: two projections per layer carry an explicit `pre_quant_scale` that Musubi multiplies into their inputs at runtime, and the remaining scales are already folded into the checkpoint's norm weights. Because AWQ requires calibration data, there is deliberately no on-the-fly NVFP4 quantization of BF16 weights — for dynamic quantization use ConvRot INT8, which reproduces the published INT8 artifact bit-exactly.
+
+By default the patched layers run weight-only: the NVFP4 weight is transiently dequantized each forward and multiplied in BF16, which works on any GPU and matches the artifact's own `full_precision_matrix_mult` declaration. `--nvfp4_scaled_mm` opts into W4A4 matmuls via `torch.nn.functional.scaled_mm`, which also quantizes the activations to NVFP4; it requires PyTorch 2.10+ and a Blackwell-generation GPU, and trades some quality for speed (measured end-to-end against a BF16 text encoder with an identical DiT/seed: mean 5.9/255 decoded deviation in the default mode, 7.2/255 with `--nvfp4_scaled_mm`; the ConvRot INT8 text encoder scores 3.5/255 and a typical LoRA effect ~79/255 on the same pipeline).
+
+The text encoder is frozen in every Musubi flow, so the NVFP4 path is inference-only; it does not affect LoRA training of the transformer. Text-encoder LoRAs cannot be merged into or attached to the NVFP4 artifact.
+
 ## Generation
 
 T2VA generation with the FL2VA base:
@@ -260,7 +271,7 @@ Add a trained LoRA with:
 --lora_weight /data/h3/output/h3-lora.safetensors --lora_multiplier 1.0
 ```
 
-The same command accepts the full or pruned ConvRot INT8 transformer and the ConvRot INT8 text encoder; formats are detected automatically. With a BF16 transformer, LoRAs are merged destructively once after loading (fastest inference); with a ConvRot INT8 base, each `--lora_weight` stays a separate runtime additive branch with its corresponding multiplier (see [ConvRot INT8 Quantized Base Weights](#convrot-int8-quantized-base-weights)).
+The same command accepts the full or pruned ConvRot INT8 transformer and the ConvRot INT8 or NVFP4+AWQ text encoder; formats are detected automatically. With a BF16 transformer, LoRAs are merged destructively once after loading (fastest inference); with a ConvRot INT8 base, each `--lora_weight` stays a separate runtime additive branch with its corresponding multiplier (see [ConvRot INT8 Quantized Base Weights](#convrot-int8-quantized-base-weights)).
 
 For FL2VA, keep the FL2VA base and replace the task inputs:
 
@@ -283,8 +294,8 @@ The native sampler builds one common base grid, derives independent shifted vide
 ## Limitations
 
 - Released BF16 full and ConvRot INT8 full/pruned FL2VA/Ref2VA transformer bases only; pruned BF16 files are not published and not supported.
-- BF16 or ConvRot INT8 Qwen3-VL text encoder only.
-- No FP8 or NVFP4/AWQ artifact loading.
+- BF16, ConvRot INT8, or NVFP4+AWQ Qwen3-VL text encoder only.
+- No FP8 artifact loading, and no NVFP4 transformer loading.
 - No CFG or negative prompt.
 - No numbered reference-directory convention.
 - Dataset `batch_size` is fixed to 1; use gradient accumulation for larger effective batches.

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -261,6 +261,7 @@ def load_h3_text_encoder(
     device: str | torch.device,
     dtype: torch.dtype = torch.bfloat16,
     disable_mmap: bool = False,
+    nvfp4_scaled_mm: bool = False,
 ):
     from transformers import Qwen3VLConfig, Qwen3VLModel
 
@@ -272,11 +273,14 @@ def load_h3_text_encoder(
 
     from accelerate import init_empty_weights
 
-    from musubi_tuner.modules.convrot_int8_utils import (
-        ConvRotInt8Quantizer,
-        apply_convrot_int8_monkey_patch,
-        has_comfy_quant_tensors,
+    from musubi_tuner.modules.comfy_quant_utils import (
+        FORMAT_CONVROT_INT8,
+        FORMAT_INT8_TENSORWISE,
+        FORMAT_NVFP4,
+        detect_comfy_quant_formats,
     )
+    from musubi_tuner.modules.convrot_int8_utils import ConvRotInt8Quantizer, apply_convrot_int8_monkey_patch
+    from musubi_tuner.modules.nvfp4_utils import NvFp4Quantizer, apply_nvfp4_monkey_patch
     from musubi_tuner.utils.lora_utils import load_safetensors_with_lora_and_fp8
     from musubi_tuner.utils.safetensors_utils import load_safetensors
 
@@ -284,13 +288,8 @@ def load_h3_text_encoder(
         model = Qwen3VLModel(config)
         del model.language_model.norm
 
-    # loading straight to the target device avoids a resident full-model CPU copy
-    device = torch.device(device)
-    files = resolve_safetensors_files(checkpoint_path)
-    if has_comfy_quant_tensors(files, disable_numpy_memmap=disable_mmap):
-        # pre-quantized ConvRot INT8 artifact: the same streaming loader as the transformer;
-        # an empty target list disables dynamic quantization, the file dictates the layers
-        quantizer = ConvRotInt8Quantizer(target_layer_keys=[])
+    def _load_with_quantizer(quantizer):
+        # the same streaming loader as the transformer; the file dictates the quantized layers
         sd = load_safetensors_with_lora_and_fp8(
             model_files=[str(checkpoint_path)],  # unexpanded: the loader expands split shards itself
             lora_weights_list=None,
@@ -301,20 +300,48 @@ def load_h3_text_encoder(
             disable_numpy_memmap=disable_mmap,
             quantizer=quantizer,
         )
-        sd = {normalize_h3_text_encoder_key(key): value for key, value in sd.items()}
+        return {normalize_h3_text_encoder_key(key): value for key, value in sd.items()}
+
+    # loading straight to the target device avoids a resident full-model CPU copy
+    device = torch.device(device)
+    files = resolve_safetensors_files(checkpoint_path)
+    formats = detect_comfy_quant_formats(files, disable_numpy_memmap=disable_mmap)
+    if formats == {FORMAT_CONVROT_INT8}:
+        # pre-quantized ConvRot INT8 artifact; an empty target list disables dynamic quantization
+        quantizer = ConvRotInt8Quantizer(target_layer_keys=[])
+        sd = _load_with_quantizer(quantizer)
         groupsize_map = {normalize_h3_text_encoder_key(key): value for key, value in quantizer.module_groupsizes.items()}
         apply_convrot_int8_monkey_patch(model, sd, groupsize_map=groupsize_map)
         # int8 tensors cannot require grad, and load_state_dict(assign=True) re-wraps incoming
         # tensors with the meta params' requires_grad; the text encoder is frozen anyway
         model.requires_grad_(False)
+    elif FORMAT_NVFP4 in formats and formats <= {FORMAT_NVFP4, FORMAT_INT8_TENSORWISE}:
+        # pre-quantized ComfyUI NVFP4 (+AWQ) artifact with an INT8 per-row embedding
+        quantizer = NvFp4Quantizer()
+        sd = _load_with_quantizer(quantizer)
+        nvfp4_module_shapes = {normalize_h3_text_encoder_key(key): value for key, value in quantizer.nvfp4_module_shapes.items()}
+        int8_embedding_modules = [normalize_h3_text_encoder_key(key) for key in quantizer.int8_embedding_modules]
+        apply_nvfp4_monkey_patch(
+            model, sd, nvfp4_module_shapes, int8_embedding_modules, use_scaled_mm=nvfp4_scaled_mm, embedding_dtype=dtype
+        )
+        model.requires_grad_(False)
+    elif formats:
+        raise ValueError(
+            f"Unsupported ComfyUI quantization format combination in text encoder checkpoint: {sorted(formats)}."
+            " Supported: ConvRot INT8, or NVFP4 with an INT8 embedding."
+            f" / テキストエンコーダの量子化形式の組み合わせ {sorted(formats)} はサポートされていません。"
+            "ConvRot INT8、または NVFP4(+INT8 embedding) のみ対応しています。"
+        )
     else:
         sd = {}
         for file in files:
             shard = load_safetensors(str(file), device=device, disable_mmap=True, disable_numpy_memmap=disable_mmap)
             sd.update({normalize_h3_text_encoder_key(key): value for key, value in shard.items()})
 
+    # quantization scale tensors keep their own dtypes (fp32 row scales, fp8 block scales)
+    _KEEP_DTYPE_SUFFIXES = (".scale_weight", ".nvfp4_scale", ".nvfp4_block_scale")
     for key in sd.keys():
-        if sd[key].is_floating_point() and not key.endswith(".scale_weight"):
+        if sd[key].is_floating_point() and not key.endswith(_KEEP_DTYPE_SUFFIXES):
             sd[key] = sd[key].to(dtype)
     model.load_state_dict(sd, strict=True, assign=True)
     model.to(device)

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -122,7 +122,17 @@ def _cache_dtype(name: str) -> torch.dtype:
 
 def setup_parser() -> argparse.ArgumentParser:
     parser = cache_text_encoder_outputs.setup_parser_common()
-    parser.add_argument("--text_encoder", type=str, required=True, help="released MiniMax-H3 Qwen3-VL BF16 safetensors")
+    parser.add_argument(
+        "--text_encoder",
+        type=str,
+        required=True,
+        help="MiniMax-H3 Qwen3-VL safetensors (BF16, ConvRot INT8 or NVFP4, auto-detected)",
+    )
+    parser.add_argument(
+        "--nvfp4_scaled_mm",
+        action="store_true",
+        help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
+    )
     parser.add_argument(
         "--processor",
         type=str,
@@ -173,6 +183,7 @@ def main() -> None:
         device=device,
         dtype=torch.bfloat16,
         disable_mmap=args.disable_mmap,
+        nvfp4_scaled_mm=args.nvfp4_scaled_mm,
     )
 
     decoded_reference_cache = {}

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -187,6 +187,7 @@ def _encode_text(args, record: H3Record, text_visuals, device: torch.device):
         device=device,
         dtype=torch.bfloat16,
         disable_mmap=args.disable_numpy_memmap,
+        nvfp4_scaled_mm=args.nvfp4_scaled_mm,
     )
     hidden_states, token_tags = encode_h3_presentation(processor, text_encoder, presentation)
     del processor, text_encoder
@@ -297,7 +298,12 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--video_vae", required=True, help="MiniMax-H3 video VAE safetensors path or directory")
     parser.add_argument("--audio_vae", required=True, help="MiniMax-H3 audio VAE safetensors path or directory")
     parser.add_argument(
-        "--text_encoder", default=None, help="MiniMax-H3 Qwen3-VL safetensors path (BF16 or ConvRot INT8, auto-detected)"
+        "--text_encoder", default=None, help="MiniMax-H3 Qwen3-VL safetensors path (BF16, ConvRot INT8 or NVFP4, auto-detected)"
+    )
+    parser.add_argument(
+        "--nvfp4_scaled_mm",
+        action="store_true",
+        help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
     )
     parser.add_argument("--text_cache", default=None, help="optional precomputed mmh3 text cache")
     parser.add_argument("--processor", default=DEFAULT_PROCESSOR_ID, help="Qwen3-VL processor repo or directory")

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -447,6 +447,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             device=device,
             dtype=torch.bfloat16,
             disable_mmap=getattr(args, "disable_numpy_memmap", False),
+            nvfp4_scaled_mm=getattr(args, "nvfp4_scaled_mm", False),
         )
         text_encoder.eval().requires_grad_(False)
         try:
@@ -1020,6 +1021,11 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         type=str,
         default=None,
         help="MiniMax-H3 Qwen3-VL checkpoint used to encode training sample prompts",
+    )
+    parser.add_argument(
+        "--nvfp4_scaled_mm",
+        action="store_true",
+        help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
     )
     parser.add_argument(
         "--processor",

--- a/src/musubi_tuner/modules/comfy_quant_utils.py
+++ b/src/musubi_tuner/modules/comfy_quant_utils.py
@@ -1,0 +1,62 @@
+"""Shared helpers for ComfyUI ``.comfy_quant`` pre-quantized checkpoint specs.
+
+Each quantized module in a ComfyUI checkpoint carries a tiny sibling tensor
+``<module>.comfy_quant`` holding the uint8 bytes of a JSON object that declares the
+module's quantization format. This module only decodes the JSON and classifies
+formats so callers can route a checkpoint to the right loader; format-specific
+validation and conversion live with the loaders (``convrot_int8_utils`` for ConvRot
+INT8, ``nvfp4_utils`` for NVFP4 + per-row INT8 embeddings).
+"""
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Set, Union
+
+import torch
+
+from musubi_tuner.utils.safetensors_utils import MemoryEfficientSafeOpen
+
+COMFY_QUANT_SUFFIX = ".comfy_quant"
+COMFY_WEIGHT_SCALE_SUFFIX = ".weight_scale"
+
+# canonical labels returned by classify_comfy_quant_spec / detect_comfy_quant_formats
+FORMAT_CONVROT_INT8 = "convrot_int8"
+FORMAT_INT8_TENSORWISE = "int8_tensorwise"
+FORMAT_NVFP4 = "nvfp4"
+
+
+def decode_comfy_quant_spec(key: str, tensor: torch.Tensor) -> dict:
+    """Decode a ``.comfy_quant`` tensor (uint8 bytes of JSON) into a dict, format-agnostic."""
+    if tensor.dtype != torch.uint8 or tensor.ndim != 1:
+        raise ValueError(f"Invalid comfy_quant tensor for {key}: expected 1D uint8, got {tensor.dtype} ndim={tensor.ndim}")
+    try:
+        spec = json.loads(bytes(tensor.tolist()).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise ValueError(f"Invalid comfy_quant JSON for {key}: {e}") from e
+    if not isinstance(spec, dict):
+        raise ValueError(f"Invalid comfy_quant spec for {key}: expected a JSON object, got {type(spec).__name__}")
+    return spec
+
+
+def classify_comfy_quant_spec(spec: dict) -> str:
+    """Map a decoded spec to a canonical format label (unknown formats pass through as-is)."""
+    quant_format = spec.get("format")
+    if quant_format == FORMAT_INT8_TENSORWISE and spec.get("convrot"):
+        return FORMAT_CONVROT_INT8
+    return str(quant_format)
+
+
+def detect_comfy_quant_formats(files: Iterable[Union[str, Path]], *, disable_numpy_memmap: bool = False) -> Set[str]:
+    """Collect the canonical format labels a checkpoint declares (empty set: not pre-quantized).
+
+    Routing only — the spec tensors are tiny, so reading them here is cheap; per-format
+    validation happens again inside the selected loader.
+    """
+    formats: Set[str] = set()
+    for file in files:
+        with MemoryEfficientSafeOpen(str(file), disable_numpy_memmap=disable_numpy_memmap) as f:
+            for key in f.keys():
+                if key.endswith(COMFY_QUANT_SUFFIX):
+                    formats.add(classify_comfy_quant_spec(decode_comfy_quant_spec(key, f.get_tensor(key))))
+    return formats

--- a/src/musubi_tuner/modules/convrot_int8_utils.py
+++ b/src/musubi_tuner/modules/convrot_int8_utils.py
@@ -15,7 +15,6 @@ LoRA targets modules by class name "Linear", block swap streams ``module.weight.
 of Linear-named modules, and compile exclusion also keys on the class name.
 """
 
-import json
 import math
 import os
 from collections.abc import Iterable
@@ -30,6 +29,11 @@ import logging
 
 from tqdm import tqdm
 
+from musubi_tuner.modules.comfy_quant_utils import (
+    COMFY_QUANT_SUFFIX,
+    COMFY_WEIGHT_SCALE_SUFFIX,
+    decode_comfy_quant_spec,
+)
 from musubi_tuner.modules.convrot_int8_kernels import (
     HAS_TRITON,
     _build_hadamard,
@@ -45,10 +49,8 @@ logging.basicConfig(level=logging.INFO)
 
 CONVROT_GROUPSIZE = 256
 
-# ComfyUI pre-quantized checkpoint key suffixes: `.weight` (int8, rotated basis) +
+# ComfyUI pre-quantized ConvRot layers: `.weight` (int8, rotated basis) +
 # `.weight_scale` (fp32 [N, 1]) + `.comfy_quant` (uint8 bytes of a JSON spec).
-COMFY_QUANT_SUFFIX = ".comfy_quant"
-COMFY_WEIGHT_SCALE_SUFFIX = ".weight_scale"
 COMFY_QUANT_FORMAT_INT8 = "int8_tensorwise"
 
 
@@ -99,15 +101,7 @@ def parse_comfy_quant_spec(key: str, tensor: torch.Tensor) -> dict:
     Only ConvRot INT8 (``int8_tensorwise`` + ``convrot``) is supported; other formats
     (e.g. nvfp4) raise with a clear message.
     """
-    if tensor.dtype != torch.uint8 or tensor.ndim != 1:
-        raise ValueError(f"Invalid comfy_quant tensor for {key}: expected 1D uint8, got {tensor.dtype} ndim={tensor.ndim}")
-    try:
-        spec = json.loads(bytes(tensor.tolist()).decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as e:
-        raise ValueError(f"Invalid comfy_quant JSON for {key}: {e}") from e
-    if not isinstance(spec, dict):
-        raise ValueError(f"Invalid comfy_quant spec for {key}: expected a JSON object, got {type(spec).__name__}")
-
+    spec = decode_comfy_quant_spec(key, tensor)
     quant_format = spec.get("format")
     if quant_format != COMFY_QUANT_FORMAT_INT8 or not spec.get("convrot"):
         raise ValueError(

--- a/src/musubi_tuner/modules/nvfp4_utils.py
+++ b/src/musubi_tuner/modules/nvfp4_utils.py
@@ -1,0 +1,518 @@
+# Low-level NVFP4 routines (E2M1 encode/decode, cuBLAS swizzle, scaled_mm call) are
+# adapted from the exp-nvfp4-support-for-torch-2-10 branch, which was inspired by
+# comfy-kitchen (https://github.com/Comfy-Org/comfy-kitchen, Apache License 2.0).
+
+"""Loading ComfyUI pre-quantized NVFP4 (+AWQ) checkpoints for frozen text encoders.
+
+Layout of a ComfyUI NVFP4 artifact (verified bit-level against the BF16 reference of
+the MiniMax-H3 Qwen3-VL text encoder):
+
+- NVFP4 Linear: ``.weight`` U8 [N, K/2] with two E2M1 codes per byte (element 0 in the
+  HIGH nibble), ``.weight_scale`` F8_E4M3 per-16-block scales stored in the cuBLAS
+  128x4 tiled ("swizzled") layout, ``.weight_scale_2`` F32 per-tensor scale, and a
+  ``.comfy_quant`` spec ``{"format": "nvfp4", ...}``. Modules quantized with AWQ carry
+  a ``.pre_quant_scale`` [K] tensor that is multiplied into the *input* at runtime;
+  for the remaining modules the AWQ scale is folded into the preceding norm weights,
+  so the checkpoint is self-consistent and needs no special handling here.
+- INT8 embedding: ``.weight`` I8 [V, D] + ``.weight_scale`` F32 [V, 1]
+  (``{"format": "int8_tensorwise"}``, effectively per-row); dequant = weight * scale.
+- Everything else (norms, vision tower, biases) stays BF16.
+
+The state dict is converted to the Musubi runtime layout: ``.weight_scale`` becomes
+``.nvfp4_block_scale`` (kept swizzled: ``torch.nn.functional.scaled_mm`` consumes the
+swizzled layout directly, the dequantizing fallback unswizzles on the fly) and
+``.weight_scale_2`` becomes ``.nvfp4_scale``; the embedding scale becomes
+``.scale_weight`` (same dequant semantics as the ConvRot INT8 layout).
+
+Inference only: NVFP4 modules are frozen, the patched forwards have no autograd
+support. Dynamic (on-the-fly) NVFP4 quantization is deliberately not offered — the
+published artifacts are AWQ-calibrated, which cannot be reproduced without
+calibration data, and dynamically quantizing BF16 weights would silently produce a
+lower-quality model than ConvRot INT8.
+"""
+
+import os
+from typing import Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import logging
+
+from tqdm import tqdm
+
+from musubi_tuner.modules.comfy_quant_utils import (
+    COMFY_QUANT_SUFFIX,
+    COMFY_WEIGHT_SCALE_SUFFIX,
+    FORMAT_INT8_TENSORWISE,
+    FORMAT_NVFP4,
+    classify_comfy_quant_spec,
+    decode_comfy_quant_spec,
+)
+from musubi_tuner.utils.safetensors_utils import MemoryEfficientSafeOpen, TensorWeightAdapter, WeightTransformHooks
+
+logger = logging.getLogger(__name__)
+
+NVFP4_BLOCK_SIZE = 16
+
+F4_E2M1_MAX = 6.0
+F8_E4M3_MAX = 448.0
+
+COMFY_WEIGHT_SCALE_2_SUFFIX = ".weight_scale_2"
+COMFY_PRE_QUANT_SCALE_SUFFIX = ".pre_quant_scale"
+
+# E2M1 code -> value (codes 0..7 positive, 8..15 negative)
+_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0)
+
+# byte -> (high nibble value, low nibble value), cached per (device, dtype)
+_BYTE_PAIR_LUT_CACHE: Dict[Tuple[torch.device, torch.dtype], torch.Tensor] = {}
+
+
+def _byte_pair_lut(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    lut = _BYTE_PAIR_LUT_CACHE.get((device, dtype))
+    if lut is None:
+        values = torch.tensor(_E2M1_VALUES, dtype=torch.float32)
+        codes = torch.arange(256, dtype=torch.int64)
+        lut = torch.stack([values[codes >> 4], values[codes & 0x0F]], dim=1).to(device=device, dtype=dtype)
+        _BYTE_PAIR_LUT_CACHE[(device, dtype)] = lut
+    return lut
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _roundup(value: int, multiple: int) -> int:
+    return _ceil_div(value, multiple) * multiple
+
+
+# region cuBLAS 128x4 tiled block-scale layout
+# https://docs.nvidia.com/cuda/cublas/index.html#d-block-scaling-factors-layout
+
+
+def to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
+    """Rearrange (H, W) block scales into the cuBLAS tiled layout (padded to 128x4)."""
+    rows, cols = input_matrix.shape
+    n_row_blocks = _ceil_div(rows, 128)
+    n_col_blocks = _ceil_div(cols, 4)
+    padded_rows = n_row_blocks * 128
+    padded_cols = n_col_blocks * 4
+    padded = input_matrix
+    if (rows, cols) != (padded_rows, padded_cols):
+        padded = torch.zeros((padded_rows, padded_cols), device=input_matrix.device, dtype=input_matrix.dtype)
+        padded[:rows, :cols] = input_matrix
+    blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
+    rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
+    return rearranged.reshape(padded_rows, padded_cols)
+
+
+def from_blocked(blocked_matrix: torch.Tensor, num_rows: int, num_cols: int) -> torch.Tensor:
+    """Reverse the cuBLAS tiled layout back to a row-major (num_rows, num_cols) matrix."""
+    n_row_blocks = _ceil_div(num_rows, 128)
+    n_col_blocks = _ceil_div(num_cols, 4)
+    padded_rows = n_row_blocks * 128
+    padded_cols = n_col_blocks * 4
+    step1 = blocked_matrix.reshape(-1, 32, 16)
+    step2 = step1.reshape(-1, 32, 4, 4).transpose(1, 2)
+    step3 = step2.reshape(n_row_blocks, n_col_blocks, 4, 32, 4)
+    step4 = step3.reshape(n_row_blocks, n_col_blocks, 128, 4)
+    step5 = step4.permute(0, 2, 1, 3)
+    unblocked = step5.reshape(padded_rows, padded_cols)
+    return unblocked[:num_rows, :num_cols]
+
+
+# endregion
+
+
+def dequantize_nvfp4(
+    packed: torch.Tensor,
+    block_scale: torch.Tensor,
+    per_tensor_scale: torch.Tensor,
+    orig_shape: Tuple[int, int],
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Dequantize packed NVFP4 data (block_scale in the swizzled layout) to ``orig_shape``."""
+    stored_rows = packed.shape[0]
+    stored_cols = packed.shape[1] * 2
+    lut = _byte_pair_lut(packed.device, out_dtype)
+    # one embedding lookup decodes both nibbles of each byte: [R, C/2] -> [R, C/2, 2] -> [R, C]
+    weight = F.embedding(packed.reshape(-1).int(), lut).reshape(stored_rows, stored_cols)
+    scales = from_blocked(block_scale, stored_rows, stored_cols // NVFP4_BLOCK_SIZE)
+    total = (per_tensor_scale.float() * scales.float()).to(out_dtype)
+    weight = (weight.reshape(stored_rows, -1, NVFP4_BLOCK_SIZE) * total.unsqueeze(-1)).reshape(stored_rows, stored_cols)
+    return weight[: orig_shape[0], : orig_shape[1]]
+
+
+# region runtime activation quantization for the scaled_mm (W4A4) path
+
+
+def _n_ones(n: int) -> int:
+    return (1 << n) - 1
+
+
+_EBITS_F32, _MBITS_F32 = 8, 23
+_F32_EXP_BIAS = _n_ones(_EBITS_F32 - 1)
+
+
+def _f32_to_e2m1_unpacked(x: torch.Tensor) -> torch.Tensor:
+    """Convert FP32 to E2M1 codes stored one-per-byte in uint8 (round-to-nearest-even)."""
+    ebits, mbits = 2, 1
+    assert x.dtype == torch.float
+    exp_bias = _n_ones(ebits - 1)
+    max_int = _n_ones(ebits + mbits)
+    sign_mask = 1 << (ebits + mbits)
+    magic_adder = _n_ones(_MBITS_F32 - mbits - 1)
+    max_normal = 2 ** (_n_ones(ebits) - exp_bias) * (_n_ones(mbits + 1) / (2**mbits))
+    min_normal = 2 ** (1 - exp_bias)
+    denorm_exp = (_F32_EXP_BIAS - exp_bias) + (_MBITS_F32 - mbits) + 1
+    denorm_mask_int = denorm_exp << _MBITS_F32
+    denorm_mask_float = torch.tensor(denorm_mask_int, dtype=torch.int32, device=x.device).view(torch.float32)
+
+    x = x.view(torch.int32)
+    sign = x & 0x80000000
+    x = (x ^ sign).view(torch.float)
+
+    saturate_mask = x >= max_normal
+    denormal_mask = torch.logical_and(torch.logical_not(saturate_mask), x < min_normal)
+    normal_mask = torch.logical_not(torch.logical_or(saturate_mask, denormal_mask))
+
+    denormal_x = (x + denorm_mask_float).view(torch.int32) - denorm_mask_int
+    denormal_x = denormal_x.to(torch.uint8)
+
+    normal_x = x.view(torch.int32)
+    mant_odd = (normal_x >> (_MBITS_F32 - mbits)) & 1
+    normal_x = normal_x + (((exp_bias - _F32_EXP_BIAS) << _MBITS_F32) + magic_adder) + mant_odd
+    normal_x = (normal_x >> (_MBITS_F32 - mbits)).to(torch.uint8)
+
+    result = torch.full_like(x, max_int, dtype=torch.uint8)
+    result = torch.where(denormal_mask, denormal_x, result)
+    result = torch.where(normal_mask, normal_x, result)
+
+    sign_lp = (sign >> (_MBITS_F32 + _EBITS_F32 - mbits - ebits)).to(torch.uint8) & sign_mask
+    return result | sign_lp
+
+
+def pack_uint4(codes: torch.Tensor) -> torch.Tensor:
+    """Pack pairs of 4-bit codes (one per byte) into bytes, element 0 in the HIGH nibble."""
+    shape = codes.shape
+    assert shape[-1] % 2 == 0
+    codes = codes.contiguous().view(-1)
+    return (codes[::2] << 4 | codes[1::2]).view(*shape[:-1], shape[-1] // 2)
+
+
+def quantize_nvfp4_activation(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Quantize a 2D activation to NVFP4 for scaled_mm.
+
+    Returns (packed uint8 [Mp, K/2], swizzled block scales F8_E4M3, per-tensor scale F32,
+    original row count). Rows are padded to a multiple of 16 as scaled_mm requires.
+    """
+    orig_rows, cols = x.shape
+    if cols % NVFP4_BLOCK_SIZE != 0:
+        raise ValueError(f"NVFP4 activation width must be a multiple of {NVFP4_BLOCK_SIZE}, got {cols}")
+    padded_rows = _roundup(orig_rows, 16)
+    if padded_rows != orig_rows:
+        x = F.pad(x, (0, 0, 0, padded_rows - orig_rows))
+
+    per_tensor_scale = (torch.amax(x.abs()).float() / (F8_E4M3_MAX * F4_E2M1_MAX)).reshape(())
+
+    blocks = x.reshape(padded_rows, -1, NVFP4_BLOCK_SIZE)
+    block_scale = torch.amax(blocks.abs(), dim=-1).float() / F4_E2M1_MAX
+    scaled = torch.clamp(block_scale / torch.clamp(per_tensor_scale, min=torch.finfo(torch.float32).tiny), max=F8_E4M3_MAX)
+    scaled_f8 = scaled.to(torch.float8_e4m3fn)
+    total = per_tensor_scale * scaled_f8.float()
+    total_safe = torch.where(total == 0, torch.ones_like(total), total)
+
+    data = blocks.float() / total_safe.unsqueeze(-1)
+    data = torch.where((total == 0).unsqueeze(-1), torch.zeros_like(data), data)
+    data = torch.clamp(data, -F4_E2M1_MAX, F4_E2M1_MAX).reshape(padded_rows, cols)
+
+    packed = pack_uint4(_f32_to_e2m1_unpacked(data))
+    return packed, to_blocked(scaled_f8), per_tensor_scale, orig_rows
+
+
+def nvfp4_scaled_mm_available() -> bool:
+    return hasattr(torch, "float4_e2m1fn_x2") and hasattr(torch.nn.functional, "scaled_mm")
+
+
+def nvfp4_scaled_mm_linear(
+    x: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_block_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    orig_out_features: int,
+) -> torch.Tensor:
+    """W4A4 linear via torch.nn.functional.scaled_mm (torch 2.10+, Blackwell)."""
+    from torch.nn.functional import ScalingType, SwizzleType
+
+    x_packed, x_block_scale, x_scale, orig_rows = quantize_nvfp4_activation(x)
+    result = torch.nn.functional.scaled_mm(
+        x_packed.view(torch.float4_e2m1fn_x2),
+        weight_packed.view(torch.float4_e2m1fn_x2).t(),
+        scale_a=[x_block_scale.view(-1), x_scale],
+        scale_b=[weight_block_scale.view(-1), weight_scale],
+        bias=bias,
+        output_dtype=x.dtype,
+        scale_recipe_a=[ScalingType.BlockWise1x16, ScalingType.TensorWise],
+        scale_recipe_b=[ScalingType.BlockWise1x16, ScalingType.TensorWise],
+        swizzle_a=[SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE],
+        swizzle_b=[SwizzleType.SWIZZLE_32_4_4, SwizzleType.NO_SWIZZLE],
+    )
+    return result[:orig_rows, :orig_out_features]
+
+
+# endregion
+
+
+# region pre-quantized state dict loading
+
+
+class NvFp4Quantizer:
+    """Streams a ComfyUI pre-quantized NVFP4 (+ INT8 embedding) checkpoint.
+
+    Same protocol as ``ConvRotInt8Quantizer``: passed as ``quantizer`` to
+    ``load_safetensors_with_lora_and_fp8``. Loading only converts key names and
+    validates the tensors — there is no dynamic quantization, the file dictates the
+    quantized layers. ``nvfp4_module_shapes`` maps module paths to their original
+    (out_features, in_features) after loading; ``int8_embedding_modules`` lists the
+    per-row INT8 modules (embeddings). Pass both to ``apply_nvfp4_monkey_patch``.
+    """
+
+    def __init__(self):
+        self.nvfp4_module_shapes: Dict[str, Tuple[int, int]] = {}
+        self.int8_embedding_modules: List[str] = []
+
+    def load_and_quantize(
+        self,
+        model_files: List[str],
+        calc_device: Union[str, torch.device, None],
+        move_to_device: bool = False,
+        weight_hook: Optional[callable] = None,
+        disable_numpy_memmap: bool = False,
+        weight_transform_hooks: Optional[WeightTransformHooks] = None,
+    ) -> dict:
+        state_dict = {}
+        module_formats: Dict[str, str] = {}  # spans all shards
+        for model_file in model_files:
+            with MemoryEfficientSafeOpen(model_file, disable_numpy_memmap=disable_numpy_memmap) as original_f:
+                f = TensorWeightAdapter(weight_transform_hooks, original_f) if weight_transform_hooks is not None else original_f
+
+                keys = f.keys()
+
+                # pre-scan the tiny spec tensors so each module's format is known before
+                # the (possibly earlier-iterated) weight/scale keys arrive
+                for key in keys:
+                    if key.endswith(COMFY_QUANT_SUFFIX):
+                        module_path = key[: -len(COMFY_QUANT_SUFFIX)]
+                        spec_format = classify_comfy_quant_spec(decode_comfy_quant_spec(key, f.get_tensor(key)))
+                        if spec_format not in (FORMAT_NVFP4, FORMAT_INT8_TENSORWISE):
+                            raise ValueError(
+                                f"Unsupported comfy_quant format for {key}: {spec_format}. The NVFP4 loader supports"
+                                ' "nvfp4" Linear layers and "int8_tensorwise" embeddings only.'
+                                f" / {key} の comfy_quant 形式 {spec_format} はNVFP4ローダーではサポートされていません。"
+                            )
+                        module_formats[module_path] = spec_format
+                if module_formats and weight_hook is not None:
+                    raise ValueError(
+                        f"Cannot merge LoRA weights into pre-quantized NVFP4 checkpoint {model_file}."
+                        " Use the original BF16 weights instead."
+                        f" / 事前量子化済みNVFP4チェックポイント {model_file} にはLoRAをマージできません。"
+                        "BF16の元重みを使用してください。"
+                    )
+
+                for key in tqdm(keys, desc=f"Loading {os.path.basename(model_file)}", unit="key"):
+                    if key.endswith(COMFY_QUANT_SUFFIX):
+                        continue  # consumed in the pre-scan, not a model tensor
+
+                    value = f.get_tensor(key)
+                    original_device = value.device  # usually cpu
+                    passthrough_device = calc_device if (calc_device is not None and move_to_device) else original_device
+                    converted_key = self._convert_key(key, value, module_formats)
+                    state_dict[converted_key] = value.to(passthrough_device)
+
+        self._validate_completeness(state_dict, module_formats)
+        logger.info(
+            f"Number of pre-quantized layers: {len(self.nvfp4_module_shapes)} NVFP4 Linear,"
+            f" {len(self.int8_embedding_modules)} INT8 embedding"
+        )
+        return state_dict
+
+    def _convert_key(self, key: str, value: torch.Tensor, module_formats: Dict[str, str]) -> str:
+        """Validate a tensor against its module's declared format and return the Musubi key."""
+        for suffix in (COMFY_WEIGHT_SCALE_SUFFIX, COMFY_WEIGHT_SCALE_2_SUFFIX, COMFY_PRE_QUANT_SCALE_SUFFIX, ".weight"):
+            if key.endswith(suffix):
+                module_path = key[: -len(suffix)]
+                break
+        else:
+            return key  # bias, norm, etc.: passthrough
+        spec_format = module_formats.get(module_path)
+        if spec_format is None:
+            if key.endswith(".weight") and value.dtype.itemsize == 1:
+                raise ValueError(
+                    f"Layer {key} is already in {value.dtype} format but has no {COMFY_QUANT_SUFFIX} spec."
+                    f" / レイヤー {key} は既に{value.dtype}形式ですが {COMFY_QUANT_SUFFIX} がありません。"
+                )
+            if key.endswith((COMFY_WEIGHT_SCALE_SUFFIX, COMFY_WEIGHT_SCALE_2_SUFFIX, COMFY_PRE_QUANT_SCALE_SUFFIX)):
+                raise ValueError(f"Found {key} without a matching {module_path}{COMFY_QUANT_SUFFIX} spec")
+            return key
+
+        if spec_format == FORMAT_NVFP4:
+            if key.endswith(COMFY_WEIGHT_SCALE_SUFFIX):
+                if value.dtype is not torch.float8_e4m3fn:
+                    raise ValueError(f"NVFP4 block scale {key} must be F8_E4M3, got {value.dtype}")
+                return module_path + ".nvfp4_block_scale"
+            if key.endswith(COMFY_WEIGHT_SCALE_2_SUFFIX):
+                if value.dtype is not torch.float32 or value.ndim != 0:
+                    raise ValueError(f"NVFP4 per-tensor scale {key} must be a F32 scalar, got {value.dtype} {tuple(value.shape)}")
+                return module_path + ".nvfp4_scale"
+            if key.endswith(COMFY_PRE_QUANT_SCALE_SUFFIX):
+                if not value.is_floating_point() or value.ndim != 1:
+                    raise ValueError(f"AWQ pre_quant_scale {key} must be a 1D float tensor, got {value.dtype} {tuple(value.shape)}")
+                return key
+            # .weight
+            if value.dtype is not torch.uint8 or value.ndim != 2:
+                raise ValueError(f"NVFP4 weight {key} must be 2D uint8 (packed), got {value.dtype} ndim={value.ndim}")
+            in_features = value.shape[1] * 2
+            if in_features % NVFP4_BLOCK_SIZE != 0:
+                raise ValueError(f"NVFP4 weight {key}: in_features {in_features} not a multiple of {NVFP4_BLOCK_SIZE}")
+            self.nvfp4_module_shapes[module_path] = (value.shape[0], in_features)
+            return key
+
+        # FORMAT_INT8_TENSORWISE: per-row INT8, embeddings only (validated at patch time)
+        if key.endswith(COMFY_WEIGHT_SCALE_SUFFIX):
+            if value.dtype is not torch.float32:
+                raise ValueError(f"INT8 per-row scale {key} must be F32, got {value.dtype}")
+            return module_path + ".scale_weight"
+        if key.endswith((COMFY_WEIGHT_SCALE_2_SUFFIX, COMFY_PRE_QUANT_SCALE_SUFFIX)):
+            raise ValueError(f"Unexpected tensor {key} for int8_tensorwise module {module_path}")
+        if value.dtype is not torch.int8:
+            raise ValueError(f"INT8 weight {key} must be int8, got {value.dtype}")
+        self.int8_embedding_modules.append(module_path)
+        return key
+
+    def _validate_completeness(self, state_dict: dict, module_formats: Dict[str, str]) -> None:
+        for module_path, spec_format in module_formats.items():
+            if spec_format == FORMAT_NVFP4:
+                required = (".weight", ".nvfp4_block_scale", ".nvfp4_scale")
+            else:
+                required = (".weight", ".scale_weight")
+            missing = [module_path + suffix for suffix in required if module_path + suffix not in state_dict]
+            if missing:
+                raise ValueError(f"Pre-quantized module {module_path} is missing tensors {missing}")
+
+            if spec_format == FORMAT_NVFP4:
+                rows, in_features = self.nvfp4_module_shapes[module_path]
+                expected_scale_numel = _roundup(rows, 128) * _roundup(in_features // NVFP4_BLOCK_SIZE, 4)
+                block_scale = state_dict[module_path + ".nvfp4_block_scale"]
+                if block_scale.numel() != expected_scale_numel:
+                    raise ValueError(
+                        f"NVFP4 module {module_path}: block scale has {block_scale.numel()} elements,"
+                        f" expected {expected_scale_numel} for weight shape ({rows}, {in_features})"
+                    )
+                pre_quant_scale = state_dict.get(module_path + COMFY_PRE_QUANT_SCALE_SUFFIX)
+                if pre_quant_scale is not None and pre_quant_scale.shape[0] != in_features:
+                    raise ValueError(
+                        f"NVFP4 module {module_path}: pre_quant_scale has {pre_quant_scale.shape[0]} elements,"
+                        f" expected in_features {in_features}"
+                    )
+            else:
+                weight = state_dict[module_path + ".weight"]
+                scale = state_dict[module_path + ".scale_weight"]
+                expected_scale_shape = (weight.shape[0], 1)
+                if tuple(scale.shape) != expected_scale_shape:
+                    raise ValueError(
+                        f"INT8 module {module_path}: scale shape must be {expected_scale_shape}, got {tuple(scale.shape)}"
+                    )
+
+
+# endregion
+
+
+# region monkey patch
+
+
+def nvfp4_linear_forward_patch(self: nn.Linear, x: torch.Tensor) -> torch.Tensor:
+    pre_quant_scale = getattr(self, "pre_quant_scale", None)
+    if pre_quant_scale is not None:
+        x = x * pre_quant_scale
+    if self._nvfp4_use_scaled_mm:
+        x_2d = x.reshape(-1, x.shape[-1])
+        out = nvfp4_scaled_mm_linear(
+            x_2d, self.weight, self.nvfp4_block_scale, self.nvfp4_scale, self.bias, self._nvfp4_orig_shape[0]
+        )
+        return out.reshape(*x.shape[:-1], out.shape[-1])
+    weight = dequantize_nvfp4(self.weight, self.nvfp4_block_scale, self.nvfp4_scale, self._nvfp4_orig_shape, x.dtype)
+    return F.linear(x, weight, self.bias)
+
+
+def int8_embedding_forward_patch(self: nn.Embedding, input: torch.Tensor) -> torch.Tensor:
+    rows = self.weight[input]  # index_select works on int8; padding_idx etc. only affect training
+    return (rows.float() * self.scale_weight[input]).to(self._int8_dequant_dtype)
+
+
+def apply_nvfp4_monkey_patch(
+    model: nn.Module,
+    optimized_state_dict: dict,
+    nvfp4_module_shapes: Dict[str, Tuple[int, int]],
+    int8_embedding_modules: List[str],
+    use_scaled_mm: bool = False,
+    embedding_dtype: torch.dtype = torch.bfloat16,
+) -> nn.Module:
+    """Patch NVFP4 Linear and INT8 embedding modules so a strict assign load can follow.
+
+    The patched modules get placeholder parameters/buffers with the quantized shapes and
+    dtypes (on the meta device); ``model.load_state_dict(state_dict, strict=True,
+    assign=True)`` then installs the real tensors. Modules stay ``nn.Linear`` /
+    ``nn.Embedding`` (patched forward), mirroring the ConvRot INT8 approach.
+    """
+    if use_scaled_mm and not nvfp4_scaled_mm_available():
+        raise ValueError(
+            "NVFP4 scaled_mm requires PyTorch 2.10+ (torch.float4_e2m1fn_x2 and torch.nn.functional.scaled_mm)."
+            " Omit the scaled_mm option to use the dequantize fallback."
+            " / NVFP4 scaled_mm には PyTorch 2.10 以降が必要です。scaled_mm オプションを外すと dequantize フォールバックで動作します。"
+        )
+
+    modules_by_name = dict(model.named_modules())
+    patched_count = 0
+
+    for name, (out_features, in_features) in nvfp4_module_shapes.items():
+        module = modules_by_name.get(name)
+        if not isinstance(module, nn.Linear):
+            raise ValueError(f"NVFP4 state dict declares {name}, which is not an nn.Linear in the model")
+        weight_key = name + ".weight"
+        module.weight = nn.Parameter(torch.empty_like(optimized_state_dict[weight_key], device="meta"), requires_grad=False)
+        module.register_buffer(
+            "nvfp4_block_scale", torch.empty_like(optimized_state_dict[name + ".nvfp4_block_scale"], device="meta")
+        )
+        module.register_buffer("nvfp4_scale", torch.empty((), dtype=torch.float32, device="meta"))
+        pre_quant_key = name + COMFY_PRE_QUANT_SCALE_SUFFIX
+        if pre_quant_key in optimized_state_dict:
+            module.register_buffer("pre_quant_scale", torch.empty_like(optimized_state_dict[pre_quant_key], device="meta"))
+        module._nvfp4_orig_shape = (out_features, in_features)
+        module._nvfp4_use_scaled_mm = use_scaled_mm
+        module.forward = nvfp4_linear_forward_patch.__get__(module, type(module))
+        patched_count += 1
+
+    for name in int8_embedding_modules:
+        module = modules_by_name.get(name)
+        if not isinstance(module, nn.Embedding):
+            raise ValueError(
+                f"int8_tensorwise module {name} is not an nn.Embedding; INT8 per-row quantization is only"
+                " supported for embeddings (use ConvRot INT8 checkpoints for Linear layers)"
+            )
+        module.weight = nn.Parameter(torch.empty_like(optimized_state_dict[name + ".weight"], device="meta"), requires_grad=False)
+        module.register_buffer("scale_weight", torch.empty_like(optimized_state_dict[name + ".scale_weight"], device="meta"))
+        module._int8_dequant_dtype = embedding_dtype
+        module.forward = int8_embedding_forward_patch.__get__(module, type(module))
+        patched_count += 1
+
+    if not use_scaled_mm and nvfp4_module_shapes:
+        logger.info("NVFP4 runs in weight-only mode (transient dequantization per forward)")
+    model.is_nvfp4 = True
+    model.nvfp4_layer_count = len(nvfp4_module_shapes)
+    logger.info(f"Number of NVFP4/INT8 monkey-patched modules: {patched_count}")
+    return model
+
+
+# endregion

--- a/tests/test_minimax_h3_nvfp4.py
+++ b/tests/test_minimax_h3_nvfp4.py
@@ -1,0 +1,378 @@
+import json
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from safetensors.torch import save_file
+
+from musubi_tuner.modules.comfy_quant_utils import (
+    FORMAT_CONVROT_INT8,
+    FORMAT_INT8_TENSORWISE,
+    FORMAT_NVFP4,
+    classify_comfy_quant_spec,
+    detect_comfy_quant_formats,
+)
+from musubi_tuner.modules import nvfp4_utils
+from musubi_tuner.modules.nvfp4_utils import (
+    NvFp4Quantizer,
+    apply_nvfp4_monkey_patch,
+    dequantize_nvfp4,
+    from_blocked,
+    quantize_nvfp4_activation,
+    to_blocked,
+)
+
+
+def _payload(**values) -> torch.Tensor:
+    raw = json.dumps(values, separators=(",", ":")).encode("utf-8")
+    return torch.tensor(list(raw), dtype=torch.uint8)
+
+
+def _nvfp4_payload() -> torch.Tensor:
+    return _payload(format="nvfp4", full_precision_matrix_mult=True)
+
+
+def _int8_payload() -> torch.Tensor:
+    return _payload(format="int8_tensorwise")
+
+
+def _quantize_linear_weight(weight: torch.Tensor):
+    """Produce the ComfyUI on-disk triple for a float weight (rows must be a multiple of 16)."""
+    packed, block_scale, scale, orig_rows = quantize_nvfp4_activation(weight.float())
+    assert orig_rows == weight.shape[0]
+    return packed, block_scale, scale
+
+
+def _nvfp4_module(module: str, weight: torch.Tensor, *, pre_quant_scale: torch.Tensor = None) -> dict:
+    packed, block_scale, scale = _quantize_linear_weight(weight)
+    tensors = {
+        f"{module}.weight": packed,
+        f"{module}.weight_scale": block_scale,
+        f"{module}.weight_scale_2": scale,
+        f"{module}.comfy_quant": _nvfp4_payload(),
+    }
+    if pre_quant_scale is not None:
+        tensors[f"{module}.pre_quant_scale"] = pre_quant_scale
+    return tensors
+
+
+def _int8_embedding_module(module: str, weight: torch.Tensor) -> dict:
+    scale = weight.abs().amax(dim=1, keepdim=True).float() / 127.0
+    quantized = torch.round(weight.float() / scale).clamp(-127, 127).to(torch.int8)
+    return {
+        f"{module}.weight": quantized,
+        f"{module}.weight_scale": scale,
+        f"{module}.comfy_quant": _int8_payload(),
+    }
+
+
+def _save(path, tensors):
+    save_file(tensors, str(path))
+    return path
+
+
+def _load(*paths, weight_hook=None):
+    quantizer = NvFp4Quantizer()
+    state_dict = quantizer.load_and_quantize([str(path) for path in paths], None, weight_hook=weight_hook)
+    return state_dict, quantizer
+
+
+# region format classification and probing
+
+
+def test_classify_comfy_quant_spec_labels():
+    assert classify_comfy_quant_spec({"format": "int8_tensorwise", "convrot": True}) == FORMAT_CONVROT_INT8
+    assert classify_comfy_quant_spec({"format": "int8_tensorwise"}) == FORMAT_INT8_TENSORWISE
+    assert classify_comfy_quant_spec({"format": "nvfp4"}) == FORMAT_NVFP4
+    assert classify_comfy_quant_spec({"format": "something_else"}) == "something_else"
+
+
+def test_detect_comfy_quant_formats(tmp_path):
+    nvfp4_file = _save(
+        tmp_path / "nvfp4.safetensors",
+        {
+            **_nvfp4_module("linear", torch.randn(16, 32)),
+            **_int8_embedding_module("embed", torch.randn(8, 32)),
+        },
+    )
+    plain_file = _save(tmp_path / "plain.safetensors", {"linear.weight": torch.zeros(8, 16, dtype=torch.bfloat16)})
+
+    assert detect_comfy_quant_formats([nvfp4_file]) == {FORMAT_NVFP4, FORMAT_INT8_TENSORWISE}
+    assert detect_comfy_quant_formats([plain_file]) == set()
+
+
+# endregion
+
+# region quantization roundtrip
+
+
+def test_swizzle_roundtrip_with_padding():
+    for rows, cols in ((8, 2), (128, 4), (200, 10)):
+        matrix = torch.randn(rows, cols)
+        assert torch.equal(from_blocked(to_blocked(matrix), rows, cols), matrix)
+
+
+def test_nvfp4_quantize_dequantize_roundtrip():
+    torch.manual_seed(0)
+    weight = torch.randn(32, 64)
+    packed, block_scale, scale = _quantize_linear_weight(weight)
+
+    assert packed.dtype is torch.uint8
+    assert packed.shape == (32, 32)
+    assert block_scale.dtype is torch.float8_e4m3fn
+
+    restored = dequantize_nvfp4(packed, block_scale, scale, (32, 64), torch.float32)
+    rel_err = (restored - weight).norm() / weight.norm()
+    assert rel_err < 0.15  # NVFP4 quantization noise is ~10% relative
+
+
+def test_nvfp4_nibble_order_is_high_first():
+    # one block of 16 values; the first value must land in the high nibble of byte 0
+    weight = torch.zeros(16, 16)
+    weight[0, 0] = 6.0  # E2M1 max, exactly representable
+    packed, _block_scale, _scale = _quantize_linear_weight(weight)
+    assert packed[0, 0] >> 4 == 0b0111  # +6.0 code
+    assert packed[0, 0] & 0x0F == 0
+
+
+# endregion
+
+# region streaming loader
+
+
+def test_conversion_produces_musubi_layout(tmp_path):
+    weight = torch.randn(16, 32)
+    embed_weight = torch.randn(8, 32)
+    path = _save(
+        tmp_path / "artifact.safetensors",
+        {
+            **_nvfp4_module("proj", weight, pre_quant_scale=torch.rand(32, dtype=torch.bfloat16) + 0.5),
+            **_int8_embedding_module("embed", embed_weight),
+            "norm.weight": torch.ones(32, dtype=torch.bfloat16),
+        },
+    )
+
+    state_dict, quantizer = _load(path)
+
+    assert state_dict["proj.weight"].dtype is torch.uint8
+    assert state_dict["proj.nvfp4_block_scale"].dtype is torch.float8_e4m3fn
+    assert state_dict["proj.nvfp4_scale"].dtype is torch.float32
+    assert state_dict["proj.pre_quant_scale"].shape == (32,)
+    assert "proj.weight_scale" not in state_dict
+    assert "proj.weight_scale_2" not in state_dict
+    assert "proj.comfy_quant" not in state_dict
+    assert state_dict["embed.weight"].dtype is torch.int8
+    assert state_dict["embed.scale_weight"].dtype is torch.float32
+    assert state_dict["norm.weight"].dtype is torch.bfloat16
+    assert quantizer.nvfp4_module_shapes == {"proj": (16, 32)}
+    assert quantizer.int8_embedding_modules == ["embed"]
+
+
+def test_conversion_rejects_lora_merge_hook(tmp_path):
+    path = _save(tmp_path / "artifact.safetensors", _nvfp4_module("proj", torch.randn(16, 32)))
+
+    with pytest.raises(ValueError, match="Cannot merge LoRA"):
+        _load(path, weight_hook=lambda key, value, keep_on_calc_device=False: value)
+
+
+def test_conversion_rejects_convrot_spec(tmp_path):
+    tensors = _nvfp4_module("proj", torch.randn(16, 32))
+    tensors["proj.comfy_quant"] = _payload(format="int8_tensorwise", convrot=True, convrot_groupsize=256)
+    path = _save(tmp_path / "convrot.safetensors", tensors)
+
+    with pytest.raises(ValueError, match="convrot_int8"):
+        _load(path)
+
+
+def test_conversion_rejects_orphan_quantized_weight(tmp_path):
+    path = _save(tmp_path / "orphan.safetensors", {"orphan.weight": torch.zeros(8, 16, dtype=torch.uint8)})
+
+    with pytest.raises(ValueError, match="comfy_quant"):
+        _load(path)
+
+
+def test_conversion_rejects_scale_without_spec(tmp_path):
+    path = _save(tmp_path / "orphan-scale.safetensors", {"orphan.weight_scale": torch.ones(8, 1)})
+
+    with pytest.raises(ValueError, match="without a matching"):
+        _load(path)
+
+
+@pytest.mark.parametrize("missing_suffix", [".weight", ".weight_scale", ".weight_scale_2"])
+def test_conversion_rejects_missing_nvfp4_siblings(tmp_path, missing_suffix):
+    tensors = _nvfp4_module("proj", torch.randn(16, 32))
+    del tensors["proj" + missing_suffix]
+    path = _save(tmp_path / "missing.safetensors", tensors)
+
+    with pytest.raises(ValueError, match="proj is missing tensors"):
+        _load(path)
+
+
+@pytest.mark.parametrize(
+    ("key", "replacement", "match"),
+    [
+        ("proj.weight", torch.zeros(16, 16, dtype=torch.int8), "must be 2D uint8"),
+        ("proj.weight_scale", torch.ones(128, 4, dtype=torch.float16), "must be F8_E4M3"),
+        ("proj.weight_scale_2", torch.ones(1, dtype=torch.float32), "F32 scalar"),
+    ],
+)
+def test_conversion_rejects_dtype_mismatches(tmp_path, key, replacement, match):
+    tensors = _nvfp4_module("proj", torch.randn(16, 32))
+    tensors[key] = replacement
+    path = _save(tmp_path / "bad-dtype.safetensors", tensors)
+
+    with pytest.raises(ValueError, match=match):
+        _load(path)
+
+
+def test_conversion_rejects_block_scale_size_mismatch(tmp_path):
+    tensors = _nvfp4_module("proj", torch.randn(16, 32))
+    tensors["proj.weight_scale"] = torch.zeros(128, 8, dtype=torch.float8_e4m3fn)
+    path = _save(tmp_path / "bad-scale-size.safetensors", tensors)
+
+    with pytest.raises(ValueError, match="block scale"):
+        _load(path)
+
+
+def test_conversion_rejects_pre_quant_scale_length_mismatch(tmp_path):
+    tensors = _nvfp4_module("proj", torch.randn(16, 32), pre_quant_scale=torch.ones(16, dtype=torch.bfloat16))
+    path = _save(tmp_path / "bad-pqs.safetensors", tensors)
+
+    with pytest.raises(ValueError, match="pre_quant_scale"):
+        _load(path)
+
+
+def test_conversion_rejects_int8_embedding_scale_shape(tmp_path):
+    tensors = _int8_embedding_module("embed", torch.randn(8, 32))
+    tensors["embed.weight_scale"] = torch.ones(8, dtype=torch.float32)
+    path = _save(tmp_path / "bad-embed-scale.safetensors", tensors)
+
+    with pytest.raises(ValueError, match="scale shape"):
+        _load(path)
+
+
+# endregion
+
+# region monkey patch and forward
+
+
+class _TinyTextModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Embedding(8, 32)
+        self.proj = nn.Linear(32, 16, bias=False)
+        self.head = nn.Linear(16, 4, bias=True)  # stays BF16
+
+    def forward(self, ids):
+        return self.head(self.proj(self.embed(ids)))
+
+
+def _build_patched_model(tmp_path, *, use_scaled_mm=False, pre_quant_scale=None):
+    torch.manual_seed(0)
+    proj_weight = torch.randn(16, 32)
+    embed_weight = torch.randn(8, 32)
+    tensors = {
+        **_nvfp4_module("proj", proj_weight, pre_quant_scale=pre_quant_scale),
+        **_int8_embedding_module("embed", embed_weight),
+        "head.weight": torch.randn(4, 16, dtype=torch.bfloat16),
+        "head.bias": torch.zeros(4, dtype=torch.bfloat16),
+    }
+    path = _save(tmp_path / "artifact.safetensors", tensors)
+    state_dict, quantizer = _load(path)
+
+    model = _TinyTextModel()
+    apply_nvfp4_monkey_patch(
+        model,
+        state_dict,
+        quantizer.nvfp4_module_shapes,
+        quantizer.int8_embedding_modules,
+        use_scaled_mm=use_scaled_mm,
+    )
+    model.requires_grad_(False)
+    for key in state_dict:
+        if state_dict[key].is_floating_point() and not key.endswith((".scale_weight", ".nvfp4_scale", ".nvfp4_block_scale")):
+            state_dict[key] = state_dict[key].to(torch.bfloat16)
+    model.load_state_dict(state_dict, strict=True, assign=True)
+    return model, proj_weight, embed_weight
+
+
+def test_patch_installs_quantized_tensors_and_strict_assign_load(tmp_path):
+    model, _proj_weight, _embed_weight = _build_patched_model(tmp_path)
+
+    assert type(model.proj) is nn.Linear
+    assert model.proj.weight.dtype is torch.uint8
+    assert not model.proj.weight.requires_grad
+    assert model.proj.nvfp4_block_scale.dtype is torch.float8_e4m3fn
+    assert model.proj.nvfp4_scale.dtype is torch.float32
+    assert model.proj._nvfp4_orig_shape == (16, 32)
+    assert type(model.embed) is nn.Embedding
+    assert model.embed.weight.dtype is torch.int8
+    assert model.embed.scale_weight.shape == (8, 1)
+    assert model.is_nvfp4 is True
+    assert model.nvfp4_layer_count == 1
+
+
+def test_patched_forward_matches_dequantized_reference(tmp_path):
+    model, proj_weight, embed_weight = _build_patched_model(tmp_path)
+    ids = torch.tensor([[0, 3, 7, 1]])
+
+    output = model(ids)
+
+    expected_embed = (model.embed.weight[ids].float() * model.embed.scale_weight[ids]).to(torch.bfloat16)
+    dequantized = dequantize_nvfp4(
+        model.proj.weight, model.proj.nvfp4_block_scale, model.proj.nvfp4_scale, (16, 32), torch.bfloat16
+    )
+    expected = model.head(F.linear(expected_embed, dequantized))
+    assert torch.equal(output, expected)
+
+    # and the whole pipeline stays close to the unquantized reference
+    reference = F.linear(F.embedding(ids, embed_weight.to(torch.bfloat16)), proj_weight.to(torch.bfloat16))
+    approx = F.linear(expected_embed, dequantized)
+    rel_err = (approx.float() - reference.float()).norm() / reference.float().norm()
+    assert rel_err < 0.2
+
+
+def test_patched_forward_applies_pre_quant_scale(tmp_path):
+    pre_quant_scale = torch.rand(32, dtype=torch.bfloat16) + 0.5
+    model, _proj_weight, _embed_weight = _build_patched_model(tmp_path, pre_quant_scale=pre_quant_scale)
+    x = torch.randn(2, 32, dtype=torch.bfloat16)
+
+    output = model.proj(x)
+
+    dequantized = dequantize_nvfp4(
+        model.proj.weight, model.proj.nvfp4_block_scale, model.proj.nvfp4_scale, (16, 32), torch.bfloat16
+    )
+    expected = F.linear(x * model.proj.pre_quant_scale, dequantized)
+    assert torch.equal(output, expected)
+
+
+def test_patch_rejects_nvfp4_on_non_linear(tmp_path):
+    path = _save(tmp_path / "artifact.safetensors", _nvfp4_module("embed", torch.randn(16, 32)))
+    state_dict, quantizer = _load(path)
+    model = _TinyTextModel()
+
+    with pytest.raises(ValueError, match="not an nn.Linear"):
+        apply_nvfp4_monkey_patch(model, state_dict, quantizer.nvfp4_module_shapes, [])
+
+
+def test_patch_rejects_int8_on_linear(tmp_path):
+    path = _save(tmp_path / "artifact.safetensors", _int8_embedding_module("proj", torch.randn(16, 32)))
+    state_dict, quantizer = _load(path)
+    model = _TinyTextModel()
+
+    with pytest.raises(ValueError, match="only\\s+supported for embeddings"):
+        apply_nvfp4_monkey_patch(model, state_dict, {}, quantizer.int8_embedding_modules)
+
+
+def test_patch_scaled_mm_requires_torch_support(tmp_path, monkeypatch):
+    path = _save(tmp_path / "artifact.safetensors", _nvfp4_module("proj", torch.randn(16, 32)))
+    state_dict, quantizer = _load(path)
+    model = _TinyTextModel()
+    monkeypatch.setattr(nvfp4_utils, "nvfp4_scaled_mm_available", lambda: False)
+
+    with pytest.raises(ValueError, match="PyTorch 2.10"):
+        apply_nvfp4_monkey_patch(model, state_dict, quantizer.nvfp4_module_shapes, [], use_scaled_mm=True)
+
+
+# endregion


### PR DESCRIPTION
## Summary

Adds loading of the ComfyUI pre-quantized **NVFP4+AWQ Qwen3-VL text encoder** (`qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors`, ~14.6 GB) for MiniMax-H3, wherever `--text_encoder` is accepted (TE caching, training-time sampling, generation). The format is auto-detected from the `comfy_quant` specs, like the ConvRot INT8 artifacts — no flag needed.

Text-encoder weight footprint: **BF16 ~48 GB → ConvRot INT8 ~25 GB → NVFP4 ~16 GB** (measured VRAM during TE caching).

## Design

- **Pre-quantized loading only, no dynamic NVFP4 quantization.** The artifact is AWQ-calibrated: `down_proj`/`o_proj` carry an explicit `pre_quant_scale` (multiplied into the input at runtime), and the AWQ scales of the remaining projections are folded into the preceding RMSNorm weights. This cannot be reproduced from BF16 weights without calibration data, so a dynamic path would silently produce a lower-quality model than ConvRot INT8 (which reproduces its published artifact bit-exactly and remains the choice for on-the-fly quantization).
- **New `modules/comfy_quant_utils.py`** — thin shared layer: `comfy_quant` spec decode/classification and header-level format probing. `convrot_int8_utils` reuses the decode helper; the ConvRot loader itself is unchanged.
- **New `modules/nvfp4_utils.py`** — `NvFp4Quantizer` (same streaming-quantizer protocol as `ConvRotInt8Quantizer`) converts the file to the Musubi runtime layout, and `apply_nvfp4_monkey_patch` patches the 350 NVFP4 `nn.Linear`s plus the per-row INT8 `nn.Embedding` (`embed_tokens`), followed by the usual strict `assign` load. Modules keep their classes, mirroring the ConvRot approach.
- **Forward modes**: default is weight-only (transient LUT dequantization + BF16 GEMM; works on any GPU and matches the artifact's own `full_precision_matrix_mult` declaration). `--nvfp4_scaled_mm` opts into W4A4 via `torch.nn.functional.scaled_mm` (torch 2.10+, Blackwell).
- `load_h3_text_encoder` routes by the declared format set; unknown or mixed combinations are rejected with explicit errors (NVFP4 transformers remain unsupported).

## Verification

- **Layout confirmed bit-level against the BF16 reference** before implementation: nibble order is high-first, block scales are stored cuBLAS-128×4-swizzled, AWQ direction is input-side. With the AWQ norm-folding accounted for, every probed layer matches at the NVFP4 noise floor (cos 0.994–0.996, rel err ~0.10); the INT8 embedding matches at cos 0.99994.
- **Unit tests**: 25 new tests (quantize/dequantize roundtrip, nibble order, swizzle roundtrip incl. padding, loader validation/rejection paths, monkey patch + strict assign load, forward parity incl. `pre_quant_scale`). Full suite 381 passed, ruff clean.
- **End-to-end on real weights** (same DiT/prompt/seed as the ConvRot INT8 gates): decoded deviation vs the BF16 text encoder is **mean 5.9/255** in the default mode (ConvRot INT8 TE: 3.5/255; typical LoRA effect on the same pipeline: ~79/255). With `--nvfp4_scaled_mm`: 7.2/255 — the activation FP4 quantization measurably costs quality, which is why weight-only is the default and W4A4 stays opt-in. TE caching ran at 1.2 s/record on GPU (INT8: 4.4 s/record; dequant+BF16 GEMM is lighter than the fused INT8 rotation path).

Docs: `docs/minimax_h3.md` gains an "NVFP4 Text Encoder" section; model table and limitations updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)