### PR TITLE
MiniMax-H3: fix single-token VAE decode and add inline --ref references for Ref2VA

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -312,6 +312,8 @@ All entries in one run use the training `--task`. T2VA JSON entries use the comm
 
 FL2VA entries additionally use `first_frame` and `last_frame`; the common `image_path` and `end_image_path` names are accepted as aliases. Ref2VA entries use `reference_jsonl`, optional `reference_index`, and an optional `prompt` override. Ref2VA keeps the same ordered JSONL schema as caching and standalone generation.
 
+Ref2VA entries may instead carry inline references with the same `--ref` spec strings as generation (see [Generation](#generation)): the `ref` key holds the ordered spec list (in `.txt` prompt files, repeat `--ref` on the line; `--rj` likewise sets `reference_jsonl` per line), the entry's prompt is the caption, and `reference_index` does not apply. `ref` and `reference_jsonl` are mutually exclusive per entry. Relative `ref` paths — and relative `reference_jsonl` paths, when the file exists there — resolve from the prompt file's directory. Because prompt lines split on ` --`, a caption containing that character sequence cannot be expressed in `.txt` prompt files (a pre-existing limitation).
+
 Sample geometry must be 32-pixel aligned. Frame counts of at least 5 are rounded down to the nearest `17*n+5` value, matching the shared training-sample convention. Released durations are 5-15 seconds; `--h3_allow_experimental_sample_duration` permits shorter smoke samples. H3 sampling does not accept negative prompts, CFG, or a per-prompt generic flow shift.
 
 ## ConvRot INT8 Quantized Base Weights
@@ -399,6 +401,15 @@ For Ref2VA, use a Ref2VA base (BF16 or ConvRot INT8) and an ordered JSONL record
 ```
 
 The Ref2VA generation JSONL intentionally uses the same validated schema as training, including target `video_path`, optional target audio, caption, and references. The target media identifies the record but is not used as a generation target. `--prompt` may override the record caption when encoding fresh text conditioning.
+
+Alternatively, inline references skip the JSONL (and its target `video_path` placeholder, which generation never reads):
+
+```text
+--task ref2va --dit /models/minimax_h3_ref2va_bf16.safetensors --prompt "A cat sings." \
+  --ref refs/cat.png --ref "refs/dance.mp4;audio=refs/song.wav" --ref refs/bgm.mp3
+```
+
+`--ref PATH[;type=image|video|audio][;audio=AUDIO_PATH]` is repeatable, and the occurrence order is the reference order. Everything after the path is strict `key=value` options separated by `;`. When `type` is omitted it is inferred from the extension — image: `.bmp` `.jpeg` `.jpg` `.png` `.webp`; audio: `.aac` `.flac` `.m4a` `.mp3` `.ogg` `.opus` `.wav`; anything else (including no extension) is video. `;audio=` attaches an external audio track to a video reference; a video's embedded audio is adopted automatically when present (suppressing embedded audio, the JSONL `"audio_path": null` form, has no inline spelling — use the JSONL). Image references cannot take `;audio=`, and a standalone audio reference puts its file in the path itself. Relative paths resolve from the current directory. Validation is exactly the JSONL `references` schema: at most 12 references, at most 9 images, 3 videos, and 3 audio-bearing references, at least one visual reference, and video references of 2-15 seconds. The caption comes from `--prompt` (required). Mutually exclusive with `--reference_jsonl`.
 
 T2VA and Ref2VA generation may use `--text_cache` instead of `--text_encoder`. The cache must match the requested task, cache format version, and exact presentation fingerprint (which covers the prompt, frame count, and size+mtime identities of the reference media, so the cache must be used on the machine holding the original files). T2VA still requires `--prompt` so that identity can be verified; Ref2VA uses the selected record caption unless `--prompt` overrides it. FL2VA generation does not accept a dataset text cache because external first/last images cannot be proven identical to the crop presentation that produced that cache.
 

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -13,6 +13,7 @@ from musubi_tuner.minimax_h3.media import (
     H3Record,
     audio_latent_frames,
     load_h3_jsonl_records,
+    parse_inline_references,
     waveform_samples,
 )
 from musubi_tuner.minimax_h3.packing import H3ReferenceGeometry, H3VideoGeometry
@@ -53,6 +54,12 @@ def prepare_pixels(frames: torch.Tensor) -> torch.Tensor:
 def load_generation_record(args) -> H3Record:
     if args.task in {"t2va", "fl2va"}:
         return dummy_record(args.prompt or "")
+
+    ref_specs = getattr(args, "ref", None)
+    if ref_specs:
+        base_directory = Path(getattr(args, "ref_base_directory", None) or Path.cwd())
+        references = parse_inline_references(ref_specs, base_directory)
+        return H3Record(video_path=Path("."), caption=args.prompt or "", references=references, jsonl_line=0)
 
     records = load_h3_jsonl_records(args.reference_jsonl, "ref2va")
     if args.reference_index >= len(records):

--- a/src/musubi_tuner/minimax_h3/media.py
+++ b/src/musubi_tuner/minimax_h3/media.py
@@ -94,73 +94,73 @@ def probe_h3_media(path: Path) -> H3MediaInfo:
     return H3MediaInfo(has_audio=has_audio, duration_seconds=duration_seconds)
 
 
-def _resolve_existing_path(value: object, base_directory: Path, field: str, line_number: int) -> Path:
+def _resolve_existing_path(value: object, base_directory: Path, field: str, context: str) -> Path:
     if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"H3 JSONL line {line_number}: {field} must be a non-empty path")
+        raise ValueError(f"{context}: {field} must be a non-empty path")
     path = Path(value)
     if not path.is_absolute():
         path = base_directory / path
     path = path.resolve()
     if not path.is_file():
-        raise ValueError(f"H3 JSONL line {line_number}: {field} does not exist: {path}")
+        raise ValueError(f"{context}: {field} does not exist: {path}")
     return path
 
 
-def _probe_required_audio(path: Path, probe: H3MediaProbe, label: str, line_number: int) -> H3MediaInfo:
+def _probe_required_audio(path: Path, probe: H3MediaProbe, label: str, context: str) -> H3MediaInfo:
     try:
         info = probe(path)
     except Exception as error:
-        raise ValueError(f"H3 JSONL line {line_number}: {label} failed to decode: {error}") from error
+        raise ValueError(f"{context}: {label} failed to decode: {error}") from error
     if not info.has_audio:
-        raise ValueError(f"H3 JSONL line {line_number}: {label} contains no audio stream: {path}")
+        raise ValueError(f"{context}: {label} contains no audio stream: {path}")
     return info
 
 
-def _validate_reference_counts(references: list, line_number: int) -> None:
+def _validate_reference_counts(references: list, context: str) -> None:
     if len(references) > 12:
-        raise ValueError(f"H3 JSONL line {line_number}: Ref2VA allows at most 12 reference items")
+        raise ValueError(f"{context}: Ref2VA allows at most 12 reference items")
 
     types = [reference.get("type") if isinstance(reference, dict) else None for reference in references]
     unsupported = [reference_type for reference_type in types if reference_type not in {"image", "video", "audio"}]
     if unsupported:
-        raise ValueError(f"H3 JSONL line {line_number}: Unsupported reference type: {unsupported[0]!r}")
+        raise ValueError(f"{context}: Unsupported reference type: {unsupported[0]!r}")
     if types.count("image") > 9:
-        raise ValueError(f"H3 JSONL line {line_number}: Ref2VA allows at most 9 image references")
+        raise ValueError(f"{context}: Ref2VA allows at most 9 image references")
     if types.count("video") > 3:
-        raise ValueError(f"H3 JSONL line {line_number}: Ref2VA allows at most 3 video references")
+        raise ValueError(f"{context}: Ref2VA allows at most 3 video references")
     if types.count("audio") > 3:
-        raise ValueError(f"H3 JSONL line {line_number}: Ref2VA allows at most 3 audio-bearing references")
+        raise ValueError(f"{context}: Ref2VA allows at most 3 audio-bearing references")
     if not any(reference_type in {"image", "video"} for reference_type in types):
-        raise ValueError(f"H3 JSONL line {line_number}: Ref2VA requires at least one visual reference")
+        raise ValueError(f"{context}: Ref2VA requires at least one visual reference")
 
 
 def _parse_references(
     raw_references: object,
     base_directory: Path,
-    line_number: int,
+    context: str,
     probe: H3MediaProbe,
 ) -> tuple[H3Reference, ...]:
     if not isinstance(raw_references, list):
-        raise ValueError(f"H3 JSONL line {line_number}: references must be a list")
-    _validate_reference_counts(raw_references, line_number)
+        raise ValueError(f"{context}: references must be a list")
+    _validate_reference_counts(raw_references, context)
 
     references = []
     audio_bearing_count = 0
     for index, raw_reference in enumerate(raw_references):
         reference_type = raw_reference["type"]
         field_prefix = f"references[{index}]"
-        path = _resolve_existing_path(raw_reference.get("path"), base_directory, f"{field_prefix}.path", line_number)
+        path = _resolve_existing_path(raw_reference.get("path"), base_directory, f"{field_prefix}.path", context)
 
         if reference_type == "image":
             if "audio_path" in raw_reference:
-                raise ValueError(f"H3 JSONL line {line_number}: {field_prefix} image cannot have audio_path")
+                raise ValueError(f"{context}: {field_prefix} image cannot have audio_path")
             references.append(H3Reference(type="image", path=path))
             continue
 
         if reference_type == "audio":
             if "audio_path" in raw_reference:
-                raise ValueError(f"H3 JSONL line {line_number}: {field_prefix} audio uses path, not audio_path")
-            info = _probe_required_audio(path, probe, f"{field_prefix} audio", line_number)
+                raise ValueError(f"{context}: {field_prefix} audio uses path, not audio_path")
+            info = _probe_required_audio(path, probe, f"{field_prefix} audio", context)
             references.append(
                 H3Reference(
                     type="audio",
@@ -175,10 +175,10 @@ def _parse_references(
         try:
             video_info = probe(path)
         except Exception as error:
-            raise ValueError(f"H3 JSONL line {line_number}: {field_prefix} video failed to decode: {error}") from error
+            raise ValueError(f"{context}: {field_prefix} video failed to decode: {error}") from error
         duration = video_info.duration_seconds
         if duration is None or duration < 2.0 or duration > 15.0:
-            raise ValueError(f"H3 JSONL line {line_number}: {field_prefix} video must be between 2 and 15 seconds; got {duration}")
+            raise ValueError(f"{context}: {field_prefix} video must be between 2 and 15 seconds; got {duration}")
 
         # an explicit "audio_path": null makes the reference visual-only (e.g. a motion
         # reference), suppressing the video's embedded audio track
@@ -187,18 +187,74 @@ def _parse_references(
             if video_info.has_audio:
                 audio = H3AudioSource(path=path, embedded=True)
         elif raw_reference["audio_path"] is not None:
-            audio_path = _resolve_existing_path(
-                raw_reference["audio_path"], base_directory, f"{field_prefix}.audio_path", line_number
-            )
-            _probe_required_audio(audio_path, probe, f"Explicit {field_prefix} audio", line_number)
+            audio_path = _resolve_existing_path(raw_reference["audio_path"], base_directory, f"{field_prefix}.audio_path", context)
+            _probe_required_audio(audio_path, probe, f"Explicit {field_prefix} audio", context)
             audio = H3AudioSource(path=audio_path, embedded=False)
         if audio is not None:
             audio_bearing_count += 1
         references.append(H3Reference(type="video", path=path, audio=audio, duration_seconds=duration))
 
     if audio_bearing_count > 3:
-        raise ValueError(f"H3 JSONL line {line_number}: Ref2VA allows at most 3 audio-bearing references")
+        raise ValueError(f"{context}: Ref2VA allows at most 3 audio-bearing references")
     return tuple(references)
+
+
+INLINE_REFERENCE_IMAGE_SUFFIXES = frozenset({".bmp", ".jpeg", ".jpg", ".png", ".webp"})
+INLINE_REFERENCE_AUDIO_SUFFIXES = frozenset({".aac", ".flac", ".m4a", ".mp3", ".ogg", ".opus", ".wav"})
+
+
+def _inline_reference_data(spec: str, context: str) -> dict:
+    """Parses one inline reference spec `path[;type=...][;audio=...]` into the JSONL dict shape."""
+    parts = spec.split(";")
+    path = parts[0].strip()
+    if not path:
+        raise ValueError(f"{context}: inline reference must start with a path: {spec!r}")
+
+    options: dict[str, str] = {}
+    for part in parts[1:]:
+        key, separator, value = part.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not separator or not key or not value:
+            raise ValueError(f"{context}: inline reference options must be key=value, got {part!r} in {spec!r}")
+        if key not in {"type", "audio"}:
+            raise ValueError(f"{context}: unknown inline reference option {key!r} in {spec!r} (allowed: type, audio)")
+        if key in options:
+            raise ValueError(f"{context}: duplicate inline reference option {key!r} in {spec!r}")
+        options[key] = value
+
+    reference_type = options.get("type")
+    if reference_type is None:
+        suffix = Path(path).suffix.lower()
+        if suffix in INLINE_REFERENCE_IMAGE_SUFFIXES:
+            reference_type = "image"
+        elif suffix in INLINE_REFERENCE_AUDIO_SUFFIXES:
+            reference_type = "audio"
+        else:
+            reference_type = "video"
+    elif reference_type not in {"image", "video", "audio"}:
+        raise ValueError(f"{context}: inline reference type must be image, video, or audio, got {reference_type!r}")
+
+    data: dict = {"type": reference_type, "path": path}
+    if "audio" in options:
+        # the JSONL-shape validation rejects audio_path on image and audio references
+        data["audio_path"] = options["audio"]
+    return data
+
+
+def parse_inline_references(
+    specs: list[str] | tuple[str, ...],
+    base_directory: Path,
+    probe: H3MediaProbe = probe_h3_media,
+    context: str = "H3 --ref",
+) -> tuple[H3Reference, ...]:
+    """Parses inline `--ref` specs with exactly the JSONL `references` validation rules.
+
+    Relative paths resolve from base_directory (the caller decides: CWD for the CLI,
+    the prompt file's directory for sample-prompt lines).
+    """
+    raw_references = [_inline_reference_data(spec, f"{context}[{index}]") for index, spec in enumerate(specs)]
+    return _parse_references(raw_references, base_directory, context, probe)
 
 
 def _record_from_jsonl_data(

--- a/src/musubi_tuner/minimax_h3/video_vae.py
+++ b/src/musubi_tuner/minimax_h3/video_vae.py
@@ -634,7 +634,11 @@ class MiniMaxH3VideoVAE(nn.Module):
         latent_std = self.latents_std.view(1, -1, 1, 1, 1).to(latents)
         latents = latents * latent_std + latent_mean
         if latents.shape[2] == 1:
-            pixels = self._decode_clip(latents)[:, :, -1:]
+            # The temporal decoder needs at least two tokens of context; a solo token decodes
+            # with severe color/scanline artifacts (~15 dB PSNR). Duplicating the token to a
+            # pseudo two-token clip and keeping pixel frame 0 stays within ~1-2 dB of a true
+            # two-token decode.
+            pixels = self._decode_video(latents.repeat(1, 1, 2, 1, 1))[:, :, :1]
         else:
             pixels = self._decode_video(latents)
         pixels = pixels.float() * self.pixel_std.to(pixels) + self.pixel_mean.to(pixels)

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -108,7 +108,7 @@ def validate_generation_args(args: argparse.Namespace) -> None:
     if args.task == "t2va":
         if not args.prompt:
             raise ValueError("MiniMax-H3 T2VA requires --prompt")
-        if args.first_frame or args.last_frame or args.reference_jsonl:
+        if args.first_frame or args.last_frame or args.reference_jsonl or args.ref:
             raise ValueError("MiniMax-H3 T2VA does not accept first/last/reference inputs")
     elif args.task == "fl2va":
         if using_text_cache:
@@ -117,14 +117,22 @@ def validate_generation_args(args: argparse.Namespace) -> None:
             raise ValueError("MiniMax-H3 FL2VA requires --prompt")
         _require_path(args.first_frame, "first_frame")
         _require_path(args.last_frame, "last_frame")
-        if args.reference_jsonl:
-            raise ValueError("MiniMax-H3 FL2VA does not accept --reference_jsonl")
+        if args.reference_jsonl or args.ref:
+            raise ValueError("MiniMax-H3 FL2VA does not accept --reference_jsonl or --ref")
     else:
-        _require_path(args.reference_jsonl, "reference_jsonl")
+        if bool(args.reference_jsonl) == bool(args.ref):
+            raise ValueError("MiniMax-H3 Ref2VA requires exactly one of --reference_jsonl or --ref")
         if args.first_frame or args.last_frame:
             raise ValueError("MiniMax-H3 Ref2VA does not accept --first_frame or --last_frame")
-        if args.reference_index < 0:
-            raise ValueError("MiniMax-H3 --reference_index must be nonnegative")
+        if args.ref:
+            if not args.prompt:
+                raise ValueError("MiniMax-H3 Ref2VA with --ref requires --prompt")
+            if args.reference_index:
+                raise ValueError("MiniMax-H3 --reference_index selects a --reference_jsonl record and does not apply to --ref")
+        else:
+            _require_path(args.reference_jsonl, "reference_jsonl")
+            if args.reference_index < 0:
+                raise ValueError("MiniMax-H3 --reference_index must be nonnegative")
 
     lora_weights = args.lora_weight or []
     for path in lora_weights:
@@ -342,6 +350,16 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--last_frame", default=None)
     parser.add_argument("--reference_jsonl", default=None)
     parser.add_argument("--reference_index", type=int, default=0)
+    parser.add_argument(
+        "--ref",
+        action="append",
+        default=None,
+        metavar="PATH[;type=image|video|audio][;audio=AUDIO_PATH]",
+        help="Ref2VA inline reference, repeatable; occurrence order is the reference order and the caption comes from"
+        " --prompt, so no JSONL (and no dummy target video_path) is needed. The type is inferred from the file"
+        " extension unless ;type= overrides it; ;audio= attaches an external audio track to a video reference."
+        " Validation matches the JSONL references schema exactly. Mutually exclusive with --reference_jsonl.",
+    )
     parser.add_argument("--width", type=int, default=768)
     parser.add_argument("--height", type=int, default=1344)
     parser.add_argument("--frame_count", type=int, default=124)

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -31,7 +31,7 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     load_generation_record,
     module_device_dtype,
 )
-from musubi_tuner.minimax_h3.media import H3_AUDIO_SPEC, audio_latent_frames, video_latent_frames
+from musubi_tuner.minimax_h3.media import H3_AUDIO_SPEC, audio_latent_frames, parse_inline_references, video_latent_frames
 from musubi_tuner.minimax_h3.model import load_h3_transformer
 from musubi_tuner.minimax_h3.packing import (
     H3PackedLayout,
@@ -124,25 +124,48 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
     first_frame = sample.get("first_frame") or sample.get("image_path")
     last_frame = sample.get("last_frame") or sample.get("end_image_path")
     reference_jsonl = sample.get("reference_jsonl")
+    ref_specs = sample.get("ref")
     reference_index = int(sample.get("reference_index", 0))
+    if ref_specs is not None:
+        if not isinstance(ref_specs, list) or not all(isinstance(spec, str) and spec.strip() for spec in ref_specs):
+            raise ValueError("MiniMax-H3 training sample --ref entries must be non-empty strings")
     if args.task == "t2va":
         if not prompt:
             raise ValueError("MiniMax-H3 T2VA training sample requires a prompt")
-        if first_frame or last_frame or reference_jsonl:
+        if first_frame or last_frame or reference_jsonl or ref_specs:
             raise ValueError("MiniMax-H3 T2VA training sample does not accept first/last/reference inputs")
     elif args.task == "fl2va":
         if not prompt:
             raise ValueError("MiniMax-H3 FL2VA training sample requires a prompt")
+        if reference_jsonl or ref_specs:
+            raise ValueError("MiniMax-H3 FL2VA training sample does not accept reference_jsonl or --ref")
         _require_sampling_path(first_frame, "first_frame")
         _require_sampling_path(last_frame, "last_frame")
-        if reference_jsonl:
-            raise ValueError("MiniMax-H3 FL2VA training sample does not accept reference_jsonl")
     else:
-        _require_sampling_path(reference_jsonl, "reference_jsonl")
         if first_frame or last_frame:
             raise ValueError("MiniMax-H3 Ref2VA training sample does not accept first/last frames")
-        if reference_index < 0:
-            raise ValueError("MiniMax-H3 reference_index must be nonnegative")
+        prompt_directory = Path(args.sample_prompts).expanduser().resolve().parent
+        if ref_specs:
+            if reference_jsonl:
+                raise ValueError("MiniMax-H3 Ref2VA training sample cannot combine --ref with --rj/reference_jsonl")
+            if not prompt:
+                raise ValueError("MiniMax-H3 Ref2VA training sample with --ref requires a prompt")
+            if reference_index:
+                raise ValueError("MiniMax-H3 reference_index selects a reference_jsonl record and does not apply to --ref")
+            sample["ref_base_directory"] = str(prompt_directory)
+            # validate the specs (existence, probes, count limits) before the heavyweight
+            # sampling models are loaded; load_generation_record re-parses them later
+            parse_inline_references(ref_specs, prompt_directory)
+        else:
+            # relative reference_jsonl paths resolve from the prompt file's directory,
+            # falling back to the historical CWD-relative behavior
+            if reference_jsonl and not Path(reference_jsonl).expanduser().is_absolute():
+                prompt_relative = prompt_directory / Path(reference_jsonl).expanduser()
+                if prompt_relative.exists():
+                    reference_jsonl = str(prompt_relative)
+            _require_sampling_path(reference_jsonl, "reference_jsonl")
+            if reference_index < 0:
+                raise ValueError("MiniMax-H3 reference_index must be nonnegative")
 
     seed = sample.get("seed")
     sample.update(
@@ -151,6 +174,7 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
         first_frame=first_frame,
         last_frame=last_frame,
         reference_jsonl=reference_jsonl,
+        ref=ref_specs,
         reference_index=reference_index,
         width=width,
         height=height,

--- a/src/musubi_tuner/training/sampling_prompts.py
+++ b/src/musubi_tuner/training/sampling_prompts.py
@@ -93,6 +93,19 @@ def line_to_prompt_dict(line: str) -> dict:
                 prompt_dict["one_frame"] = m.group(1).strip()
                 continue
 
+            m = re.match(r"rj (.+)", parg, re.IGNORECASE)
+            if m:  # reference JSONL (MiniMax-H3 Ref2VA)
+                prompt_dict["reference_jsonl"] = m.group(1).strip()
+                continue
+
+            m = re.match(r"ref (.+)", parg, re.IGNORECASE)
+            if m:
+                # can be multiple inline references (MiniMax-H3 Ref2VA)
+                if "ref" not in prompt_dict:
+                    prompt_dict["ref"] = []
+                prompt_dict["ref"].append(m.group(1).strip())
+                continue
+
         except ValueError as ex:
             logger.error(f"Exception in parsing / 解析エラー: {parg}")
             logger.error(ex)

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -18,6 +18,7 @@ from musubi_tuner.minimax_h3.media import (
     audio_latent_frames,
     h3_records_from_datasource,
     load_h3_jsonl_records,
+    parse_inline_references,
     video_latent_frames,
     waveform_samples,
 )
@@ -107,6 +108,78 @@ def test_ref2va_jsonl_preserves_reference_order_and_canonicalizes_paths(tmp_path
     assert record.references[2].audio is not None
     assert record.references[2].audio.path == voice
     assert record_media_paths(record) == {video, image, reference_video, reference_audio, voice}
+
+
+def test_inline_references_infer_types_from_extensions_and_resolve_relative_paths(tmp_path: Path):
+    image = _touch(tmp_path / "refs" / "face.png")
+    motion = _touch(tmp_path / "refs" / "motion.mp4")
+    song = _touch(tmp_path / "refs" / "song.wav")
+    voice = _touch(tmp_path / "refs" / "voice.flac")
+    clip = _touch(tmp_path / "refs" / "clip")  # no extension -> video
+    media = {
+        motion: H3MediaInfo(has_audio=False, duration_seconds=6.0),
+        song: H3MediaInfo(has_audio=True, duration_seconds=6.0),
+        voice: H3MediaInfo(has_audio=True, duration_seconds=4.0),
+        clip: H3MediaInfo(has_audio=True, duration_seconds=3.0),
+    }
+
+    references = parse_inline_references(
+        ["refs/face.png", "refs/motion.mp4;audio=refs/song.wav", "refs/voice.flac", "refs/clip"],
+        tmp_path,
+        media.__getitem__,
+    )
+
+    assert [reference.type for reference in references] == ["image", "video", "audio", "video"]
+    assert [reference.path for reference in references] == [image, motion, voice, clip]
+    assert references[1].audio == H3AudioSource(path=song, embedded=False)
+    assert references[2].audio == H3AudioSource(path=voice, embedded=False)
+    assert references[3].audio == H3AudioSource(path=clip, embedded=True)
+
+
+def test_inline_reference_type_override_and_spec_errors(tmp_path: Path):
+    still = _touch(tmp_path / "still.png")
+    _touch(tmp_path / "voice.wav")
+
+    def probe(path):
+        del path
+        return H3MediaInfo(has_audio=False, duration_seconds=6.0)
+
+    references = parse_inline_references(["still.png;type=video"], tmp_path, probe)
+    assert references[0].type == "video"
+    assert references[0].path == still
+
+    for spec, message in (
+        ("still.png;fast", "key=value"),
+        ("still.png;size=2", "unknown inline reference option"),
+        ("still.png;type=image;type=video", "duplicate inline reference option"),
+        ("still.png;type=photo", "must be image, video, or audio"),
+        (";type=image", "must start with a path"),
+        ("still.png;audio=voice.wav", "image cannot have audio_path"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            parse_inline_references([spec], tmp_path, probe)
+
+    # the reference-count validation (at least one visual) runs before the per-item checks
+    with pytest.raises(ValueError, match="audio uses path"):
+        parse_inline_references(["still.png", "voice.wav;audio=voice.wav"], tmp_path, probe)
+
+
+def test_inline_references_share_the_jsonl_count_and_duration_rules(tmp_path: Path):
+    _touch(tmp_path / "still.png")
+    _touch(tmp_path / "voice.wav")
+    _touch(tmp_path / "long.mp4")
+
+    def probe(path):
+        return H3MediaInfo(has_audio=True, duration_seconds=30.0 if path.suffix == ".mp4" else 4.0)
+
+    with pytest.raises(ValueError, match="at most 9 image references"):
+        parse_inline_references(["still.png"] * 10, tmp_path, probe)
+    with pytest.raises(ValueError, match="at least one visual reference"):
+        parse_inline_references(["voice.wav"], tmp_path, probe)
+    with pytest.raises(ValueError, match="between 2 and 15 seconds"):
+        parse_inline_references(["long.mp4"], tmp_path, probe)
+    with pytest.raises(ValueError, match="does not exist"):
+        parse_inline_references(["missing.png"], tmp_path, probe)
 
 
 def test_records_from_jsonl_datasource_share_the_parsed_data(tmp_path: Path):

--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -44,6 +44,7 @@ def _load_training_module(monkeypatch):
         "musubi_tuner.minimax_h3.media",
         H3_AUDIO_SPEC=object(),
         audio_latent_frames=noop,
+        parse_inline_references=noop,
         video_latent_frames=noop,
     )
     _stub(

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -21,6 +21,7 @@ from musubi_tuner.minimax_h3.sampling import (
     sample_joint_av,
     write_joint_av,
 )
+from musubi_tuner.minimax_h3.generation_inputs import load_generation_record
 from musubi_tuner.minimax_h3_generate_video import load_cached_text_conditioning, validate_generation_args
 
 
@@ -292,6 +293,7 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         "last_frame": None,
         "reference_jsonl": None,
         "reference_index": 0,
+        "ref": None,
         "width": 64,
         "height": 64,
         "frame_count": 124,
@@ -332,6 +334,53 @@ def test_generation_validation_enforces_task_inputs_and_block_swap_range(tmp_pat
         validate_generation_args(_generation_args(tmp_path, task="ref2va"))
     with pytest.raises(ValueError, match="blocks_to_swap"):
         validate_generation_args(_generation_args(tmp_path, blocks_to_swap=49))
+
+
+def test_generation_validation_accepts_inline_refs_exclusively_with_reference_jsonl(tmp_path):
+    validate_generation_args(_generation_args(tmp_path, task="ref2va", ref=["face.png"]))
+
+    jsonl = tmp_path / "refs.jsonl"
+    jsonl.touch()
+    with pytest.raises(ValueError, match="exactly one of"):
+        validate_generation_args(_generation_args(tmp_path, task="ref2va", ref=["face.png"], reference_jsonl=str(jsonl)))
+    with pytest.raises(ValueError, match="requires --prompt"):
+        validate_generation_args(_generation_args(tmp_path, task="ref2va", ref=["face.png"], prompt=None))
+    with pytest.raises(ValueError, match="reference_index"):
+        validate_generation_args(_generation_args(tmp_path, task="ref2va", ref=["face.png"], reference_index=1))
+    with pytest.raises(ValueError, match="T2VA does not accept"):
+        validate_generation_args(_generation_args(tmp_path, task="t2va", ref=["face.png"]))
+    first = tmp_path / "first.png"
+    last = tmp_path / "last.png"
+    first.touch()
+    last.touch()
+    with pytest.raises(ValueError, match="FL2VA does not accept"):
+        validate_generation_args(
+            _generation_args(tmp_path, task="fl2va", first_frame=str(first), last_frame=str(last), ref=["face.png"])
+        )
+
+
+def test_load_generation_record_builds_inline_ref_records_without_a_jsonl(tmp_path):
+    refs_directory = tmp_path / "refs"
+    refs_directory.mkdir()
+    face = refs_directory / "face.png"
+    style = refs_directory / "style.webp"
+    face.touch()
+    style.touch()
+
+    record = load_generation_record(
+        SimpleNamespace(
+            task="ref2va",
+            prompt="a cat sings",
+            ref=["refs/face.png", "refs/style.webp"],
+            ref_base_directory=str(tmp_path),
+            reference_jsonl=None,
+            reference_index=0,
+        )
+    )
+
+    assert record.caption == "a cat sings"
+    assert [reference.type for reference in record.references] == ["image", "image"]
+    assert [reference.path for reference in record.references] == [face.resolve(), style.resolve()]
 
 
 def test_cached_text_conditioning_validates_task_format_and_fingerprint(tmp_path):

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -23,9 +23,11 @@ from musubi_tuner.minimax_h3_train_network import (
     MiniMaxH3NetworkTrainer,
     _apply_timestep_focus,
     _decomposed_flow_loss,
+    _normalize_h3_sample_parameter,
     _prediction_geometry_log,
     minimax_h3_setup_parser,
 )
+from musubi_tuner.training.sampling_prompts import line_to_prompt_dict
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.networks import lora_minimax_h3
 from musubi_tuner.training.trainer_base import DiTOutput
@@ -150,6 +152,71 @@ def _training_batch(batch_size: int = 1, *, text_length: int = 3):
         "mmh3_token_tags": [torch.tensor([1, 0, 1][:text_length], dtype=torch.int64) for _ in range(batch_size)],
         "timesteps": None,
     }
+
+
+def test_sample_prompt_line_parses_inline_refs_and_reference_jsonl():
+    line = "a cat sings --ref refs/cat.png --ref refs/dance.mp4;audio=refs/song.wav --w 640 --h 384"
+
+    prompt_dict = line_to_prompt_dict(line)
+
+    assert prompt_dict["prompt"] == "a cat sings"
+    assert prompt_dict["ref"] == ["refs/cat.png", "refs/dance.mp4;audio=refs/song.wav"]
+    assert prompt_dict["width"] == 640
+    assert prompt_dict["height"] == 384
+
+    assert line_to_prompt_dict("a cat sings --rj refs/all.jsonl")["reference_jsonl"] == "refs/all.jsonl"
+
+
+def test_h3_ref2va_sample_normalization_resolves_inline_refs_from_the_prompt_file_directory(tmp_path):
+    prompt_file = tmp_path / "prompts.txt"
+    prompt_file.touch()
+    face = tmp_path / "refs" / "face.png"
+    face.parent.mkdir()
+    face.touch()
+    args = _trainer_args(task="ref2va", sample_prompts=str(prompt_file))
+
+    sample = _normalize_h3_sample_parameter(args, {"prompt": "a cat sings", "ref": ["refs/face.png"]})
+
+    assert sample["ref"] == ["refs/face.png"]
+    assert Path(sample["ref_base_directory"]) == tmp_path.resolve()
+    assert sample["reference_jsonl"] is None
+
+    with pytest.raises(ValueError, match="does not exist"):
+        _normalize_h3_sample_parameter(args, {"prompt": "a cat sings", "ref": ["refs/missing.png"]})
+    with pytest.raises(ValueError, match="cannot combine"):
+        _normalize_h3_sample_parameter(
+            args, {"prompt": "a cat sings", "ref": ["refs/face.png"], "reference_jsonl": "refs/all.jsonl"}
+        )
+    with pytest.raises(ValueError, match="requires a prompt"):
+        _normalize_h3_sample_parameter(args, {"ref": ["refs/face.png"]})
+    with pytest.raises(ValueError, match="does not apply to --ref"):
+        _normalize_h3_sample_parameter(args, {"prompt": "a cat sings", "ref": ["refs/face.png"], "reference_index": 1})
+    with pytest.raises(ValueError, match="non-empty strings"):
+        _normalize_h3_sample_parameter(args, {"prompt": "a cat sings", "ref": " "})
+
+    for task in ("t2va", "fl2va"):
+        with pytest.raises(ValueError, match="does not accept"):
+            _normalize_h3_sample_parameter(
+                _trainer_args(task=task, sample_prompts=str(prompt_file)),
+                {"prompt": "a cat sings", "ref": ["refs/face.png"]},
+            )
+
+
+def test_h3_ref2va_sample_normalization_resolves_relative_reference_jsonl_from_the_prompt_file(tmp_path):
+    prompt_directory = tmp_path / "sub"
+    prompt_directory.mkdir()
+    prompt_file = prompt_directory / "prompts.txt"
+    prompt_file.touch()
+    jsonl = prompt_directory / "refs.jsonl"
+    jsonl.touch()
+    args = _trainer_args(task="ref2va", sample_prompts=str(prompt_file))
+
+    sample = _normalize_h3_sample_parameter(args, {"prompt": "p", "reference_jsonl": "refs.jsonl"})
+
+    assert Path(sample["reference_jsonl"]) == jsonl.resolve()
+
+    with pytest.raises(ValueError, match="does not exist"):
+        _normalize_h3_sample_parameter(args, {"prompt": "p", "reference_jsonl": "nowhere.jsonl"})
 
 
 def test_h3_parser_defaults_to_the_only_supported_training_coordinates():

--- a/tests/test_minimax_h3_vae.py
+++ b/tests/test_minimax_h3_vae.py
@@ -121,6 +121,46 @@ def test_video_condition_uses_seed_42_and_fp16_round_trip_before_normalization()
     torch.testing.assert_close(actual, expected)
 
 
+def _decode_routing_vae():
+    vae = MiniMaxH3VideoVAE.__new__(MiniMaxH3VideoVAE)
+    nn.Module.__init__(vae)
+    vae.register_buffer("latents_mean", torch.zeros(24))
+    vae.register_buffer("latents_std", torch.full((24,), 2.0))
+    vae.register_buffer("pixel_mean", torch.zeros(1, 3, 1, 1, 1))
+    vae.register_buffer("pixel_std", torch.ones(1, 3, 1, 1, 1))
+    seen = {}
+
+    def fake_decode_video(latents):
+        seen["latents"] = latents
+        return (torch.arange(1.0, 6.0).view(1, 1, 5, 1, 1) / 10.0).expand(1, 3, 5, 2, 2)
+
+    vae._decode_video = fake_decode_video
+    return vae, seen
+
+
+def test_video_vae_decode_duplicates_a_single_token_and_keeps_pixel_frame_zero():
+    vae, seen = _decode_routing_vae()
+    latents = torch.randn(1, 24, 1, 2, 2)
+
+    pixels = vae.decode(latents)
+
+    assert seen["latents"].shape == (1, 24, 2, 2, 2)
+    torch.testing.assert_close(seen["latents"][:, :, 0], latents[:, :, 0] * 2.0)
+    torch.testing.assert_close(seen["latents"][:, :, 1], seen["latents"][:, :, 0])
+    assert pixels.shape == (1, 3, 1, 2, 2)
+    torch.testing.assert_close(pixels, torch.full((1, 3, 1, 2, 2), 0.1 * 2.0 - 1.0))
+
+
+def test_video_vae_decode_keeps_multi_token_latents_and_frames_unchanged():
+    vae, seen = _decode_routing_vae()
+    latents = torch.randn(1, 24, 2, 2, 2)
+
+    pixels = vae.decode(latents)
+
+    torch.testing.assert_close(seen["latents"], latents * 2.0)
+    assert pixels.shape == (1, 3, 5, 2, 2)
+
+
 def test_causal_conv_single_frame_truncates_temporal_kernel():
     conv = CausalConv3d(1, 1, kernel_size=3, padding=1)
     nn.init.ones_(conv.weight)


### PR DESCRIPTION
Two generation-side improvements for MiniMax-H3, groundwork for the upcoming one-frame (image) generation mode.

## 1. Single-token video VAE decode fix

`MiniMaxH3VideoVAE.decode` routed `T=1` latents through a solo-clip decode that breaks down badly (~15 dB PSNR, color/scanline artifacts): the temporal decoder needs at least two tokens of context. The `T=1` branch now duplicates the token to a pseudo two-token clip, runs the normal temporal decode, and keeps pixel frame 0 — measured within ~1-2 dB of a true two-token decode and visually clean (independently derived by 月須和・那々氏's technical report on 1-frame H3 generation). No production caller decodes `T=1` today, so this is a pure improvement; it makes every future one-frame path decode correctly. The encode branch (released condition policy) is unchanged.

## 2. Inline `--ref` references for Ref2VA

```
--task ref2va --prompt "A cat sings." --ref refs/cat.png --ref "refs/dance.mp4;audio=refs/song.wav" --ref refs/bgm.mp3
```

- `--ref PATH[;type=image|video|audio][;audio=AUDIO_PATH]`, repeatable; occurrence order is the reference order. Options are strict `key=value`; `type` is inferred from the extension when omitted (image: bmp/jpeg/jpg/png/webp; audio: aac/flac/m4a/mp3/ogg/opus/wav; anything else including no extension is video).
- Specs are converted to the JSONL `references` dict shape and flow through the existing parser, so validation (max 12/9/3/3, at least one visual, 2-15 s videos, audio rules) is **identical by construction**.
- The caption comes from `--prompt`, so generation no longer needs a JSONL with a dummy target `video_path`. Mutually exclusive with `--reference_jsonl`.
- Training-time sample prompts accept the same specs: repeated `--ref` and per-line `--rj` in `.txt` lines (a `ref` list / `reference_jsonl` in TOML/JSON entries). Relative paths resolve from the prompt file's directory, and specs are validated before the heavyweight sampling models load.

Error messages in the shared reference parser were generalized from `H3 JSONL line N:` to a caller-supplied context prefix so inline and JSONL parsing share one code path.

## Status

- 475 tests pass (new: VAE decode routing, inline spec parsing/validation, prompt-line parsing, sample normalization), ruff clean.
- Real-machine smoke of `--ref` generation pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)