### PR TITLE
ci: add pytest CI workflow with a CPU torch extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout musubi-tuner
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version-file: .python-version
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgl1 libglib2.0-0 libsm6 libxext6 libxrender1
+
+      - name: Install the project
+        run: uv sync --extra cpu
+
+      - name: Run tests
+        run: uv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,29 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
+    name: pytest (torch ${{ matrix.torch-version }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # lowest torch version supported by any extra (cu124's floor)
+          - torch-version: "2.5.1"
+            torchvision-version: "0.20.1"
+          # current cpu-extra torch version
+          - torch-version: "2.13.0"
+            torchvision-version: "0.28.0"
     steps:
       - name: Checkout musubi-tuner
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -31,4 +49,11 @@ jobs:
         run: uv sync --extra cpu
 
       - name: Run tests
-        run: uv run pytest
+        env:
+          TORCH_VERSION: ${{ matrix.torch-version }}
+          TORCHVISION_VERSION: ${{ matrix.torchvision-version }}
+        run: >
+          uv run --index https://download.pytorch.org/whl/cpu
+          --with "torch==$TORCH_VERSION"
+          --with "torchvision==$TORCHVISION_VERSION"
+          pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,8 +215,17 @@ ruff check
 # Format code
 ruff format src
 
+# Run the unit tests
+pytest
+
 # Test your changes manually with the relevant scripts
 ```
+
+New test files should go in `tests/`. Tests use pytest (fixtures, marks, etc.), so run them with
+`pytest`, not `python -m unittest`.
+
+CI runs the same test suite on every push and pull request, against two PyTorch versions.
+See [`.github/workflows/test.yml`](.github/workflows/test.yml).
 
 ### Manual Testing Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,8 +221,7 @@ pytest
 # Test your changes manually with the relevant scripts
 ```
 
-New test files should go in `tests/` and be named `test_*.py`. Tests use pytest (fixtures, marks,
-etc.), so run them with `pytest`, not `python -m unittest`.
+New test files should go in `tests/` and be named `test_*.py`. Use pytest to run them.
 
 CI runs the same test suite on every push and pull request, against two PyTorch versions.
 See [`.github/workflows/test.yml`](.github/workflows/test.yml).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,8 +221,8 @@ pytest
 # Test your changes manually with the relevant scripts
 ```
 
-New test files should go in `tests/`. Tests use pytest (fixtures, marks, etc.), so run them with
-`pytest`, not `python -m unittest`.
+New test files should go in `tests/` and be named `test_*.py`. Tests use pytest (fixtures, marks,
+etc.), so run them with `pytest`, not `python -m unittest`.
 
 CI runs the same test suite on every push and pull request, against two PyTorch versions.
 See [`.github/workflows/test.yml`](.github/workflows/test.yml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ cu132 = [
     "torch>=2.12.0",
     "torchvision>=0.27.0",
 ]
+cpu = [
+    "torch>=2.12.0",
+    "torchvision>=0.27.0",
+]
 gui = [
     "gradio>=4.0.0, <6.0.0",
 ]
@@ -53,6 +57,7 @@ hidream_o1 = [
 [tool.uv]
 conflicts = [
   [
+    { extra = "cpu" },
     { extra = "cu124" },
     { extra = "cu128" },
     { extra = "cu130" },
@@ -66,6 +71,7 @@ dev = [
   "matplotlib==3.10.0",
   "tensorboard",
   "prompt-toolkit==3.0.51",
+  "pytest>=8.0",
   "ruff>=0.12.10",
 ]
 
@@ -73,14 +79,19 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.uv.sources]
 torch = [
+  { index = "pytorch-cpu", extra = "cpu" },
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
   { index = "pytorch-cu130", extra = "cu130" },
   { index = "pytorch-cu132", extra = "cu132" },
 ]
 torchvision = [
+  { index = "pytorch-cpu", extra = "cpu" },
   { index = "pytorch-cu124", extra = "cu124" },
   { index = "pytorch-cu128", extra = "cu128" },
   { index = "pytorch-cu130", extra = "cu130" },
@@ -105,6 +116,11 @@ explicit = true
 [[tool.uv.index]]
 name = "pytorch-cu132"
 url = "https://download.pytorch.org/whl/cu132"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+python_files = "test_*.py"
 
 [tool.uv.sources]
 torch = [


### PR DESCRIPTION
## Summary
Adds a CI workflow that runs the pytest suite on push/PR, CPU-only (no GPU runner needed), against two torch versions (2.5.1 and 2.13.0) to catch version-specific breakage.

- New `cpu` extra in `pyproject.toml` for CPU-only torch/torchvision, alongside the existing `cu124`/`cu128`/`cu130`/`cu132` extras
- `pytest` added as a dev dependency; `tests/` scoped via `testpaths`, and collection limited to `test_*.py` files via `python_files`
- System libs (`libgl1` etc.) installed so `opencv-python` can import on the runner
- Matrix tests torch 2.5.1 (floor of `cu124`) and 2.13.0 (current), pinned per-job with `uv run --with` so torch/torchvision resolve together consistently
- Workflow hardened per `zizmor` (permissions, concurrency, no unsafe template interpolation)
- `CONTRIBUTING.md`'s Testing section now documents running `pytest`, the `test_*.py` naming convention, and links to the CI workflow (tests use pytest fixtures/marks, so `python -m unittest` won't discover most of the suite)

## Test plan
- [x] Both matrix legs verified locally with `act` — 85 tests pass on each
- [x] `zizmor --persona=pedantic` — no findings
- [x] Verified on an actual GitHub-hosted runner: https://github.com/kohya-ss/musubi-tuner/actions/runs/31636114103 — both `pytest (torch 2.5.1)` and `pytest (torch 2.13.0)` passed