### PR TITLE
Fix MiniMax-H3 activation CPU offload device mismatch

### DIFF
--- a/src/musubi_tuner/minimax_h3/model.py
+++ b/src/musubi_tuner/minimax_h3/model.py
@@ -944,6 +944,9 @@ class MiniMaxH3Model(nn.Module):
             if self.blocks_to_swap:
                 self.offloader.submit_move_blocks_forward(self.blocks, index)
 
+        if hidden_states.device != execution_device:
+            hidden_states = hidden_states.to(execution_device)
+
         video_rows, audio_rows = self.final_layer(
             hidden_states,
             timestep_embeddings,

--- a/tests/test_minimax_h3_model.py
+++ b/tests/test_minimax_h3_model.py
@@ -633,6 +633,23 @@ def test_gradient_checkpointed_forward_and_backward_recompute_the_same_block():
     assert model.blocks[0].attn.qkv_proj.weight.grad is not None
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="activation CPU offloading requires CUDA")
+def test_activation_cpu_offloading_restores_hidden_states_before_final_layer():
+    model = _tiny_model(num_layers=1).cuda()
+    model.enable_gradient_checkpointing(activation_cpu_offloading=True)
+    inputs = {
+        key: value.cuda() if isinstance(value, torch.Tensor) else value
+        for key, value in _t2_inputs(batch_size=1).items()
+    }
+
+    output = model(**inputs)
+    (output.video.square().mean() + output.audio.square().mean()).backward()
+
+    assert output.video.device.type == "cuda"
+    assert output.audio.device.type == "cuda"
+    assert model.blocks[0].attn.qkv_proj.weight.grad is not None
+
+
 def test_block_device_assertion_catches_parameters_left_off_execution_device():
     model = _tiny_model(num_layers=1)
     model._execution_device = torch.device("meta")


### PR DESCRIPTION
## Summary

- restore MiniMax-H3 checkpointed activations to the transformer execution device before the final layer
- add a CUDA regression test covering activation CPU offload through forward and backward

## Root cause

`create_cpu_offloading_wrapper` returns each checkpointed block output on CPU. After the last block, MiniMax-H3 passed that CPU residual stream directly to a CUDA `final_layer`, so RMSNorm failed with a CPU/CUDA device mismatch.

## Impact

MiniMax-H3 training can use `--gradient_checkpointing_cpu_offload` without failing at the final RMSNorm.

## Validation

- `python -m pytest tests/test_minimax_h3_model.py -q` (40 passed)
- `..\.venv\Scripts\ruff.exe check src/musubi_tuner/minimax_h3/model.py tests/test_minimax_h3_model.py`