### PR TITLE
Repair the MiniMax-H3 tests left behind by the sampling seams

### DIFF
--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -50,6 +50,7 @@ def _load_training_module(monkeypatch):
         monkeypatch,
         "musubi_tuner.minimax_h3.sampling",
         augment_condition_latents=noop,
+        create_sampling_generator=noop,
         initialize_target_latents=noop,
         sample_joint_av=noop,
         synchronize_decoded_av=noop,

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -15,6 +15,7 @@ from musubi_tuner.minimax_h3.packing import H3VideoGeometry, build_h3_layout
 from musubi_tuner.minimax_h3.sampling import (
     augment_condition_latents,
     build_shifted_schedule,
+    create_sampling_generator,
     decode_joint_av,
     initialize_target_latents,
     sample_joint_av,
@@ -55,7 +56,7 @@ def test_target_initialization_draws_video_then_audio_from_one_request_generator
     video, audio = initialize_target_latents(
         video_shape=(1, 24, 2, 4, 4),
         audio_shape=(1, 32, 2, 8),
-        seed=123,
+        generator=create_sampling_generator(123),
         device=torch.device("cpu"),
         video_dtype=torch.float16,
         audio_dtype=torch.float32,
@@ -68,65 +69,85 @@ def test_target_initialization_draws_video_then_audio_from_one_request_generator
     assert torch.equal(audio, expected_audio)
 
 
-def test_condition_augmentation_resets_visual_stream_and_uses_seed_plus_one_for_audio():
+def test_condition_augmentation_draws_visuals_then_audio_from_the_same_request_stream():
     visuals = (torch.zeros(1, 24, 1, 4, 4), torch.zeros(1, 24, 1, 4, 4))
     audios = (torch.zeros(1, 32, 2, 8),)
 
     augmented_visuals, augmented_audios = augment_condition_latents(
         visuals,
         audios,
-        seed=456,
+        generator=create_sampling_generator(456),
         visual_clean=0.5,
         audio_clean=0.5,
         device=torch.device("cpu"),
     )
 
-    expected_visual = 0.5 * _cpu_noise((1, 24, 1, 4, 4), torch.Generator(device="cpu").manual_seed(456))
-    expected_audio = 0.5 * _cpu_noise((1, 32, 2, 8), torch.Generator(device="cpu").manual_seed(457))
-    assert torch.equal(augmented_visuals[0], expected_visual)
-    assert torch.equal(augmented_visuals[1], expected_visual)
-    assert torch.equal(augmented_audios[0], expected_audio)
-
-    changed_visuals, changed_audios = augment_condition_latents(
-        visuals,
-        audios,
-        seed=457,
-        visual_clean=0.5,
-        audio_clean=0.5,
-        device=torch.device("cpu"),
-    )
-    assert not torch.equal(changed_visuals[0], augmented_visuals[0])
-    assert not torch.equal(changed_audios[0], augmented_audios[0])
+    # sequential draws from the one request stream: each condition tensor gets its own noise, and
+    # the conditions are zeros here, so clean*x + (1-clean)*eps collapses to the scaled draw
+    expected = torch.Generator(device="cpu").manual_seed(456)
+    assert torch.equal(augmented_visuals[0], 0.5 * _cpu_noise((1, 24, 1, 4, 4), expected))
+    assert torch.equal(augmented_visuals[1], 0.5 * _cpu_noise((1, 24, 1, 4, 4), expected))
+    assert torch.equal(augmented_audios[0], 0.5 * _cpu_noise((1, 32, 2, 8), expected))
+    assert not torch.equal(augmented_visuals[0], augmented_visuals[1])
 
 
-def test_condition_augmentation_does_not_change_target_noise_sequence():
-    expected = initialize_target_latents(
-        video_shape=(1, 24, 2, 4, 4),
-        audio_shape=(1, 32, 2, 8),
-        seed=789,
-        device=torch.device("cpu"),
-        video_dtype=torch.float32,
-        audio_dtype=torch.float32,
-    )
-    augment_condition_latents(
-        (torch.zeros(1, 24, 1, 4, 4),),
-        (torch.zeros(1, 32, 2, 8),),
-        seed=789,
-        visual_clean=0.5,
-        audio_clean=0.5,
-        device=torch.device("cpu"),
-    )
-    actual = initialize_target_latents(
-        video_shape=(1, 24, 2, 4, 4),
-        audio_shape=(1, 32, 2, 8),
-        seed=789,
-        device=torch.device("cpu"),
-        video_dtype=torch.float32,
-        audio_dtype=torch.float32,
-    )
+def test_condition_noise_does_not_alias_across_consecutive_request_seeds():
+    # per-role seed offsets (visuals from seed, audio from seed + 1) made one request's audio noise
+    # the next request's visual noise; the shared per-request stream removes that alias
+    def augmented(seed: int):
+        return augment_condition_latents(
+            (torch.zeros(1, 32, 2, 8),),
+            (torch.zeros(1, 32, 2, 8),),
+            generator=create_sampling_generator(seed),
+            visual_clean=0.5,
+            audio_clean=0.5,
+            device=torch.device("cpu"),
+        )
 
-    assert torch.equal(actual[0], expected[0])
-    assert torch.equal(actual[1], expected[1])
+    visuals, audios = augmented(456)
+    next_visuals, next_audios = augmented(457)
+
+    assert not torch.equal(audios[0], next_visuals[0])
+    assert not torch.equal(visuals[0], next_visuals[0])
+    assert not torch.equal(audios[0], next_audios[0])
+
+
+def test_one_request_generator_feeds_target_noise_then_condition_noise_in_call_order():
+    def request(seed: int):
+        generator = create_sampling_generator(seed)
+        video, audio = initialize_target_latents(
+            video_shape=(1, 24, 2, 4, 4),
+            audio_shape=(1, 32, 2, 8),
+            generator=generator,
+            device=torch.device("cpu"),
+            video_dtype=torch.float32,
+            audio_dtype=torch.float32,
+        )
+        conditions = augment_condition_latents(
+            (torch.zeros(1, 24, 1, 4, 4),),
+            (torch.zeros(1, 32, 2, 8),),
+            generator=generator,
+            visual_clean=0.5,
+            audio_clean=0.5,
+            device=torch.device("cpu"),
+        )
+        return video, audio, conditions
+
+    expected = torch.Generator(device="cpu").manual_seed(789)
+    video, audio, (visuals, audios) = request(789)
+
+    assert torch.equal(video, _cpu_noise((1, 24, 2, 4, 4), expected))
+    assert torch.equal(audio, _cpu_noise((1, 32, 2, 8), expected))
+    assert torch.equal(visuals[0], 0.5 * _cpu_noise((1, 24, 1, 4, 4), expected))
+    assert torch.equal(audios[0], 0.5 * _cpu_noise((1, 32, 2, 8), expected))
+    # the same seed replays the whole request, and a different one changes every tensor
+    replayed_video, replayed_audio, (replayed_visuals, _) = request(789)
+    other_video, _, (other_visuals, _) = request(790)
+    assert torch.equal(video, replayed_video)
+    assert torch.equal(audio, replayed_audio)
+    assert torch.equal(visuals[0], replayed_visuals[0])
+    assert not torch.equal(video, other_video)
+    assert not torch.equal(visuals[0], other_visuals[0])
 
 
 def test_joint_sampler_uses_native_dataward_predictions_and_each_sigma_delta():

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -13,6 +13,7 @@ import torch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
+from musubi_tuner.hv_train_network import setup_parser_common
 from musubi_tuner.minimax_h3.model import MiniMaxH3Config, MiniMaxH3Model
 from musubi_tuner.minimax_h3.packing import H3ReferenceGeometry, H3VideoGeometry, build_h3_layout
 from musubi_tuner.modules.convrot_int8_kernels import quantize_int8_convrot_weight
@@ -116,29 +117,26 @@ class _RecordingTransformer:
         )
 
 
-def _trainer_args(**overrides):
-    values = {
-        "timestep_sampling": "uniform",
-        "weighting_scheme": "none",
-        "discrete_flow_shift": 1.0,
-        "h3_shift_video": 12.0,
-        "h3_shift_audio": 3.0,
-        "h3_visual_cond_clean": 0.999,
-        "h3_audio_cond_clean": 1.0,
-        "min_timestep": None,
-        "max_timestep": None,
-        "blocks_to_swap": 0,
-        "sample_prompts": None,
-        "gradient_checkpointing": False,
-        "task": "t2va",
-        "video_only": False,
-        "audio_loss_weight": 1.0,
-        "convrot_int8": False,
-        "convrot_int8_bwd": "bf16",
-        "base_weights": None,
+def _parser_defaults() -> dict[str, object]:
+    parser = minimax_h3_setup_parser(setup_parser_common())
+    return {
+        action.dest: action.default
+        for action in parser._actions
+        if action.dest != "help" and action.default is not argparse.SUPPRESS
     }
-    values.update(overrides)
-    return SimpleNamespace(**values)
+
+
+# the trainer reads plain argparse attributes, so the fake args start from the real parser defaults:
+# a hand-written subset goes stale without a failing assertion whenever the shared training
+# arguments grow, and only the values the tests actually choose are spelled out here
+_TRAINER_DEFAULTS = _parser_defaults() | {
+    "task": "t2va",  # required on the real command line
+    "blocks_to_swap": 0,  # the parser leaves this None to mean "disabled"
+}
+
+
+def _trainer_args(**overrides):
+    return SimpleNamespace(**(_TRAINER_DEFAULTS | overrides))
 
 
 def _training_batch(batch_size: int = 1, *, text_length: int = 3):
@@ -727,12 +725,24 @@ def test_process_batch_video_only_disables_audio_loss_even_with_real_audio(monke
     assert torch.count_nonzero(transformer.calls[0]["audio_latents"]) > 0
 
 
-def _cpu_noise(shape, seed):
-    generator = torch.Generator(device="cpu").manual_seed(seed)
-    return torch.randn(shape, generator=generator, dtype=torch.float32)
+def _recording_randn(monkeypatch) -> list[torch.Tensor]:
+    """Record every global-RNG normal draw while still returning real noise."""
+    real_randn = torch.randn
+    draws: list[torch.Tensor] = []
+
+    def recording_randn(*args, **kwargs):
+        noise = real_randn(*args, **kwargs)
+        draws.append(noise)
+        return noise
+
+    monkeypatch.setattr(torch, "randn", recording_randn)
+    return draws
 
 
-def test_condition_noise_restarts_per_role_uses_audio_seed_plus_one_and_changes_per_step(monkeypatch):
+def test_condition_noise_is_drawn_from_the_global_rng_per_condition_and_step(monkeypatch):
+    # per-role condition seeds (visuals from seed, audio from seed + 1) made one item's audio noise
+    # the next item's visual noise; training now draws from the global RNG like the target noise,
+    # so every condition tensor and every step gets its own independent draw
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(task="ref2va", h3_visual_cond_clean=0.5, h3_audio_cond_clean=0.5)
     trainer.handle_model_specific_args(args)
@@ -741,8 +751,7 @@ def test_condition_noise_restarts_per_role_uses_audio_seed_plus_one_and_changes_
     batch["latents_ref_000_image"] = torch.zeros(1, 24, 1, 4, 4)
     batch["latents_ref_001_audio"] = torch.zeros(1, 32, 2, 8)
     video_latents = torch.zeros(1, 24, 2, 4, 4)
-    seeds = iter((torch.tensor([100]), torch.tensor([300])))
-    monkeypatch.setattr(torch, "randint", lambda *args, **kwargs: next(seeds))
+    draws = _recording_randn(monkeypatch)
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
 
@@ -762,13 +771,16 @@ def test_condition_noise_restarts_per_role_uses_audio_seed_plus_one_and_changes_
             step,
         )
 
+    # one draw per condition tensor, visuals before audio, repeated for the second step
+    assert [tuple(noise.shape) for noise in draws] == [(1, 24, 1, 4, 4), (1, 32, 2, 8)] * 2
     first_call, second_call = transformer.calls
-    first_visual = first_call["visual_condition_latents"][0]
-    first_audio = first_call["audio_condition_latents"][0]
-    assert torch.equal(first_visual[0], 0.5 * _cpu_noise((24, 1, 4, 4), 100))
-    assert torch.equal(first_audio[0], 0.5 * _cpu_noise((32, 2, 8), 101))
-    assert not torch.equal(first_visual, second_call["visual_condition_latents"][0])
-    assert not torch.equal(first_audio, second_call["audio_condition_latents"][0])
+    # the conditions are zeros here, so clean*x + (1-clean)*eps collapses to the scaled draw
+    assert torch.equal(first_call["visual_condition_latents"][0], 0.5 * draws[0])
+    assert torch.equal(first_call["audio_condition_latents"][0], 0.5 * draws[1])
+    assert not torch.equal(draws[0], draws[2])
+    assert not torch.equal(draws[1], draws[3])
+    assert not torch.equal(first_call["visual_condition_latents"][0], second_call["visual_condition_latents"][0])
+    assert not torch.equal(first_call["audio_condition_latents"][0], second_call["audio_condition_latents"][0])
 
 
 def test_runtime_rejects_batch_size_above_one():
@@ -879,17 +891,13 @@ def test_runtime_rejects_a_batch_from_a_different_authoritative_task():
         )
 
 
-def test_t2va_does_not_advance_the_condition_seed_stream(monkeypatch):
+def test_t2va_draws_no_condition_noise(monkeypatch):
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args()
     trainer.handle_model_specific_args(args)
+    draws = _recording_randn(monkeypatch)
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
-    monkeypatch.setattr(
-        torch,
-        "randint",
-        lambda *args, **kwargs: pytest.fail("T2VA without conditions must not draw a condition seed"),
-    )
     video_latents = torch.zeros(1, 24, 2, 4, 4)
 
     trainer.process_batch(
@@ -906,6 +914,8 @@ def test_t2va_does_not_advance_the_condition_seed_stream(monkeypatch):
         None,
         0,
     )
+
+    assert not draws, "T2VA has no conditions to augment, so it must not draw condition noise"
 
 
 def test_compute_loss_is_video_mean_plus_weighted_audio_mean_mse():


### PR DESCRIPTION
Twelve H3 tests have been failing on `dev` since #1035 and #1036 changed the code they cover. Only ruff runs in CI, so nothing reported it. `pytest tests/` now reports 396 passed.

## Causes

| File | Failures | Cause |
| --- | --- | --- |
| `test_minimax_h3_training.py` | 7 | the fake trainer args are a hand-written attribute subset, so `preserve_distribution_shape` (added by #1035) was missing and `trainer_base` raised `AttributeError` |
| `test_minimax_h3_convrot_runtime.py` | 2 | the sampling module stub predates `create_sampling_generator`, so importing the training module failed |
| `test_minimax_h3_sampling.py` | 3 | the tests still call `initialize_target_latents(seed=...)` / `augment_condition_latents(seed=...)`, replaced by a shared generator in #1036 |

## Changes

**`_trainer_args` now starts from the real parser defaults.** A hand-written subset goes stale without a failing assertion whenever the shared training arguments grow, which is exactly what happened here. Only the two values the tests actually choose stay explicit: `task` (required on the real command line) and `blocks_to_swap` (the parser leaves it `None` to mean disabled). Every other value in the old dict already matched its parser default.

**The condition-noise tests are rewritten against the current contract** rather than patched. #1036 removed the per-role seed offsets — visuals from `seed`, audio from `seed + 1`, an offset that made one request's audio noise the next request's visual noise — so the old test names and assertions described behavior that no longer exists:

- sampling: targets then conditions come from one per-request stream, drawn in call order. Covered by `..._draws_visuals_then_audio_from_the_same_request_stream`, `..._does_not_alias_across_consecutive_request_seeds`, and `..._feeds_target_noise_then_condition_noise_in_call_order`.
- training: conditions are drawn from the global RNG like the target noise, one draw per condition tensor per step. Covered by `test_condition_noise_is_drawn_from_the_global_rng_per_condition_and_step`, with `test_t2va_draws_no_condition_noise` asserting T2VA draws nothing (it previously asserted a `torch.randint` call that no longer exists, so it could not fail).

## Verification

Both old behaviors were reintroduced locally to confirm the rewritten tests are not vacuous: restarting each condition group from its own generator fails 2 of the 3 sampling tests, restoring the `seed + 1` offset fails all 3, and a fixed per-role seed in training fails the training test. `ruff check` and `ruff format --check` pass.
