### PR TITLE
fix: pin ruff below 0.16.0 to keep CI lint passing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,9 @@ dev = [
   "matplotlib==3.10.0",
   "tensorboard",
   "prompt-toolkit==3.0.51",
-  "ruff>=0.12.10",
+  # ruff 0.16.0 enabled many new lint rules by default, producing ~2000 new findings;
+  # pinned below 0.16 until those are triaged and resolved
+  "ruff>=0.12.10,<0.16",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

ruff 0.16.0 enabled a large batch of new lint rules by default. With no changes to our code, upgrading to it produces ~2000 new findings across the repo (CI run: https://github.com/kohya-ss/musubi-tuner/actions/runs/31637928085). This pins the dev dependency below 0.16 so CI stays green until those rules are triaged and addressed deliberately.

https://astral.sh/blog/ruff-v0.16.0

## Test plan

- [x] `uv lock` resolves `ruff` to `0.15.22`
- [x] `ruff check` passes clean on the tracked repo with the pinned version