### PR TITLE
Add MiniMax-H3 text encoder layer streaming

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -137,7 +137,7 @@ python minimax_h3_cache_text_encoder_outputs.py \
   --skip_existing
 ```
 
-The same command accepts the ConvRot INT8 text encoder (`qwen3vl_32b_minimax_h3_int8_convrot.safetensors`) and the NVFP4+AWQ text encoder (`qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors`); the formats are detected automatically. The cache stores the state after the first 50 Qwen layers, before a final language-model norm. `hidden_states[0]` is the embedding output, so this is `hidden_states[50]`. The cache also stores per-row modality tags and presentation fingerprints; stale or structurally incompatible caches are rejected.
+The same command accepts the ConvRot INT8 text encoder (`qwen3vl_32b_minimax_h3_int8_convrot.safetensors`) and the NVFP4+AWQ text encoder (`qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors`); the formats are detected automatically. On VRAM-limited GPUs add `--text_encoder_blocks_to_swap 50` to stream the encoder layers from CPU, and `--text_encoder_attn_mode flash_attention_2` for long Ref2VA presentations (see Text Encoder Layer Streaming below). The cache stores the state after the first 50 Qwen layers, before a final language-model norm. `hidden_states[0]` is the embedding output, so this is `hidden_states[50]`. The cache also stores per-row modality tags and presentation fingerprints; stale or structurally incompatible caches are rejected.
 
 ## LoRA Training
 
@@ -194,7 +194,7 @@ Add the sampling assets and normal sampling schedule flags to the training comma
 
 The text presentations and condition latents are prepared once before the transformer is loaded. The two decode VAEs then remain on CPU and are moved to the accelerator one at a time for each scheduled sample. The shared trainer still owns sampling cadence, distributed prompt assignment, RNG restoration, and the block-swap inference/training transition.
 
-Training-time samples load the selected Qwen3-VL text encoder on the training accelerator before the transformer. The BF16 artifact is approximately 48 GB, so `--sample_prompts` requires roughly 50 GB of available accelerator memory there; the ConvRot INT8 artifact lowers the persistent text-encoder weights to ~25 GB and the NVFP4+AWQ artifact to ~15 GB, selected simply by passing their paths. Omit scheduled sampling when the selected encoder does not fit; a text-encoder device override or cached sample conditioning is follow-up scope.
+Training-time samples load the selected Qwen3-VL text encoder on the training accelerator before the transformer. The BF16 artifact is approximately 48 GB, so `--sample_prompts` requires roughly 50 GB of available accelerator memory there; the ConvRot INT8 artifact lowers the persistent text-encoder weights to ~25 GB and the NVFP4+AWQ artifact to ~15 GB, selected simply by passing their paths. `--text_encoder_blocks_to_swap` (see Text Encoder Layer Streaming below) removes most of the remaining weight footprint by streaming the encoder layers from CPU during this phase.
 
 All entries in one run use the training `--task`. T2VA JSON entries use the common prompt fields:
 
@@ -243,6 +243,16 @@ The artifact quantizes the 350 language-model Linears to NVFP4 (4-bit E2M1 value
 By default the patched layers run weight-only: the NVFP4 weight is transiently dequantized each forward and multiplied in BF16, which works on any GPU and matches the artifact's own `full_precision_matrix_mult` declaration. `--nvfp4_scaled_mm` opts into W4A4 matmuls via `torch.nn.functional.scaled_mm`, which also quantizes the activations to NVFP4; it requires PyTorch 2.10+ and a Blackwell-generation GPU, and trades some quality for speed (measured end-to-end against a BF16 text encoder with an identical DiT/seed: mean 5.9/255 decoded deviation in the default mode, 7.2/255 with `--nvfp4_scaled_mm`; the ConvRot INT8 text encoder scores 3.5/255 and a typical LoRA effect ~79/255 on the same pipeline).
 
 The text encoder is frozen in every Musubi flow, so the NVFP4 path is inference-only; it does not affect LoRA training of the transformer. Text-encoder LoRAs cannot be merged into or attached to the NVFP4 artifact.
+
+## Text Encoder Layer Streaming
+
+`--text_encoder_blocks_to_swap N` streams `N` of the 50 Qwen3-VL decoder layers from CPU memory instead of keeping them resident on the GPU, wherever `--text_encoder` is accepted (TE caching, training-time sampling, generation). `N=50` minimizes the device footprint; smaller values keep `50-N` layers resident and transfer proportionally less per record (useful when the encoder almost fits). Requires CUDA.
+
+The text encoder is frozen and forward-only in every Musubi flow, so this uses the H2D-only streaming machinery from `docs/block_swap.md`: the layer weights stay in pageable CPU masters (no large pinned allocation) and are prefetched layer by layer into a small ring of two reused GPU buffers while earlier layers compute; nothing is ever copied back. Quantized layers stream their weights together with their scale tensors, so the mechanism combines with every accepted artifact. The computed values are identical to a fully resident run — the same weights are read from the same bytes, only their location changes.
+
+With `--text_encoder_blocks_to_swap 50` the resident weights reduce to the embedding, the vision tower, and the norms, plus two ring buffers of one layer each (per-layer stream size: ~0.9 GB BF16, ~0.5 GB ConvRot INT8, ~0.3 GB NVFP4) and activations. This brings TE caching and training-time sampling with the quantized artifacts into reach of consumer GPUs; the trade-off is the CPU-side resident copy (the artifact size) and per-record transfer time of the streamed layers.
+
+`--text_encoder_attn_mode {sdpa,flash_attention_2,eager}` separately selects the transformers attention implementation for the text encoder (default: transformers' own default, sdpa). At long context, transformers' sdpa can fall back to the O(L^2) FP32 math kernel — around 12k rows the attention workspace alone exceeds 30 GB, defeating the streaming savings. Pass `flash_attention_2` (requires flash-attn) for long Ref2VA presentations of more than a few thousand rows.
 
 ## Generation
 

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -25,11 +25,11 @@ import hashlib
 import json
 import logging
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import torch
+import torch.nn as nn
 
 from musubi_tuner.minimax_h3.checkpoint import resolve_safetensors_files
 from musubi_tuner.minimax_h3.media import H3Record, H3Task
@@ -224,23 +224,6 @@ def _language_layers(model) -> list:
     return layers
 
 
-def extract_layer_50_pre_norm(output, model) -> torch.Tensor:
-    layers = _language_layers(model)
-    if len(layers) < LAYER_50_HIDDEN_STATE_INDEX:
-        raise ValueError(f"MiniMax-H3 Qwen3-VL needs at least 50 layers, got {len(layers)}")
-
-    captured = getattr(output, "h3_layer_50_pre_norm", None)
-    if captured is None:
-        captured = getattr(model, "_h3_layer_50_pre_norm", None)
-    if captured is not None:
-        return captured
-
-    hidden_states = getattr(output, "hidden_states", None)
-    if hidden_states is None or len(hidden_states) <= LAYER_50_HIDDEN_STATE_INDEX:
-        raise ValueError("MiniMax-H3 layer-50 pre-norm state was not captured")
-    return hidden_states[LAYER_50_HIDDEN_STATE_INDEX]
-
-
 def normalize_h3_text_encoder_key(key: str) -> str:
     if key.startswith("model."):
         return "language_model." + key.removeprefix("model.")
@@ -262,14 +245,26 @@ def load_h3_text_encoder(
     dtype: torch.dtype = torch.bfloat16,
     disable_mmap: bool = False,
     nvfp4_scaled_mm: bool = False,
+    blocks_to_swap: int = 0,
+    attn_mode: str | None = None,
 ):
     from transformers import Qwen3VLConfig, Qwen3VLModel
+
+    device = torch.device(device)
+    if blocks_to_swap > 0 and device.type != "cuda":
+        raise ValueError(
+            "--text_encoder_blocks_to_swap requires a CUDA device. / --text_encoder_blocks_to_swap には CUDA デバイスが必要です。"
+        )
 
     config = Qwen3VLConfig.from_pretrained(processor_path, revision=revision)
     if config.text_config.hidden_size != TEXT_WIDTH:
         raise ValueError(f"MiniMax-H3 Qwen3-VL hidden size must be {TEXT_WIDTH}, got {config.text_config.hidden_size}")
     config.text_config.num_hidden_layers = LAYER_50_HIDDEN_STATE_INDEX
     config.text_config.use_cache = False
+    if attn_mode is not None:
+        # sdpa falls back to the O(L^2) math kernel at long context; flash_attention_2 is
+        # recommended for presentations beyond ~3k rows
+        config._attn_implementation = attn_mode
 
     from accelerate import init_empty_weights
 
@@ -286,7 +281,15 @@ def load_h3_text_encoder(
 
     with init_empty_weights():
         model = Qwen3VLModel(config)
-        del model.language_model.norm
+        # the layer-50 pre-norm convention: the model is truncated to 50 layers and the final
+        # norm is replaced by Identity, so last_hidden_state IS the layer-50 pre-norm state
+        model.language_model.norm = nn.Identity()
+
+    # with block swap the state dict stays on the CPU and the streamed layers never fully
+    # reside on the device; otherwise loading straight to the target device avoids a
+    # resident full-model CPU copy
+    streaming = blocks_to_swap > 0
+    load_device = torch.device("cpu") if streaming else device
 
     def _load_with_quantizer(quantizer):
         # the same streaming loader as the transformer; the file dictates the quantized layers
@@ -296,14 +299,12 @@ def load_h3_text_encoder(
             lora_multipliers=None,
             fp8_optimization=False,
             calc_device=device,
-            move_to_device=True,
+            move_to_device=not streaming,
             disable_numpy_memmap=disable_mmap,
             quantizer=quantizer,
         )
         return {normalize_h3_text_encoder_key(key): value for key, value in sd.items()}
 
-    # loading straight to the target device avoids a resident full-model CPU copy
-    device = torch.device(device)
     files = resolve_safetensors_files(checkpoint_path)
     formats = detect_comfy_quant_formats(files, disable_numpy_memmap=disable_mmap)
     if formats == {FORMAT_CONVROT_INT8}:
@@ -335,7 +336,7 @@ def load_h3_text_encoder(
     else:
         sd = {}
         for file in files:
-            shard = load_safetensors(str(file), device=device, disable_mmap=True, disable_numpy_memmap=disable_mmap)
+            shard = load_safetensors(str(file), device=load_device, disable_mmap=True, disable_numpy_memmap=disable_mmap)
             sd.update({normalize_h3_text_encoder_key(key): value for key, value in shard.items()})
 
     # quantization scale tensors keep their own dtypes (fp32 row scales, fp8 block scales)
@@ -344,13 +345,74 @@ def load_h3_text_encoder(
         if sd[key].is_floating_point() and not key.endswith(_KEEP_DTYPE_SUFFIXES):
             sd[key] = sd[key].to(dtype)
     model.load_state_dict(sd, strict=True, assign=True)
-    model.to(device)
+    if streaming:
+        # the offloader requires frozen weights (the text encoder is frozen by contract anyway;
+        # the quantized branches have already dropped requires_grad, BF16 has not)
+        model.requires_grad_(False)
+        _enable_h3_text_encoder_streaming(model, device, blocks_to_swap)
+    else:
+        model.to(device)
     model.eval()
     return model
 
 
-class _Layer50Captured(Exception):
-    pass
+# quantization tensors that the ConvRot INT8 / NVFP4 monkey patches hang off the patched Linear
+# modules; streamed together with the weight. An explicit allowlist keeps unrelated (tiny)
+# buffers resident instead of silently streaming whatever a future patch registers.
+_TE_STREAM_QUANT_BUFFER_NAMES = ("scale_weight", "nvfp4_block_scale", "nvfp4_scale", "pre_quant_scale")
+
+
+def _te_swap_tensor_selector(block: nn.Module) -> list[tuple[nn.Module, str]]:
+    jobs: list[tuple[nn.Module, str]] = []
+    for _, module in block.named_modules():
+        if isinstance(module, nn.Linear) and module.weight is not None:
+            jobs.append((module, "weight"))
+            for name in _TE_STREAM_QUANT_BUFFER_NAMES:
+                if name in module._buffers:
+                    jobs.append((module, name))
+    return jobs
+
+
+def _enable_h3_text_encoder_streaming(model, device: torch.device, blocks_to_swap: int) -> None:
+    """Stream ``blocks_to_swap`` of the 50 Qwen3-VL decoder layers from CPU masters (H2D only).
+
+    The text encoder is frozen and forward-only, so ``LoRAStreamOffloader`` applies as-is;
+    the transformers forward loop does not know about the offloader, so it is driven from
+    forward hooks. Everything outside the decoder layers (embeddings, vision tower, norms)
+    stays resident on the device. Masters are pageable (staged copier): no giant pinned
+    allocation, which matters on Windows.
+    """
+    from musubi_tuner.modules.custom_offloading_utils import LoRAStreamOffloader, attach_forward_streaming_hooks
+
+    layers = list(_language_layers(model))
+    num_layers = len(layers)
+    if blocks_to_swap > num_layers:
+        raise ValueError(
+            f"--text_encoder_blocks_to_swap must be at most the number of text encoder layers ({num_layers}), got {blocks_to_swap}"
+        )
+
+    for name, child in model.named_children():
+        if name != "language_model":
+            child.to(device)
+    for name, child in model.language_model.named_children():
+        if name != "layers":
+            child.to(device)
+
+    offloader = LoRAStreamOffloader(
+        "mmh3-te",
+        layers,
+        num_layers,
+        blocks_to_swap,
+        supports_backward=False,
+        device=device,
+        ring_size=2,
+        use_pinned_memory=False,
+        swap_tensor_selector=_te_swap_tensor_selector,
+    )
+    # the handles are kept on the model so the hooks live exactly as long as the model does
+    model._h3_te_stream_hook_handles = attach_forward_streaming_hooks(offloader, layers)
+    offloader.prepare_block_devices_before_forward(layers)
+    model.h3_te_offloader = offloader
 
 
 def _processor_value(value):
@@ -391,31 +453,23 @@ def encode_h3_presentation(processor, model, presentation: H3Presentation) -> tu
     layers = _language_layers(model)
     if len(layers) != LAYER_50_HIDDEN_STATE_INDEX:
         raise ValueError(f"Released MiniMax-H3 text encoder must contain exactly 50 layers, got {len(layers)}")
-    captured = {}
+    norm = getattr(model.language_model, "norm", None)
+    if not isinstance(norm, nn.Identity):
+        raise ValueError("MiniMax-H3 text encoder must have an Identity final norm (load via load_h3_text_encoder)")
 
-    def capture_layer_50(module, args, output):
-        del module, args
-        captured["hidden"] = output[0] if isinstance(output, tuple) else output
-        raise _Layer50Captured
-
-    handle = layers[LAYER_50_HIDDEN_STATE_INDEX - 1].register_forward_hook(capture_layer_50)
-    device = next(model.parameters()).device
+    # with block swap the layer weights live on CPU masters, so the input device is taken
+    # from the always-resident embedding
+    device = model.language_model.embed_tokens.weight.device
     model_inputs = {
         key: value.to(device) if isinstance(value, torch.Tensor) else value
         for key, value in processed.items()
         if key != "token_type_ids"
     }
-    try:
-        model(**model_inputs, use_cache=False)
-    except _Layer50Captured:
-        pass
-    finally:
-        handle.remove()
-    if "hidden" not in captured:
-        raise RuntimeError("MiniMax-H3 text encoder did not reach layer 50")
-
-    output = SimpleNamespace(h3_layer_50_pre_norm=captured["hidden"], hidden_states=None, last_hidden_state=None)
-    hidden_states = extract_layer_50_pre_norm(output, model)
+    # the model is truncated to 50 layers and the final norm is Identity, so
+    # last_hidden_state is the layer-50 pre-norm hidden state
+    hidden_states = model(**model_inputs, use_cache=False).last_hidden_state
+    if hidden_states is None:
+        raise RuntimeError("MiniMax-H3 text encoder returned no last_hidden_state")
     if hidden_states.ndim != 3 or hidden_states.shape[0] != 1:
         raise ValueError(f"MiniMax-H3 layer-50 output must be [1,L,{TEXT_WIDTH}], got {tuple(hidden_states.shape)}")
     hidden_states = hidden_states[0]

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -134,6 +134,20 @@ def setup_parser() -> argparse.ArgumentParser:
         help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
     )
     parser.add_argument(
+        "--text_encoder_blocks_to_swap",
+        type=int,
+        default=0,
+        help="number of the 50 Qwen3-VL decoder layers to stream from CPU instead of keeping them on the GPU"
+        " (0 = disabled, 50 = minimum VRAM; requires CUDA)",
+    )
+    parser.add_argument(
+        "--text_encoder_attn_mode",
+        choices=("sdpa", "flash_attention_2", "eager"),
+        default=None,
+        help="attention implementation for the text encoder (default: transformers default, sdpa)."
+        " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
+    )
+    parser.add_argument(
         "--processor",
         type=str,
         default=DEFAULT_PROCESSOR_ID,
@@ -184,6 +198,8 @@ def main() -> None:
         dtype=torch.bfloat16,
         disable_mmap=args.disable_mmap,
         nvfp4_scaled_mm=args.nvfp4_scaled_mm,
+        blocks_to_swap=args.text_encoder_blocks_to_swap,
+        attn_mode=args.text_encoder_attn_mode,
     )
 
     decoded_reference_cache = {}

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -188,6 +188,8 @@ def _encode_text(args, record: H3Record, text_visuals, device: torch.device):
         dtype=torch.bfloat16,
         disable_mmap=args.disable_numpy_memmap,
         nvfp4_scaled_mm=args.nvfp4_scaled_mm,
+        blocks_to_swap=args.text_encoder_blocks_to_swap,
+        attn_mode=args.text_encoder_attn_mode,
     )
     hidden_states, token_tags = encode_h3_presentation(processor, text_encoder, presentation)
     del processor, text_encoder
@@ -304,6 +306,20 @@ def setup_parser() -> argparse.ArgumentParser:
         "--nvfp4_scaled_mm",
         action="store_true",
         help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
+    )
+    parser.add_argument(
+        "--text_encoder_blocks_to_swap",
+        type=int,
+        default=0,
+        help="number of the 50 Qwen3-VL decoder layers to stream from CPU instead of keeping them on the GPU"
+        " (0 = disabled, 50 = minimum VRAM; requires CUDA)",
+    )
+    parser.add_argument(
+        "--text_encoder_attn_mode",
+        choices=("sdpa", "flash_attention_2", "eager"),
+        default=None,
+        help="attention implementation for the text encoder (default: transformers default, sdpa)."
+        " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
     )
     parser.add_argument("--text_cache", default=None, help="optional precomputed mmh3 text cache")
     parser.add_argument("--processor", default=DEFAULT_PROCESSOR_ID, help="Qwen3-VL processor repo or directory")

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -448,6 +448,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             dtype=torch.bfloat16,
             disable_mmap=getattr(args, "disable_numpy_memmap", False),
             nvfp4_scaled_mm=getattr(args, "nvfp4_scaled_mm", False),
+            blocks_to_swap=getattr(args, "text_encoder_blocks_to_swap", 0),
+            attn_mode=getattr(args, "text_encoder_attn_mode", None),
         )
         text_encoder.eval().requires_grad_(False)
         try:
@@ -1026,6 +1028,20 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         "--nvfp4_scaled_mm",
         action="store_true",
         help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
+    )
+    parser.add_argument(
+        "--text_encoder_blocks_to_swap",
+        type=int,
+        default=0,
+        help="number of the 50 Qwen3-VL decoder layers to stream from CPU while encoding training sample prompts"
+        " (0 = disabled, 50 = minimum VRAM; requires CUDA; unrelated to the transformer's --blocks_to_swap)",
+    )
+    parser.add_argument(
+        "--text_encoder_attn_mode",
+        choices=("sdpa", "flash_attention_2", "eager"),
+        default=None,
+        help="attention implementation for the sample-prompt text encoder (default: transformers default, sdpa)."
+        " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
     )
     parser.add_argument(
         "--processor",

--- a/src/musubi_tuner/modules/custom_offloading_utils.py
+++ b/src/musubi_tuner/modules/custom_offloading_utils.py
@@ -65,6 +65,46 @@ def weighs_to_device(layer: nn.Module, device: torch.device):
             module.weight.data = module.weight.data.to(device, non_blocking=device.type != "cpu")
 
 
+def default_swap_tensor_selector(block: nn.Module) -> list[tuple[nn.Module, str]]:
+    """Default streaming selection rule: the ``weight`` of every ``*Linear`` module.
+
+    Same rule as ``ModelOffloader.swap_weight_devices_cuda``. An offloader can be given a
+    different selector to also stream tensors that a quantization scheme hangs off the same
+    modules (per-group scales etc.); each entry is ``(module, attribute_name)`` where the
+    attribute is a parameter or a registered buffer of the module.
+    """
+    jobs = []
+    for _, module in block.named_modules():
+        if hasattr(module, "weight") and module.weight is not None and module.__class__.__name__.endswith("Linear"):
+            jobs.append((module, "weight"))
+    return jobs
+
+
+def attach_forward_streaming_hooks(offloader, blocks: list[nn.Module]) -> list:
+    """Drive a block-swap offloader from forward hooks.
+
+    For models whose forward loop does not call the offloader itself (e.g. a Hugging Face
+    text encoder): each block waits for its own weights before running and releases/prefetches
+    after it finishes. Forward-only offloaders handle the pass boundary (wrap-around preload)
+    internally. Hooks must be attached before any per-call hooks so the prefetch of the last
+    block runs first. Returns the hook handles so callers can detach them.
+    """
+    handles = []
+    for index, block in enumerate(blocks):
+
+        def _wait_hook(module, args, _index=index):
+            del module, args
+            offloader.wait_for_block(_index)
+
+        def _submit_hook(module, args, output, _index=index):
+            del module, args, output
+            offloader.submit_move_blocks_forward(blocks, _index)
+
+        handles.append(block.register_forward_pre_hook(_wait_hook))
+        handles.append(block.register_forward_hook(_submit_hook))
+    return handles
+
+
 @dataclass
 class BlockSwapConfig:
     """
@@ -737,6 +777,10 @@ class LoRAStreamOffloader:
       - Because the streamed weights are frozen (no ``.grad`` to preserve), we swap the whole ``module.weight``
         *reference* between its CPU master Parameter and a preallocated GPU ring Parameter, instead of the
         ``.data`` storage trick used by ``ModelOffloader``. No per-step ``cudaMalloc``.
+      - What is streamed is decided by ``swap_tensor_selector`` (default: every ``*Linear`` ``weight``). A
+        selector may return several tensors per module -- e.g. a quantized weight together with its scale
+        buffers -- as ``(module, attribute_name)`` pairs; parameters are rebound as ``nn.Parameter`` ring
+        views, registered buffers as plain tensor views.
       - All swap weights of a block are packed into a single contiguous (byte) buffer -- one pinned CPU
         buffer per streaming block and one GPU buffer per ring slot -- and the individual weights are
         dtype/shape views into it. Loading a block is therefore a single H2D ``copy_`` instead of one
@@ -763,6 +807,7 @@ class LoRAStreamOffloader:
         ring_size: int = 2,
         use_pinned_memory: bool = True,
         debug: bool = False,
+        swap_tensor_selector=None,
     ):
         self.block_type = block_type
         self._blocks = blocks
@@ -772,6 +817,7 @@ class LoRAStreamOffloader:
         self.use_pinned_memory = use_pinned_memory
         self.supports_backward = supports_backward
         self.forward_only = not supports_backward
+        self.swap_tensor_selector = swap_tensor_selector if swap_tensor_selector is not None else default_swap_tensor_selector
 
         import os
 
@@ -791,11 +837,12 @@ class LoRAStreamOffloader:
         self.B = min(ring_size, self.S)  # clamp ring to number of streaming blocks
 
         # ---- finetuning guard: H2D-only must never lose weight updates ----
+        self._job_cache = {}  # block_idx -> [(module, attr_name, is_param) per swap tensor]
         for b in stream_idx:
-            for m in self._swap_modules(blocks[b]):
-                assert not m.weight.requires_grad, (
+            for m, name, is_param in self._jobs(b):
+                assert not (is_param and getattr(m, name).requires_grad), (
                     "LoRAStreamOffloader requires frozen base weights (LoRA / no full fine-tune). "
-                    f"Found a trainable Linear weight in block {b}."
+                    f"Found a trainable swap tensor {name} in block {b}."
                 )
 
         # ---- transfer engine: owns the copy stream and all H2D primitives ----
@@ -807,14 +854,13 @@ class LoRAStreamOffloader:
             self.copier = _StagedCopier(device, num_staging=self.B, debug=self.debug)
 
         # ---- runtime state (GPU buffers allocated lazily in prepare_block_devices_before_forward) ----
-        self.cpu_master = {}  # block_idx -> [CPU (pinned) Parameter per swap weight] (views into cpu_flat)
+        self.cpu_master = {}  # block_idx -> [CPU (pinned) Parameter / buffer tensor per swap tensor] (views into cpu_flat)
         self.cpu_flat = {}  # block_idx -> flat (pinned) uint8 CPU tensor backing the masters
-        self.ring_param = None  # [slot] -> [GPU nn.Parameter per swap weight] (views into ring_flat)
+        self.ring_param = None  # [slot] -> [GPU nn.Parameter / buffer tensor per swap tensor] (views into ring_flat)
         self.ring_flat = None  # [slot] -> flat uint8 GPU tensor backing the ring params
-        self._layout = None  # ([byte offset per swap weight], total bytes) shared by all streaming blocks
+        self._layout = None  # ([byte offset per swap tensor], total bytes) shared by all streaming blocks
         self.in_slot = [None] * self.B  # slot -> block_idx currently bound to this slot (or None)
         self.free_event = [None] * self.B  # slot -> cuda.Event recording when compute finished using the slot
-        self._module_cache = {}  # block_idx -> [modules with swap weights]
 
         self._wait_ctx = "fwd"  # context tag for wait/load timing ("fwd" while in the forward loop, "bwd" in hooks)
         if self.debug:
@@ -836,24 +882,30 @@ class LoRAStreamOffloader:
 
     # ------------------------------------------------------------------ helpers
 
-    def _swap_modules(self, block: nn.Module) -> list[nn.Module]:
-        # same selection rule as ModelOffloader.swap_weight_devices_cuda: Linear layers with a weight
-        mods = []
-        for _, m in block.named_modules():
-            if hasattr(m, "weight") and m.weight is not None and m.__class__.__name__.endswith("Linear"):
-                mods.append(m)
-        return mods
-
-    def _modules(self, block_idx: int) -> list[nn.Module]:
-        cached = self._module_cache.get(block_idx)
+    def _jobs(self, block_idx: int) -> list[tuple[nn.Module, str, bool]]:
+        """Swap jobs of a block: ``(module, attr_name, is_param)`` per streamed tensor, cached."""
+        cached = self._job_cache.get(block_idx)
         if cached is None:
-            cached = self._swap_modules(self._blocks[block_idx])
-            self._module_cache[block_idx] = cached
+            cached = []
+            for m, name in self.swap_tensor_selector(self._blocks[block_idx]):
+                if name in m._parameters:
+                    is_param = True
+                elif name in m._buffers:
+                    is_param = False
+                else:
+                    raise ValueError(
+                        f"swap tensor selector returned {name!r}, which is neither a parameter nor a"
+                        f" registered buffer of {m.__class__.__name__} (block {block_idx})"
+                    )
+                cached.append((m, name, is_param))
+            self._job_cache[block_idx] = cached
         return cached
 
-    def _bind(self, block_idx: int, params: list[nn.Parameter]):
-        for m, p in zip(self._modules(block_idx), params):
-            m.weight = p
+    def _bind(self, block_idx: int, tensors: list[torch.Tensor]):
+        # parameters arrive as nn.Parameter, buffers as plain tensors; setattr keeps them in the
+        # module's _parameters / _buffers dicts respectively (buffer names are already registered)
+        for (m, name, _is_param), t in zip(self._jobs(block_idx), tensors):
+            setattr(m, name, t)
 
     @staticmethod
     def _compute_layout(weights: list[torch.Tensor]) -> tuple[list[int], int]:
@@ -867,9 +919,10 @@ class LoRAStreamOffloader:
             total += w.numel() * w.element_size()
         return offsets, total
 
-    def _flat_views(self, flat: torch.Tensor, weights: list[torch.Tensor]) -> list[torch.Tensor]:
-        """dtype/shape views into a flat uint8 buffer, one per swap weight, following ``self._layout``."""
-        offsets, _ = self._layout
+    @staticmethod
+    def _flat_views(flat: torch.Tensor, weights: list[torch.Tensor], layout: tuple[list[int], int]) -> list[torch.Tensor]:
+        """dtype/shape views into a flat uint8 buffer, one per swap tensor, following ``layout``."""
+        offsets, _ = layout
         return [flat[off : off + w.numel() * w.element_size()].view(w.dtype).view(w.shape) for off, w in zip(offsets, weights)]
 
     def _load(self, rank: int, slot: int, ctx: str = "fwd"):
@@ -931,46 +984,81 @@ class LoRAStreamOffloader:
                     weighs_to_device(b, self.device)
                 continue
 
-            if first_time:
-                # move the whole block to device (buffers, norms, bias), then pull the swap weights back to
-                # the CPU into one flat (pinned) buffer per block as the persistent masters
-                b.to(self.device)
-                mods = self._modules(i)
-                weights = [m.weight.data for m in mods]
-                if self._layout is None:
-                    self._layout = self._compute_layout(weights)  # first streaming block defines the shared layout
-                flat = torch.empty(self._layout[1], dtype=torch.uint8, device=cpu_device)
-                if self.use_pinned_memory:
-                    flat = flat.pin_memory(device=self.device)
-                master = []
-                for m, view in zip(mods, self._flat_views(flat, weights)):
-                    view.copy_(m.weight.data)  # one-time D2H into the flat master
-                    m.weight.data = view
-                    master.append(m.weight)  # keep the original Parameter object as the persistent master
-                self.cpu_flat[i] = flat
-                self.cpu_master[i] = master
-            else:
+            if not first_time:
                 # re-prepare (e.g. around in-training sampling): the non-swap parts are already on the device
                 # and the CPU masters have stayed on the CPU throughout, so just repoint weights to the masters.
                 # IMPORTANT: do NOT call b.to(device) here -- it would drag the CPU masters onto the GPU and
                 # they would never be released (every swap block would end up resident).
                 self._bind(i, self.cpu_master[i])
+                continue
+
+            jobs = self._jobs(i)
+            tensors = [getattr(m, name).data for m, name, _ in jobs]
+            if self._layout is None:
+                self._layout = self._compute_layout(tensors)  # first streaming block defines the shared layout
+            flat = torch.empty(self._layout[1], dtype=torch.uint8, device=cpu_device)
+            if self.use_pinned_memory:
+                flat = flat.pin_memory(device=self.device)
+            views = self._flat_views(flat, tensors, self._layout)
+            master = []
+
+            if all(t.device.type == "cpu" for t in tensors):
+                # CPU-direct: build the flat masters host-to-host, detach the swap tensors from the
+                # module so the block's device move cannot drag them, then restore them as the masters.
+                # Avoids the H2D+D2H round trip of every streamed tensor that the general path below
+                # pays when the model starts on the CPU.
+                for (m, name, is_param), t, view in zip(jobs, tensors, views):
+                    view.copy_(t)  # host-to-host memcpy into the flat master
+                    placeholder = torch.empty(0, dtype=t.dtype, device=cpu_device)
+                    if is_param:
+                        m._parameters[name].data = placeholder
+                    else:
+                        m._buffers[name] = placeholder
+                b.to(self.device)  # non-swap params/buffers to the device; the placeholders are empty
+                for (m, name, is_param), view in zip(jobs, views):
+                    if is_param:
+                        p = m._parameters[name]
+                        p.data = view
+                        master.append(p)  # keep the original Parameter object as the persistent master
+                    else:
+                        m._buffers[name] = view
+                        master.append(view)
+            else:
+                # swap tensors already live on an accelerator: move the whole block to the device
+                # (buffers, norms, bias), then pull the swap tensors back into the flat master (one-time D2H)
+                b.to(self.device)
+                for (m, name, is_param), view in zip(jobs, views):
+                    t = getattr(m, name)
+                    view.copy_(t.data)
+                    if is_param:
+                        t.data = view
+                        master.append(t)  # keep the original Parameter object as the persistent master
+                    else:
+                        m._buffers[name] = view
+                        master.append(view)
+
+            self.cpu_flat[i] = flat
+            self.cpu_master[i] = master
 
         # validate homogeneous streaming blocks (shared ring template)
         template = self.cpu_master[self.stream_idx[0]]
         for b in self.stream_idx[1:]:
-            assert len(self.cpu_master[b]) == len(template), f"block {b} has a different number of swap weights"
+            assert len(self.cpu_master[b]) == len(template), f"block {b} has a different number of swap tensors"
             for p, t in zip(self.cpu_master[b], template):
                 assert p.data.shape == t.data.shape and p.data.dtype == t.data.dtype, (
-                    f"block {b} swap-weight shape/dtype differs from the streaming template"
+                    f"block {b} swap-tensor shape/dtype differs from the streaming template"
                 )
 
         # preallocate the GPU ring (once); copies happen into these flat buffers, never reallocated
         if self.ring_param is None:
+            template_jobs = self._jobs(self.stream_idx[0])
             template_weights = [p.data for p in template]
             self.ring_flat = [torch.empty(self._layout[1], dtype=torch.uint8, device=self.device) for _ in range(self.B)]
             self.ring_param = [
-                [nn.Parameter(view, requires_grad=False) for view in self._flat_views(flat, template_weights)]
+                [
+                    nn.Parameter(view, requires_grad=False) if is_param else view
+                    for (_m, _name, is_param), view in zip(template_jobs, self._flat_views(flat, template_weights, self._layout))
+                ]
                 for flat in self.ring_flat
             ]
 

--- a/tests/test_minimax_h3_te_streaming.py
+++ b/tests/test_minimax_h3_te_streaming.py
@@ -1,0 +1,200 @@
+"""Tests for MiniMax-H3 text encoder layer streaming.
+
+Covers the generalized multi-tensor streaming of ``LoRAStreamOffloader`` (swap-tensor
+selectors, flat-buffer layout, hook-driven forwarding) on the CPU, plus a CUDA
+end-to-end check of the offloader itself. The numerical gate (streaming on/off produces
+bit-identical hidden states on the real model) runs in the machine smoke tests.
+"""
+
+from pathlib import Path
+import sys
+
+import pytest
+import torch
+import torch.nn as nn
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from musubi_tuner.minimax_h3.text_encoder import _te_swap_tensor_selector
+from musubi_tuner.modules.custom_offloading_utils import (
+    LoRAStreamOffloader,
+    attach_forward_streaming_hooks,
+    default_swap_tensor_selector,
+)
+
+
+class _QuantLinear(nn.Linear):
+    """Class name ends with Linear, like the fp8/quantization monkey-patch targets."""
+
+
+def test_default_selector_matches_legacy_linear_weight_rule():
+    block = nn.Sequential(nn.Linear(4, 4), nn.LayerNorm(4), _QuantLinear(4, 4), nn.Conv1d(1, 1, 1))
+
+    jobs = default_swap_tensor_selector(block)
+
+    assert [(id(module), name) for module, name in jobs] == [(id(block[0]), "weight"), (id(block[2]), "weight")]
+
+
+def _tiny_te_block(seed: int) -> nn.Module:
+    generator = torch.Generator().manual_seed(seed)
+
+    block = nn.Module()
+    block.quant = nn.Linear(8, 4, bias=False)
+    block.quant.weight = nn.Parameter(torch.randint(-128, 128, (4, 8), dtype=torch.int8, generator=generator), requires_grad=False)
+    block.quant.register_buffer("scale_weight", torch.rand(4, 1, generator=generator))
+    block.quant.register_buffer("nvfp4_scale", torch.rand((), generator=generator))
+    block.quant.register_buffer("running_stat", torch.rand(4, generator=generator))  # not in the allowlist
+    block.plain = nn.Linear(4, 4, bias=False)
+    with torch.no_grad():
+        block.plain.weight.copy_(torch.rand(4, 4, generator=generator))
+    block.plain.weight.requires_grad_(False)
+    block.norm = nn.LayerNorm(4)
+    return block
+
+
+def test_te_selector_streams_weights_and_allowlisted_quant_buffers_only():
+    block = _tiny_te_block(0)
+
+    jobs = _te_swap_tensor_selector(block)
+
+    assert [(id(module), name) for module, name in jobs] == [
+        (id(block.quant), "weight"),
+        (id(block.quant), "scale_weight"),
+        (id(block.quant), "nvfp4_scale"),
+        (id(block.plain), "weight"),
+    ]
+
+
+def test_flat_layout_views_roundtrip_mixed_dtypes():
+    tensors = [
+        torch.randn(3, 5, dtype=torch.bfloat16),
+        torch.randint(-128, 128, (4, 8), dtype=torch.int8),
+        torch.rand((), dtype=torch.float32),
+        torch.randint(0, 256, (2, 6), dtype=torch.uint8),
+        torch.randn(2, 4).to(torch.float8_e4m3fn),
+    ]
+
+    layout = LoRAStreamOffloader._compute_layout(tensors)
+    flat = torch.zeros(layout[1], dtype=torch.uint8)
+    views = LoRAStreamOffloader._flat_views(flat, tensors, layout)
+
+    for view, tensor in zip(views, tensors):
+        view.copy_(tensor)
+    for view, tensor in zip(views, tensors):
+        assert view.dtype == tensor.dtype
+        assert view.shape == tensor.shape
+        assert torch.equal(view.reshape(-1).view(torch.uint8), tensor.reshape(-1).view(torch.uint8))
+
+
+class _RecordingOffloader:
+    def __init__(self, log: list):
+        self.log = log
+
+    def wait_for_block(self, block_idx: int):
+        self.log.append(("wait", block_idx))
+
+    def submit_move_blocks_forward(self, blocks, block_idx: int):
+        self.log.append(("submit", block_idx))
+
+
+class _LoggingBlock(nn.Module):
+    def __init__(self, log: list, tag: int):
+        super().__init__()
+        self.log = log
+        self.tag = tag
+
+    def forward(self, x):
+        self.log.append(("compute", self.tag))
+        return x + 1
+
+
+def test_attach_forward_streaming_hooks_waits_before_and_submits_after_each_block():
+    log = []
+    blocks = [_LoggingBlock(log, index) for index in range(3)]
+    handles = attach_forward_streaming_hooks(_RecordingOffloader(log), blocks)
+
+    x = torch.zeros(1)
+    for block in blocks:
+        x = block(x)
+
+    assert x.item() == 3.0  # a post-hook must not replace the block output
+    assert log == [
+        ("wait", 0),
+        ("compute", 0),
+        ("submit", 0),
+        ("wait", 1),
+        ("compute", 1),
+        ("submit", 1),
+        ("wait", 2),
+        ("compute", 2),
+        ("submit", 2),
+    ]
+    for handle in handles:
+        handle.remove()
+
+
+def test_selector_returning_unknown_attribute_is_rejected():
+    block = _tiny_te_block(0)
+    offloader = LoRAStreamOffloader.__new__(LoRAStreamOffloader)  # job resolution only, no CUDA
+    offloader._blocks = [block]
+    offloader._job_cache = {}
+    offloader.swap_tensor_selector = lambda b: [(b.quant, "not_a_tensor")]
+
+    with pytest.raises(ValueError, match="neither a parameter nor a registered buffer"):
+        offloader._jobs(0)
+
+
+def _snapshot(block: nn.Module) -> dict[str, torch.Tensor]:
+    return {
+        "quant.weight": block.quant.weight.detach().clone(),
+        "quant.scale_weight": block.quant.scale_weight.clone(),
+        "quant.nvfp4_scale": block.quant.nvfp4_scale.clone(),
+        "plain.weight": block.plain.weight.detach().clone(),
+    }
+
+
+def _assert_block_matches(block: nn.Module, expected: dict[str, torch.Tensor], device_type: str):
+    for key, value in expected.items():
+        owner_name, attr = key.split(".")
+        actual = getattr(getattr(block, owner_name), attr)
+        assert actual.device.type == device_type, f"{key} on {actual.device}, expected {device_type}"
+        assert torch.equal(actual.cpu(), value), f"{key} does not match its master"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for LoRAStreamOffloader")
+def test_lora_stream_offloader_streams_quantized_blocks_from_cpu_masters():
+    device = torch.device("cuda")
+    blocks = [_tiny_te_block(seed) for seed in range(4)]
+    expected = [_snapshot(block) for block in blocks]
+
+    offloader = LoRAStreamOffloader(
+        "te-test",
+        blocks,
+        num_blocks=4,
+        blocks_to_swap=4,
+        supports_backward=False,
+        device=device,
+        ring_size=2,
+        use_pinned_memory=False,
+        swap_tensor_selector=_te_swap_tensor_selector,
+    )
+    offloader.prepare_block_devices_before_forward(blocks)
+    torch.cuda.synchronize()
+
+    # non-swap parts of every block are resident on the device (CPU-direct first prepare)
+    for block in blocks:
+        assert block.norm.weight.device.type == "cuda"
+        assert block.quant.running_stat.device.type == "cuda"  # not allowlisted -> resident
+    # ring size 2: blocks 0/1 are preloaded, blocks 2/3 sit on their CPU masters
+    _assert_block_matches(blocks[0], expected[0], "cuda")
+    _assert_block_matches(blocks[2], expected[2], "cpu")
+    _assert_block_matches(blocks[3], expected[3], "cpu")
+
+    for _pass in range(2):  # second pass exercises the wrap-around preload
+        for index in range(4):
+            offloader.wait_for_block(index)
+            torch.cuda.synchronize()
+            _assert_block_matches(blocks[index], expected[index], "cuda")
+            offloader.submit_move_blocks_forward(blocks, index)
+    torch.cuda.synchronize()

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -19,7 +19,6 @@ from musubi_tuner.minimax_h3.text_encoder import (
     H3TextVisual,
     build_presentation,
     build_token_tags,
-    extract_layer_50_pre_norm,
     load_h3_text_encoder,
     normalize_h3_text_encoder_key,
     validate_text_rows,
@@ -108,30 +107,6 @@ def test_ref2va_presentation_preserves_jsonl_order_and_timestamp_format(tmp_path
     assert [tuple(video_block.shape) for video_block in presentation.videos] == [
         (3, 32, 32, 3),
     ]
-
-
-def test_layer_50_uses_hidden_state_index_50_where_zero_is_embeddings():
-    hidden_states = tuple(torch.full((1, 2, 4), float(index)) for index in range(51))
-    output = SimpleNamespace(hidden_states=hidden_states, last_hidden_state=torch.full((1, 2, 4), -1.0))
-    model = SimpleNamespace(language_model=SimpleNamespace(layers=[object() for _ in range(64)]))
-
-    actual = extract_layer_50_pre_norm(output, model)
-
-    torch.testing.assert_close(actual, hidden_states[50])
-
-
-def test_truncated_50_layer_output_prefers_captured_pre_norm_state():
-    captured = torch.full((1, 2, 4), 50.0)
-    output = SimpleNamespace(
-        hidden_states=None,
-        last_hidden_state=torch.full((1, 2, 4), -50.0),
-        h3_layer_50_pre_norm=captured,
-    )
-    model = SimpleNamespace(language_model=SimpleNamespace(layers=[object() for _ in range(50)]))
-
-    actual = extract_layer_50_pre_norm(output, model)
-
-    assert actual is captured
 
 
 def test_token_tags_cover_expanded_vision_rows_and_both_flanking_tokens():
@@ -370,6 +345,41 @@ def test_load_h3_text_encoder_accepts_nonpublished_convrot_layers_permissively(t
 
     assert loaded.visual.weight.dtype is torch.int8
     assert loaded.convrot_int8_layer_count == 351
+
+
+def test_load_h3_text_encoder_installs_identity_final_norm_for_layer_50_convention(tmp_path, monkeypatch):
+    # the hidden-state convention: 50 decoder layers + Identity final norm, so the model's
+    # last_hidden_state is exactly the layer-50 pre-norm state (no capture hook involved)
+    _install_fake_transformers(monkeypatch)
+    state, _scale = _fake_text_state(quantized=False)
+    checkpoint = tmp_path / "qwen3vl-bf16.safetensors"
+    save_file(state, checkpoint)
+
+    loaded = load_h3_text_encoder(
+        checkpoint,
+        processor_path="fake",
+        device="cpu",
+        dtype=torch.bfloat16,
+    )
+
+    assert isinstance(loaded.language_model.norm, nn.Identity)
+    assert len(loaded.language_model.layers) == 50
+
+
+def test_load_h3_text_encoder_rejects_streaming_without_cuda(tmp_path, monkeypatch):
+    _install_fake_transformers(monkeypatch)
+    state, _scale = _fake_text_state(quantized=False)
+    checkpoint = tmp_path / "qwen3vl-bf16.safetensors"
+    save_file(state, checkpoint)
+
+    with pytest.raises(ValueError, match="CUDA"):
+        load_h3_text_encoder(
+            checkpoint,
+            processor_path="fake",
+            device="cpu",
+            dtype=torch.bfloat16,
+            blocks_to_swap=50,
+        )
 
 
 def test_load_h3_text_encoder_rejects_convrot_layer_missing_from_the_model(tmp_path, monkeypatch):


### PR DESCRIPTION
## Overview

Adds `--text_encoder_blocks_to_swap N` (0-50) wherever `--text_encoder` is accepted (TE caching, generation, training-time sample encoding): N of the 50 Qwen3-VL decoder layers are streamed from pageable CPU masters into a small GPU ring instead of staying resident. The text encoder is frozen and forward-only in every Musubi flow, so this reuses the H2D-only `LoRAStreamOffloader` (#972) as-is — no D2H copies, no giant pinned allocation, and the computed hidden states are bit-identical to a fully resident run.

Also adds `--text_encoder_attn_mode {sdpa,flash_attention_2,eager}`: at long context, transformers' sdpa falls back to the O(L^2) FP32 math kernel, whose attention workspace alone can exceed 30 GB on long Ref2VA presentations.

## Changes

- **`LoRAStreamOffloader` generalization** (`modules/custom_offloading_utils.py`): internals move from "list of Linear modules" to `(module, attr, is_param)` swap jobs with an injectable `swap_tensor_selector`. The default selector reproduces the legacy `*Linear` weight rule exactly, so all existing architectures (and `create_offloader`/`BlockSwapConfig`) are untouched. Quantized TE layers stream their weight together with their scale tensors (ConvRot `scale_weight`, NVFP4 block/tensor scales, AWQ `pre_quant_scale`) in one flat coalesced buffer; parameters rebind as `nn.Parameter` ring views, registered buffers as plain views.
- **Hook-driven wiring**: new `attach_forward_streaming_hooks(offloader, blocks)` drives the offloader from forward pre/post hooks, since the transformers forward loop does not know about it. Architecture-neutral.
- **CPU-direct first prepare**: when the streamed tensors already live on the CPU, the flat masters are built host-to-host and only the non-swap parts of each block are moved to the device, removing the previous H2D+D2H round trip of every streamed weight at startup (loading is now slightly *faster* with streaming enabled).
- **Layer-50 extraction simplified**: the truncated 50-layer model now gets `norm = nn.Identity()` and returns normally — `last_hidden_state` *is* the layer-50 pre-norm state. The capture-hook + `_Layer50Captured` exception machinery is removed; this also removes a fragile hook-ordering interaction with the streaming hooks.

## Measurements (RTX PRO 6000, real weights)

Streaming on/off produces **bit-identical hidden states** for all three artifacts. Peak VRAM for load + 3 t2va encodes, `--text_encoder_blocks_to_swap 50` vs resident:

| artifact | resident | swap 50 |
| --- | --- | --- |
| BF16 (~48 GB) | 48.02 GiB | **4.43 GiB** |
| ConvRot INT8 (~25 GB) | 25.72 GiB | **3.52 GiB** |
| NVFP4+AWQ (~14.6 GB) | 15.17 GiB | **2.91 GiB** |

The overhead is per-record transfer time of the streamed layers (e.g. ~2.9 s/record for BF16, ~0.5 s/record for NVFP4 on short prompts); TE encoding is transfer-bound, which is why the feature targets memory rather than speed.

Full-pipeline smoke on real Ref2VA data (video + image + audio references): with sdpa the NVFP4 encoder peaked near 48 GB and took ~10 s per encode (math-kernel fallback); `--text_encoder_attn_mode flash_attention_2` alone brought it to ~19 GB (weights + ~3 GB) with near-instant encodes, and adding `--text_encoder_blocks_to_swap 50` ran the same encode in a bit over 6 GB with no noticeable slowdown. TE caching and training-time sampling paths verified as well.

## Tests / docs

- 387 tests passed + ruff clean. New `tests/test_minimax_h3_te_streaming.py`: default-selector regression, TE selector allowlist, mixed-dtype flat-layout round trip, hook ordering, selector validation, and a CUDA end-to-end streaming test with quantized-style blocks.
- `docs/minimax_h3.md`: new "Text Encoder Layer Streaming" section; caching and training-sample sections updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)