### PR TITLE
fix: skip duplicate sample/save when interval hits on the final training step

### DIFF
--- a/src/musubi_tuner/training/sampling_prompts.py
+++ b/src/musubi_tuner/training/sampling_prompts.py
@@ -141,3 +141,14 @@ def should_sample_images(args, steps, epoch=None):
         if not should_sample_by_steps and not should_sample_by_epochs:
             return False
     return True
+
+
+def should_sample_at_epoch_end(global_step, last_sampled_step):
+    """Whether the end-of-epoch sample call should proceed.
+
+    Guards against re-sampling at the same global_step already handled by the
+    in-loop step-based trigger, which otherwise fires a duplicate sample whenever
+    an epoch boundary coincides with a step interval -- most commonly on the final
+    training step (see kohya-ss/musubi-tuner#1048).
+    """
+    return global_step != last_sampled_step

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -57,7 +57,7 @@ from musubi_tuner.training.accelerator_setup import (
     collator_class,
     prepare_accelerator,
 )
-from musubi_tuner.training.sampling_prompts import should_sample_images
+from musubi_tuner.training.sampling_prompts import should_sample_at_epoch_end, should_sample_images
 from musubi_tuner.training.timesteps import (
     compute_density_for_timestep_sampling,
     compute_ideogram4_shift_timestep,
@@ -1941,6 +1941,7 @@ class NetworkTrainer:
 
         epoch_to_start = 0
         global_step = 0
+        last_sampled_step = None
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
@@ -2113,12 +2114,13 @@ class NetworkTrainer:
 
                     # to avoid calling optimizer_eval_fn() too frequently, we call it only when we need to sample images or save the model
                     should_sampling = should_sample_images(args, global_step, epoch=None)
-                    should_saving = args.save_every_n_steps is not None and global_step % args.save_every_n_steps == 0
+                    should_saving = train_utils.should_save_at_step(args.save_every_n_steps, global_step, args.max_train_steps)
 
                     if should_sampling or should_saving:
                         optimizer_eval_fn()
                         if should_sampling:
                             _do_sample(None, global_step)
+                            last_sampled_step = global_step
 
                         if should_saving:
                             accelerator.wait_for_everyone()
@@ -2178,7 +2180,8 @@ class NetworkTrainer:
                     if args.save_state:
                         train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
-            _do_sample(epoch + 1, global_step)
+            if should_sample_at_epoch_end(global_step, last_sampled_step):
+                _do_sample(epoch + 1, global_step)
             optimizer_train_fn()
 
             # end of epoch

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -93,6 +93,16 @@ def get_last_ckpt_name(model_name):
     return model_name + ".safetensors"
 
 
+def should_save_at_step(save_every_n_steps: int | None, global_step: int, max_train_steps: int) -> bool:
+    """Whether a step-interval checkpoint should be written at this step.
+
+    Skips the final training step: the unconditional end-of-training save already
+    writes the same weights as the "last" checkpoint, so an interval-triggered save
+    here would just duplicate it (see kohya-ss/musubi-tuner#1048).
+    """
+    return save_every_n_steps is not None and global_step % save_every_n_steps == 0 and global_step < max_train_steps
+
+
 def get_remove_epoch_no(args: argparse.Namespace, epoch_no: int):
     if args.save_last_n_epochs is None:
         return None

--- a/tests/test_final_step_save_sample.py
+++ b/tests/test_final_step_save_sample.py
@@ -1,0 +1,37 @@
+from musubi_tuner.training.sampling_prompts import should_sample_at_epoch_end
+from musubi_tuner.utils.train_utils import should_save_at_step
+
+
+def test_should_save_at_step_periodic_hit():
+    assert should_save_at_step(save_every_n_steps=500, global_step=500, max_train_steps=2000) is True
+
+
+def test_should_save_at_step_not_a_multiple():
+    assert should_save_at_step(save_every_n_steps=500, global_step=750, max_train_steps=2000) is False
+
+
+def test_should_save_at_step_disabled():
+    assert should_save_at_step(save_every_n_steps=None, global_step=500, max_train_steps=2000) is False
+
+
+def test_should_save_at_step_skips_final_step_even_if_interval_matches():
+    # issue #1048: interval hits exactly on the last step, but the unconditional
+    # end-of-training save already writes the same weights as the "last" checkpoint.
+    assert should_save_at_step(save_every_n_steps=500, global_step=2000, max_train_steps=2000) is False
+
+
+def test_should_save_at_step_final_step_non_multiple_still_false():
+    assert should_save_at_step(save_every_n_steps=300, global_step=2000, max_train_steps=2000) is False
+
+
+def test_should_sample_at_epoch_end_no_prior_sample():
+    assert should_sample_at_epoch_end(global_step=2000, last_sampled_step=None) is True
+
+
+def test_should_sample_at_epoch_end_skips_duplicate_of_last_step_sample():
+    # issue #1048: the in-loop step-based trigger already sampled this exact step.
+    assert should_sample_at_epoch_end(global_step=2000, last_sampled_step=2000) is False
+
+
+def test_should_sample_at_epoch_end_proceeds_for_different_step():
+    assert should_sample_at_epoch_end(global_step=2000, last_sampled_step=1500) is True


### PR DESCRIPTION
## Summary
- Fixes #1048: when `save_every_n_steps` or `sample_every_n_steps` evenly divides `max_train_steps`, the final step triggered both the interval-based sample/save and a redundant second one.
- The end-of-epoch sample call re-evaluated step-based sampling criteria for the same `global_step` already sampled inside the training loop, firing a duplicate sample on the final step (and on any epoch boundary that happened to coincide with a step interval).
- The interval-based save wrote a step-numbered checkpoint (e.g. `*-step0002000.safetensors`) immediately before the unconditional end-of-training save wrote the same weights again as the "last" checkpoint (`output_name.safetensors`). The step-numbered save is now skipped on the final step, so only the final checkpoint is written.
- Extracted the decision logic into two small pure functions (`should_save_at_step` in `utils/train_utils.py`, `should_sample_at_epoch_end` in `training/sampling_prompts.py`) so it's unit-testable without spinning up the full training loop.

## Test plan
- [x] `uv run --no-sync --with pytest pytest tests/test_final_step_save_sample.py -q` — 8 new unit tests covering both helpers, including the exact regression scenario from #1048
- [x] `uv run --no-sync --with pytest pytest tests/ -q` (excluding two ad-hoc GPU-only files) — 77 passed, no regressions
- [ ] Not exercised against a real training run (this code path requires a full accelerator/model/dataset setup)