### PR TITLE
Use the official MiniMax-H3 processor and config

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -28,7 +28,7 @@ Download the following files from [Comfy-Org/MiniMax-H3](https://huggingface.co/
 
 T2VA uses an FL2VA transformer without first/last conditions. Pre-quantized files (ConvRot INT8 full or pruned, transformer or text encoder; NVFP4+AWQ text encoder) are detected automatically from their tensor structure — no extra flag is needed. FP8, NVFP4 transformers, and malformed or partial quantized files are rejected rather than silently interpreted as BF16. See [ConvRot INT8 Quantized Base Weights](#convrot-int8-quantized-base-weights) and [NVFP4 Text Encoder](#nvfp4-text-encoder) for details.
 
-The Qwen processor/config defaults to `Qwen/Qwen3-VL-32B-Instruct` and is downloaded by Transformers. Pass `--processor` when using a local copy.
+The Qwen3-VL processor and config are downloaded by Transformers from the official [MiniMaxAI/MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) repository (`processor` and `text_encoder` subfolders, a few config and tokenizer files only, no weights). The upstream `Qwen/Qwen3-VL-32B-Instruct` files are not interchangeable: the H3 tokenizer adds `<d>`, `</d>`, `<|cutoff|>`, `<|lyrics_start|>`, `<|lyrics_end|>`, `<|caption_start|>`, and `<|caption_end|>` as special tokens, and the released prompt format writes dialogue and lyrics as `<d>[Language] ...</d>`.
 
 ## Implementation Provenance
 

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -46,7 +46,14 @@ IMAGE_TOKEN_ID = 151655
 VIDEO_TOKEN_ID = 151656
 IMAGE_PLACEHOLDER = "<|vision_start|><|image_pad|><|vision_end|>"
 VIDEO_PLACEHOLDER = "<|vision_start|><|video_pad|><|vision_end|>"
-DEFAULT_PROCESSOR_ID = "Qwen/Qwen3-VL-32B-Instruct"
+# the H3 encoder is Qwen3-VL-32B, but the released repository ships its own processor and config:
+# the tokenizer adds <d>, </d>, <|cutoff|>, <|lyrics_start|>, <|lyrics_end|>, <|caption_start|> and
+# <|caption_end|> as special tokens (ids 151669-151675), which Qwen/Qwen3-VL-32B-Instruct splits into
+# ordinary tokens instead. The released prompt format writes dialogue and lyrics as <d>[Language] ...</d>,
+# so the H3 files are required, not interchangeable with the upstream Qwen ones.
+H3_REPO_ID = "MiniMaxAI/MiniMax-H3"
+PROCESSOR_SUBFOLDER = "processor"
+TEXT_ENCODER_CONFIG_SUBFOLDER = "text_encoder"
 
 
 @dataclass(frozen=True)
@@ -230,17 +237,17 @@ def normalize_h3_text_encoder_key(key: str) -> str:
     return key
 
 
-def load_h3_processor(path: str = DEFAULT_PROCESSOR_ID, *, revision: str | None = None):
-    from transformers import AutoProcessor
+def load_h3_processor():
+    # the concrete class, not AutoProcessor: the auto class resolves the processor type from the
+    # repository root, where the H3 release keeps a diffusers model_index.json instead of a config
+    from transformers import Qwen3VLProcessor
 
-    return AutoProcessor.from_pretrained(path, revision=revision)
+    return Qwen3VLProcessor.from_pretrained(H3_REPO_ID, subfolder=PROCESSOR_SUBFOLDER)
 
 
 def load_h3_text_encoder(
     checkpoint_path: str | Path,
     *,
-    processor_path: str = DEFAULT_PROCESSOR_ID,
-    revision: str | None = None,
     device: str | torch.device,
     dtype: torch.dtype = torch.bfloat16,
     disable_mmap: bool = False,
@@ -256,7 +263,7 @@ def load_h3_text_encoder(
             "--text_encoder_blocks_to_swap requires a CUDA device. / --text_encoder_blocks_to_swap には CUDA デバイスが必要です。"
         )
 
-    config = Qwen3VLConfig.from_pretrained(processor_path, revision=revision)
+    config = Qwen3VLConfig.from_pretrained(H3_REPO_ID, subfolder=TEXT_ENCODER_CONFIG_SUBFOLDER)
     if config.text_config.hidden_size != TEXT_WIDTH:
         raise ValueError(f"MiniMax-H3 Qwen3-VL hidden size must be {TEXT_WIDTH}, got {config.text_config.hidden_size}")
     config.text_config.num_hidden_layers = LAYER_50_HIDDEN_STATE_INDEX

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -13,7 +13,6 @@ from musubi_tuner.dataset.cache_io import save_text_encoder_output_cache_minimax
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
 from musubi_tuner.dataset.image_video_dataset import ItemInfo, VideoDataset
 from musubi_tuner.minimax_h3.text_encoder import (
-    DEFAULT_PROCESSOR_ID,
     H3TextVisual,
     TEXT_CACHE_FORMAT,
     build_presentation,
@@ -147,13 +146,6 @@ def setup_parser() -> argparse.ArgumentParser:
         help="attention implementation for the text encoder (default: transformers default, sdpa)."
         " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
     )
-    parser.add_argument(
-        "--processor",
-        type=str,
-        default=DEFAULT_PROCESSOR_ID,
-        help="Qwen3-VL-32B processor repo or local directory",
-    )
-    parser.add_argument("--processor_revision", type=str, default=None, help="optional processor revision")
     parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), required=True)
     parser.add_argument("--text_cache_dtype", choices=("bf16", "float32"), default="bf16")
     parser.add_argument("--disable_mmap", action="store_true", help="disable memory-mapped safetensors loading")
@@ -185,15 +177,13 @@ def main() -> None:
     }
     media_fingerprints = {path: fingerprint_file(path) for path in text_paths}
 
-    logger.info("Loading MiniMax-H3 Qwen3-VL processor from %s", args.processor)
-    processor = load_h3_processor(args.processor, revision=args.processor_revision)
+    logger.info("Loading MiniMax-H3 Qwen3-VL processor")
+    processor = load_h3_processor()
     processor_identity = processor_fingerprint(processor)
     text_encoder_identity = fingerprint_checkpoint(args.text_encoder)
     logger.info("Loading MiniMax-H3 text encoder from %s", args.text_encoder)
     text_encoder = load_h3_text_encoder(
         args.text_encoder,
-        processor_path=args.processor,
-        revision=args.processor_revision,
         device=device,
         dtype=torch.bfloat16,
         disable_mmap=args.disable_mmap,

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -37,7 +37,6 @@ from musubi_tuner.minimax_h3.sampling import (
     write_joint_av,
 )
 from musubi_tuner.minimax_h3.text_encoder import (
-    DEFAULT_PROCESSOR_ID,
     TEXT_CACHE_FORMAT,
     build_presentation,
     encode_h3_presentation,
@@ -180,11 +179,9 @@ def _encode_text(args, record: H3Record, text_visuals, device: torch.device):
             presentation_identity=presentation_identity,
         )
     logger.info("Loading MiniMax-H3 Qwen3-VL text encoder")
-    processor = load_h3_processor(args.processor, revision=args.processor_revision)
+    processor = load_h3_processor()
     text_encoder = load_h3_text_encoder(
         args.text_encoder,
-        processor_path=args.processor,
-        revision=args.processor_revision,
         device=device,
         dtype=torch.bfloat16,
         disable_mmap=args.disable_numpy_memmap,
@@ -323,8 +320,6 @@ def setup_parser() -> argparse.ArgumentParser:
         " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
     )
     parser.add_argument("--text_cache", default=None, help="optional precomputed mmh3 text cache")
-    parser.add_argument("--processor", default=DEFAULT_PROCESSOR_ID, help="Qwen3-VL processor repo or directory")
-    parser.add_argument("--processor_revision", default=None)
     parser.add_argument("--prompt", default=None)
     parser.add_argument("--first_frame", default=None)
     parser.add_argument("--last_frame", default=None)

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -48,7 +48,6 @@ from musubi_tuner.minimax_h3.sampling import (
     write_joint_av,
 )
 from musubi_tuner.minimax_h3.text_encoder import (
-    DEFAULT_PROCESSOR_ID,
     build_presentation,
     encode_h3_presentation,
     load_h3_processor,
@@ -419,11 +418,9 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         decoder = PyAVH3MediaDecoder()
 
         logger.info("Loading MiniMax-H3 Qwen3-VL text encoder for training samples")
-        processor = load_h3_processor(args.processor, revision=args.processor_revision)
+        processor = load_h3_processor()
         text_encoder = load_h3_text_encoder(
             args.text_encoder,
-            processor_path=args.processor,
-            revision=args.processor_revision,
             device=device,
             dtype=torch.bfloat16,
             disable_mmap=getattr(args, "disable_numpy_memmap", False),
@@ -1011,13 +1008,6 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         help="attention implementation for the sample-prompt text encoder (default: transformers default, sdpa)."
         " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
     )
-    parser.add_argument(
-        "--processor",
-        type=str,
-        default=DEFAULT_PROCESSOR_ID,
-        help="Qwen3-VL processor repository or directory for training samples",
-    )
-    parser.add_argument("--processor_revision", type=str, default=None)
     parser.add_argument(
         "--h3_allow_experimental_sample_duration",
         action="store_true",

--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -58,7 +58,6 @@ def _load_training_module(monkeypatch):
     _stub(
         monkeypatch,
         "musubi_tuner.minimax_h3.text_encoder",
-        DEFAULT_PROCESSOR_ID="fake-processor",
         build_presentation=noop,
         encode_h3_presentation=noop,
         load_h3_processor=noop,

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -238,7 +238,6 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         "task": task,
         "prompt": "a test prompt",
         "text_cache": None,
-        "processor": "Qwen/Qwen3-VL-32B-Instruct",
         "first_frame": None,
         "last_frame": None,
         "reference_jsonl": None,
@@ -374,7 +373,6 @@ def test_generation_orchestrates_t2va_sampling_decode_and_mux_without_co_residen
         include_patterns=None,
         exclude_patterns=None,
         disable_numpy_memmap=False,
-        processor_revision=None,
     )
     # the pre-quantization probe reads the DiT file headers; the stub DiT here is not
     # a real safetensors file, so report an ordinary (non-pre-quantized) checkpoint

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -316,7 +316,7 @@ def test_load_h3_text_encoder_rejects_non_fp32_convrot_scale(tmp_path, monkeypat
     with pytest.raises(ValueError, match=r"scale.*FP32|scale.*F32"):
         load_h3_text_encoder(
             checkpoint,
-                device="cpu",
+            device="cpu",
             dtype=torch.bfloat16,
         )
 
@@ -370,7 +370,7 @@ def test_load_h3_text_encoder_rejects_streaming_without_cuda(tmp_path, monkeypat
     with pytest.raises(ValueError, match="CUDA"):
         load_h3_text_encoder(
             checkpoint,
-                device="cpu",
+            device="cpu",
             dtype=torch.bfloat16,
             blocks_to_swap=50,
         )
@@ -388,6 +388,6 @@ def test_load_h3_text_encoder_rejects_convrot_layer_missing_from_the_model(tmp_p
     with pytest.raises(ValueError, match=r"missing module missing_tower"):
         load_h3_text_encoder(
             checkpoint,
-                device="cpu",
+            device="cpu",
             dtype=torch.bfloat16,
         )

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -181,8 +181,8 @@ def test_text_cache_metadata_distinguishes_requested_storage_dtype():
 
 class _FakeQwen3VLConfig:
     @classmethod
-    def from_pretrained(cls, _path, revision=None):
-        del revision
+    def from_pretrained(cls, _path, subfolder=None):
+        del subfolder
         return SimpleNamespace(
             text_config=SimpleNamespace(
                 hidden_size=5120,
@@ -275,7 +275,6 @@ def test_load_h3_text_encoder_auto_detects_all_350_convrot_linears(tmp_path, mon
 
     loaded = load_h3_text_encoder(
         checkpoint,
-        processor_path="fake",
         device="cpu",
         dtype=torch.bfloat16,
     )
@@ -298,7 +297,6 @@ def test_load_h3_text_encoder_keeps_existing_bf16_conversion_for_ordinary_files(
 
     loaded = load_h3_text_encoder(
         checkpoint,
-        processor_path="fake",
         device="cpu",
         dtype=torch.bfloat16,
     )
@@ -318,8 +316,7 @@ def test_load_h3_text_encoder_rejects_non_fp32_convrot_scale(tmp_path, monkeypat
     with pytest.raises(ValueError, match=r"scale.*FP32|scale.*F32"):
         load_h3_text_encoder(
             checkpoint,
-            processor_path="fake",
-            device="cpu",
+                device="cpu",
             dtype=torch.bfloat16,
         )
 
@@ -338,7 +335,6 @@ def test_load_h3_text_encoder_accepts_nonpublished_convrot_layers_permissively(t
 
     loaded = load_h3_text_encoder(
         checkpoint,
-        processor_path="fake",
         device="cpu",
         dtype=torch.bfloat16,
     )
@@ -357,7 +353,6 @@ def test_load_h3_text_encoder_installs_identity_final_norm_for_layer_50_conventi
 
     loaded = load_h3_text_encoder(
         checkpoint,
-        processor_path="fake",
         device="cpu",
         dtype=torch.bfloat16,
     )
@@ -375,8 +370,7 @@ def test_load_h3_text_encoder_rejects_streaming_without_cuda(tmp_path, monkeypat
     with pytest.raises(ValueError, match="CUDA"):
         load_h3_text_encoder(
             checkpoint,
-            processor_path="fake",
-            device="cpu",
+                device="cpu",
             dtype=torch.bfloat16,
             blocks_to_swap=50,
         )
@@ -394,7 +388,6 @@ def test_load_h3_text_encoder_rejects_convrot_layer_missing_from_the_model(tmp_p
     with pytest.raises(ValueError, match=r"missing module missing_tower"):
         load_h3_text_encoder(
             checkpoint,
-            processor_path="fake",
-            device="cpu",
+                device="cpu",
             dtype=torch.bfloat16,
         )

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -272,8 +272,6 @@ def test_h3_parser_exposes_the_dual_vae_and_text_assets_needed_for_training_samp
     assert args.video_vae == "video.safetensors"
     assert args.audio_vae == "audio.safetensors"
     assert args.text_encoder == "qwen.safetensors"
-    assert args.processor == "Qwen/Qwen3-VL-32B-Instruct"
-    assert args.processor_revision is None
     assert args.h3_allow_experimental_sample_duration is False
 
 
@@ -410,8 +408,6 @@ def test_prepare_training_samples_encodes_text_once_and_returns_both_vaes_as_sam
         asset_paths[name] = str(path)
     args = _trainer_args(
         sample_prompts=str(prompt_file),
-        processor="processor",
-        processor_revision=None,
         h3_allow_experimental_sample_duration=True,
         disable_numpy_memmap=False,
         **asset_paths,
@@ -511,8 +507,6 @@ def test_prepare_ref_training_sample_carries_ordered_visual_and_audio_conditions
     args = _trainer_args(
         task="ref2va",
         sample_prompts=str(prompt_file),
-        processor="processor",
-        processor_revision=None,
         h3_allow_experimental_sample_duration=True,
         disable_numpy_memmap=False,
         **asset_paths,


### PR DESCRIPTION
Follow-up to a review comment from @sdbds on the MiniMax-H3 PR: the `--processor` and `--processor_revision` arguments were inferred from the diffusers repository before the model was released, and can now be replaced by the configuration published in the official repository.

Checking the released repository showed this is not only a cleanup. The H3 encoder is Qwen3-VL-32B, but MiniMax ships its own tokenizer configuration.

## What differs from `Qwen/Qwen3-VL-32B-Instruct`

Comparing `MiniMaxAI/MiniMax-H3` (the `processor` and `text_encoder` subfolders; `FL2VA/` and `Ref2VA/` carry identical copies) against the upstream Qwen repository:

| File | Result |
| --- | --- |
| `text_encoder/config.json` | identical |
| `preprocessor_config.json`, `video_preprocessor_config.json` | identical |
| `tokenizer.json`, `vocab.json`, `merges.txt`, `chat_template.json` | identical |
| `tokenizer_config.json` | **differs** |

`additional_special_tokens` gains seven H3 tokens: `<d>`, `</d>`, `<|cutoff|>`, `<|lyrics_start|>`, `<|lyrics_end|>`, `<|caption_start|>`, `<|caption_end|>` (ids 151669-151675, inside the 151936 embedding rows). The official README states this directly:

> We add several special tokens, such as `<d>`, to the tokenizer configuration. When using H3, the tokenizer and associated configuration files provided in the H3 repository are required.

This matters because the released prompt guide (`skills/h3-prompt-writing`) writes dialogue and lyrics as `<d>[English] I get off at the next station.</d>`. With the upstream Qwen tokenizer those markers split into ordinary tokens, so speech and lyrics conditioning did not match the released format.

## Changes

- `minimax_h3/text_encoder.py`: replace `DEFAULT_PROCESSOR_ID` with `H3_REPO_ID = "MiniMaxAI/MiniMax-H3"` plus subfolder constants; load the processor from `processor` and the Qwen3-VL config from `text_encoder`
- drop `processor_path` and `revision` from `load_h3_processor()` and `load_h3_text_encoder()`
- remove `--processor` and `--processor_revision` from the caching, training, and generation scripts
- update the H3 tests and `docs/minimax_h3.md`

`Qwen3VLProcessor` is used rather than `AutoProcessor`: the auto class drops `subfolder` while resolving the processor type and looks at the repository root, which holds a diffusers `model_index.json` instead of a model config. This matches how `qwen_image_utils.py` already loads its processor.

Only config and tokenizer files are downloaded, and the repository is not gated.

## Verification

- loaded the processor and config from the released repository and confirmed `<d>` tokenizes to the single id 151669
- confirmed the three parsers build with the arguments removed
- H3 tests show no new failures, and `ruff check` passes

Existing text caches carry the old processor fingerprint, so `--skip_existing` reports them as stale and rebuilds them.

Note: 12 H3 tests already fail on `dev` (stale signatures after #1035/#1036, and a sampling stub missing `create_sampling_generator`). They are unrelated to this change and will be fixed separately.
