### PR TITLE
[Fast Fix] MiniMax-H3 FlashAttention dtype mismatch under BF16 autocast

### DIFF
--- a/src/musubi_tuner/minimax_h3/model.py
+++ b/src/musubi_tuner/minimax_h3/model.py
@@ -350,6 +350,8 @@ class Attention(nn.Module):
         if rotation_table is not None:
             query = _apply_rope_split_half(query, rotation_table)
             key = _apply_rope_split_half(key, rotation_table)
+        query = query.to(value)
+        key = key.to(value)
 
         if self.attn_mode == "flash3":
             try:

--- a/tests/test_minimax_h3_model.py
+++ b/tests/test_minimax_h3_model.py
@@ -69,6 +69,38 @@ def _t2_inputs(batch_size: int = 1, text_length: int = 3):
     }
 
 
+def test_attention_restores_qk_dtype_before_backend(monkeypatch):
+    class PromoteToFloat(nn.Module):
+        def forward(self, tensor):
+            return tensor.float()
+
+    layer = h3_model.Attention(
+        hidden_size=16,
+        num_heads=2,
+        head_dim=8,
+        qk_norm_eps=1e-6,
+        attn_mode="flash",
+        split_attn=False,
+        dtype=torch.bfloat16,
+    )
+    layer.q_norm = PromoteToFloat()
+    layer.k_norm = PromoteToFloat()
+    seen_dtypes = None
+
+    def capture_attention(qkv, *, attn_params):
+        nonlocal seen_dtypes
+        del attn_params
+        seen_dtypes = tuple(tensor.dtype for tensor in qkv)
+        return qkv[2].reshape(qkv[2].shape[0], qkv[2].shape[1], -1)
+
+    monkeypatch.setattr(h3_model, "attention", capture_attention)
+
+    output = layer(torch.randn(1, 3, 16, dtype=torch.bfloat16))
+
+    assert seen_dtypes == (torch.bfloat16, torch.bfloat16, torch.bfloat16)
+    assert output.dtype == torch.bfloat16
+
+
 def test_released_config_and_meta_state_dict_match_published_bf16_header():
     config = MiniMaxH3Config()
 


### PR DESCRIPTION
## Summary

- align normalized MiniMax-H3 query and key tensors with the value tensor dtype before dispatching to the attention backend
- add a regression test covering RMSNorm-style FP32 promotion under BF16 execution

## Root cause

Under CUDA BF16 autocast, RMSNorm can produce FP32 query and key tensors while value remains BF16. The MiniMax-H3 attention path forwarded those mixed dtypes directly to FlashAttention 2, which only accepts FP16/BF16 inputs and raised `FlashAttention only support fp16 and bf16 data type` during standalone generation. ConvRot INT8 made the issue visible but was not the cause.

## Validation

- `pytest -q tests/test_minimax_h3_model.py`: 39 passed
- real RTX 4090 CUDA BF16 autocast + FlashAttention 2 probe: passed
- real MiniMax-H3 generation with `--attn_mode flash --convrot_int8`: passed
- Ruff check, Ruff format check, `py_compile`, and `git diff --check`: passed
- full local suite introduced no new failures compared with the exact `upstream/dev` baseline