### PR TITLE
Fix MiniMax-H3 condition-noise RNG aliasing and simplify training augmentation

### DIFF
--- a/src/musubi_tuner/minimax_h3/sampling.py
+++ b/src/musubi_tuner/minimax_h3/sampling.py
@@ -77,11 +77,19 @@ def build_shifted_schedule(
     return H3SigmaSchedule(base=base, video=_shift(base, video_shift), audio=_shift(base, audio_shift))
 
 
+def create_sampling_generator(seed: int) -> torch.Generator:
+    """One seed drives one CPU noise stream, consumed in call order:
+    initialize_target_latents (video, then audio), then augment_condition_latents
+    (visual conditions, then audio conditions). Sequential draws from the shared
+    stream keep every tensor's noise independent without per-purpose seed offsets."""
+    return torch.Generator(device="cpu").manual_seed(int(seed))
+
+
 def initialize_target_latents(
     *,
     video_shape: Sequence[int],
     audio_shape: Sequence[int],
-    seed: int,
+    generator: torch.Generator,
     device: torch.device | str,
     video_dtype: torch.dtype = torch.float16,
     audio_dtype: torch.dtype = torch.float32,
@@ -92,7 +100,6 @@ def initialize_target_latents(
         raise ValueError(f"MiniMax-H3 target video noise shape must be [B,24,F,H,W], got {video_shape}")
     if len(audio_shape) != 4 or audio_shape[1:3] != (32, 2) or audio_shape[0] != video_shape[0]:
         raise ValueError(f"MiniMax-H3 target audio noise shape must be [B,32,2,A], got {audio_shape}")
-    generator = torch.Generator(device="cpu").manual_seed(int(seed))
     video = torch.randn(video_shape, generator=generator, dtype=torch.float32, device="cpu").to(device=device, dtype=video_dtype)
     audio = torch.randn(audio_shape, generator=generator, dtype=torch.float32, device="cpu").to(device=device, dtype=audio_dtype)
     return video, audio
@@ -101,7 +108,7 @@ def initialize_target_latents(
 def _augment_condition_group(
     tensors: Sequence[torch.Tensor],
     *,
-    seed: int,
+    generator: torch.Generator,
     clean: float,
     device: torch.device | str,
 ) -> tuple[torch.Tensor, ...]:
@@ -110,7 +117,6 @@ def _augment_condition_group(
         return moved
     augmented = []
     for tensor in moved:
-        generator = torch.Generator(device="cpu").manual_seed(int(seed))
         noise = torch.randn(tuple(tensor.shape), generator=generator, dtype=torch.float32, device="cpu").to(
             device=tensor.device, dtype=tensor.dtype
         )
@@ -122,7 +128,7 @@ def augment_condition_latents(
     visual_conditions: Sequence[torch.Tensor],
     audio_conditions: Sequence[torch.Tensor],
     *,
-    seed: int,
+    generator: torch.Generator,
     visual_clean: float = 0.999,
     audio_clean: float = 1.0,
     device: torch.device | str,
@@ -132,8 +138,8 @@ def augment_condition_latents(
     if not 0.0 <= audio_clean <= 1.0:
         raise ValueError(f"MiniMax-H3 audio condition clean coefficient must be in [0,1], got {audio_clean}")
     return (
-        _augment_condition_group(visual_conditions, seed=seed, clean=visual_clean, device=device),
-        _augment_condition_group(audio_conditions, seed=seed + 1, clean=audio_clean, device=device),
+        _augment_condition_group(visual_conditions, generator=generator, clean=visual_clean, device=device),
+        _augment_condition_group(audio_conditions, generator=generator, clean=audio_clean, device=device),
     )
 
 

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -30,6 +30,7 @@ from musubi_tuner.minimax_h3.model import load_h3_transformer
 from musubi_tuner.minimax_h3.packing import H3VideoGeometry, build_h3_layout
 from musubi_tuner.minimax_h3.sampling import (
     augment_condition_latents,
+    create_sampling_generator,
     initialize_target_latents,
     sample_joint_av,
     synchronize_decoded_av,
@@ -440,6 +441,7 @@ def run_generation(args: argparse.Namespace) -> Path:
         layout.text_length,
         layout.row_count,
     )
+    generator = create_sampling_generator(args.seed)
     initial_video, initial_audio = initialize_target_latents(
         video_shape=(
             1,
@@ -449,7 +451,7 @@ def run_generation(args: argparse.Namespace) -> Path:
             layout.target_video.width,
         ),
         audio_shape=(1, 32, 2, layout.target_audio_frames),
-        seed=args.seed,
+        generator=generator,
         device=device,
         video_dtype=torch.float32,
         audio_dtype=torch.float32,
@@ -457,7 +459,7 @@ def run_generation(args: argparse.Namespace) -> Path:
     visual_conditions, audio_conditions = augment_condition_latents(
         visual_conditions,
         audio_conditions,
-        seed=args.seed,
+        generator=generator,
         visual_clean=args.h3_visual_cond_clean,
         audio_clean=args.h3_audio_cond_clean,
         device=device,

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -41,6 +41,7 @@ from musubi_tuner.minimax_h3.packing import (
 )
 from musubi_tuner.minimax_h3.sampling import (
     augment_condition_latents,
+    create_sampling_generator,
     initialize_target_latents,
     sample_joint_av,
     synchronize_decoded_av,
@@ -621,6 +622,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         if not has_self_ref_orig_mod:
             transformer.eval()
         try:
+            generator = create_sampling_generator(seed)
             initial_video, initial_audio = initialize_target_latents(
                 video_shape=(
                     1,
@@ -630,7 +632,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                     layout.target_video.width,
                 ),
                 audio_shape=(1, 32, 2, layout.target_audio_frames),
-                seed=seed,
+                generator=generator,
                 device=device,
                 video_dtype=torch.float32,
                 audio_dtype=torch.float32,
@@ -638,7 +640,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             visual_conditions, audio_conditions = augment_condition_latents(
                 sample_parameter["h3_visual_conditions"],
                 sample_parameter["h3_audio_conditions"],
-                seed=seed,
+                generator=generator,
                 visual_clean=args.h3_visual_cond_clean,
                 audio_clean=args.h3_audio_cond_clean,
                 device=device,

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -295,27 +295,18 @@ def _shift_noise_amount(base: torch.Tensor, shift: float) -> torch.Tensor:
     return shift * base / (1.0 + (shift - 1.0) * base)
 
 
-def _augment_conditions(
-    tensors: tuple[torch.Tensor, ...],
-    clean: float,
-    seeds: torch.Tensor,
-    *,
-    seed_offset: int,
-    device: torch.device,
-) -> tuple[torch.Tensor, ...]:
-    moved = tuple(tensor.to(device) for tensor in tensors)
+def _augment_conditions(tensors: tuple[torch.Tensor, ...], clean: float) -> tuple[torch.Tensor, ...]:
+    """Blend independent Gaussian noise into condition latents: clean*x + (1-clean)*eps.
+
+    Training draws fresh noise from the global RNG, like the target noise; only the
+    sampling path (minimax_h3.sampling) needs seed-reproducible condition noise.
+    """
     if clean == 1.0:
-        return moved
+        return tensors
     augmented = []
-    for tensor in moved:
-        samples = []
-        for sample, seed in zip(tensor, seeds):
-            generator = torch.Generator(device="cpu").manual_seed(int(seed.item()) + seed_offset)
-            noise = torch.randn(tuple(sample.shape), generator=generator, dtype=torch.float32, device="cpu").to(
-                device=sample.device, dtype=sample.dtype
-            )
-            samples.append(clean * sample + (1.0 - clean) * noise)
-        augmented.append(torch.stack(samples))
+    for tensor in tensors:
+        noise = torch.randn(tuple(tensor.shape), dtype=torch.float32, device=tensor.device).to(tensor.dtype)
+        augmented.append(clean * tensor + (1.0 - clean) * noise)
     return tuple(augmented)
 
 
@@ -893,27 +884,11 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         noisy_video = (1.0 - sigma_video) * latents + sigma_video * noise
         noisy_audio = (1.0 - sigma_audio) * audio_latents + sigma_audio * audio_noise
 
-        needs_condition_noise = (bool(runtime.visual_conditions) and args.h3_visual_cond_clean != 1.0) or (
-            bool(runtime.audio_conditions) and args.h3_audio_cond_clean != 1.0
-        )
-        condition_seeds = (
-            torch.randint(0, 2**63 - 2, (latents.shape[0],), dtype=torch.int64, device="cpu")
-            if needs_condition_noise
-            else torch.empty(0, dtype=torch.int64)
-        )
         visual_conditions = _augment_conditions(
-            runtime.visual_conditions,
-            args.h3_visual_cond_clean,
-            condition_seeds,
-            seed_offset=0,
-            device=device,
+            tuple(tensor.to(device) for tensor in runtime.visual_conditions), args.h3_visual_cond_clean
         )
         audio_conditions = _augment_conditions(
-            runtime.audio_conditions,
-            args.h3_audio_cond_clean,
-            condition_seeds,
-            seed_offset=1,
-            device=device,
+            tuple(tensor.to(device) for tensor in runtime.audio_conditions), args.h3_audio_cond_clean
         )
         output = self.call_dit(
             args,


### PR DESCRIPTION
## Summary

Cleans up the condition-latent noise augmentation on both H3 paths. No practical output/loss change is expected at the default clean coefficients (visual 0.999, audio 1.0), but the RNG structure was wrong in ways that would surface if the coefficients are lowered.

### Sampling path (`minimax_h3/sampling.py`, both generation and training-time samples)

- New `create_sampling_generator(seed)`: one seed drives one CPU stream, consumed in a documented call order — initial video latents, initial audio latents, visual condition noise, audio condition noise. `initialize_target_latents` and `augment_condition_latents` now take the shared `generator` instead of `seed`.
- Fixes two aliasing bugs:
  - `_augment_condition_group` re-created its generator per tensor with the same seed, so same-shape conditions in a group (fl2va first/last frame, same-resolution ref2va references) received bit-identical noise.
  - The visual group reused the initial-latent seed, so its noise was exactly the prefix of the initial video noise stream (and the `seed+1` audio offset aliased with sequential user seeds).
- Same-seed outputs change for conditioned tasks (t2va is unaffected). The noise carries a `1-clean = 0.001` coefficient by default, so the visual effect is negligible; H3 is still in development so no compatibility shim is kept.

### Training path (`minimax_h3_train_network.py`)

- `_augment_conditions` is now a pure blend helper: independent fresh float32 noise per condition tensor from the global RNG (matching how the target noise is drawn), cast to the condition dtype.
- Deletes the per-sample seed machinery (`condition_seeds`, `seed_offset`, the `needs_condition_noise` gate and its dummy empty tensor) — the seeds came from the global RNG each step, so the determinism apparatus bought nothing and the double gating held a fragile invariant at a distance.
- Device movement now happens at the call site with the rest of batch preparation.

## Verification

- `ruff check` passes on all three files.
- CPU checks: seed determinism end-to-end; same-shape conditions in a group now receive different noise; visual condition noise is no longer the prefix of the initial video noise; audio group advances the stream; `clean == 1.0` passthrough (without consuming RNG on the training path); empty condition tuples; dtype/shape preservation and blend-magnitude sanity for the training helper.
- Real-hardware smoke (conditioned training task + generation) to be run separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)