### PR TITLE
Add interactive, batch, and latent-decode modes to MiniMax-H3 generation

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -378,6 +378,8 @@ python minimax_h3_generate_video.py \
   --output output.mp4
 ```
 
+`--seed` is optional: when omitted, each generation draws a fresh random seed and logs it (auto-named outputs embed it in the filename).
+
 Add a trained LoRA with:
 
 ```text
@@ -417,9 +419,39 @@ T2VA and Ref2VA generation may use `--text_cache` instead of `--text_encoder`. T
 
 `--steps N` means N model evaluations, so the schedule uses N+1 grid points. The released implementations (SGLang serving and the diffusers scheduler) instead count grid points: their `num_inference_steps = N` performs N-1 evaluations. Musubi `--steps N` is therefore grid-identical to official `num_inference_steps = N+1`; to reproduce the official 50-step serving default exactly, pass `--steps 49`.
 
+`--compile` wraps the 50 DiT blocks with torch.compile using the same flags as training (`--compile_backend`, `--compile_mode`, `--compile_dynamic`, `--compile_fullgraph`, `--compile_cache_size_limit`; requires triton). The exclusions also match training: with block swap or a ConvRot INT8 base the Linear layers stay eager (the INT8 path's custom autograd + Triton kernels are not dynamo-traceable), so the speedup comes from fusing the rest of the block graph. The first sampling steps pay the compilation latency, and each new latent shape triggers a recompile — in interactive or batch sessions with varying resolutions or frame counts, pass `--compile_dynamic true` or budget one recompilation per shape.
+
 `--trajectory_dir DIR` is a diagnostic: it logs each step's base/video/audio sigma (also written to `DIR/sigma_schedule.csv`) and decodes each step's clean estimate (`x0_hat = x_t + sigma * v`, the model's current best guess of the final video) to a silent per-step MP4 in `DIR`, named with the step index and its base and video sigmas. Scrubbing through the files shows at which step composition, palette, and identity settle. The per-step latents are held on the CPU and decoded after the normal output, so peak VRAM is unchanged, but decode time grows with the step count; `--trajectory_stride N` decodes every N-th step (the last step is always included).
 
 The native sampler builds one common base grid, derives independent shifted video and audio sigma grids, and advances each modality with its own finite sigma interval. It does not apply CFG, negate the model heads, or apply ComfyUI's single-sampler audio slope adapter. Musubi also adds condition noise before packing, while ComfyUI adds it after packing; the distributions agree but RNG placement does not. These two intentional differences mean the same seed is not bitwise reproducible against ComfyUI. Video and audio are decoded sequentially, trimmed to a common duration, and muxed with PyAV as H.264 plus AAC.
+
+### Batch and interactive modes
+
+Model loading dominates single-shot latency (and `--convrot_int8` requantizes at every start), so repeated generation should use `--from_file` or `--interactive` instead of one process per prompt. Both read prompt lines of the form:
+
+```text
+A singer performs under stage lights. --w 768 --h 1344 --f 124 --d 42 --s 30
+```
+
+| Line option | Maps to |
+| --- | --- |
+| `--w`, `--h` | `--width`, `--height` |
+| `--f` | `--frame_count` (`--f 1` selects one-frame mode) |
+| `--d` | `--seed` |
+| `--s` | `--steps` |
+| `--fs`, `--fsa` | `--h3_shift_video`, `--h3_shift_audio` |
+| `--i`, `--ei` | `--first_frame`, `--last_frame` (end image) |
+| `--ref` | `--ref` (repeatable; replaces the session-level list) |
+| `--of` | `--one_frame` |
+| `--o` | output filename inside the output directory |
+
+Unspecified options inherit the command-line values, so a fixed `--ref` set with varying prompts works. A line starting with `--` carries only options and keeps the command-line `--prompt` in effect — with a session prompt, `--d 43` alone re-runs it with a new seed. The literal string `\n` in prompt text (line prompts and `--prompt` alike) becomes a newline, so the multi-line official prompt format fits on one line. `--task`, the model artifacts, and the LoRA configuration are fixed for the session, and `--text_cache` and `--trajectory_dir` are not accepted. In both modes `--output` names a directory (created if missing); files are auto-named `<timestamp>_<seed>.png/.mp4` unless a line overrides the name with `--o`, and omitting `--d` draws a fresh random seed per line.
+
+**`--from_file prompts.txt`** runs the prompts in four phases, loading each model family exactly once: condition VAE encoding for every line (lines starting with `#` and empty lines are skipped), then all text encodings, then all samplings, then all decodes. Peak VRAM therefore matches single-shot generation — the same `--blocks_to_swap`/`--text_encoder_blocks_to_swap` settings apply unchanged. Each sampled result is written to `<output>/<timestamp>_<index>_<seed>_latent.safetensors` before any decoding, so a crash never loses finished sampling work; the file is removed once its output is written and kept (with a log message) when decoding fails. A failing line is reported and skipped without aborting the rest of the batch.
+
+**`--latent_path FILE...`** decodes those intermediate latent files without loading the transformer or text encoder — only the VAEs (`--audio_vae` may be omitted when every file is a one-frame latent). Outputs go to the `--output` directory.
+
+**`--interactive`** reads prompt lines from the console and keeps every model resident for the whole session: the text encoder and the transformer stay loaded with their configured placements, and the VAEs idle on the CPU between prompts. Unlike the batch phases, both large models coexist, so VRAM-limited setups (24 GB and below) should combine a quantized transformer plus a generous `--blocks_to_swap` with `--text_encoder_blocks_to_swap 50` (and `--text_encoder_attn_mode flash_attention_2` for long Ref2VA presentations). The CPU-resident copies mean host RAM must hold both artifacts — 64 GB is a comfortable floor for the quantized pair. Text conditioning is cached by prompt and media fingerprints, so re-running a line with only a new seed skips the text encoder entirely. Ctrl+D (or Ctrl+Z on Windows) exits; Ctrl+C interrupts the current generation and returns to the prompt. `--bell` rings the terminal bell after each generation (in the other modes, once at the end).
 
 ## Limitations
 

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import gc
 import logging
+import random
+from collections import OrderedDict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 from safetensors import safe_open
-from safetensors.torch import load_file
+from safetensors.torch import load_file, save_file
 import torch
 from tqdm.auto import tqdm
 
@@ -62,9 +68,19 @@ from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig
 from musubi_tuner.networks import lora_minimax_h3
 from musubi_tuner.utils.device_utils import clean_memory_on_device
 from musubi_tuner.utils.lora_utils import filter_lora_state_dict
+from musubi_tuner.utils.model_utils import compile_transformer, setup_parser_compile
 
 
 logger = logging.getLogger(__name__)
+
+VIDEO_OUTPUT_SUFFIXES = (".mp4", ".mkv", ".mov")
+LATENT_FILE_FORMAT = "minimax-h3-latents-v1"
+# each cached entry can reach ~100 MB for long Ref2VA presentations, so keep the LRU small
+TEXT_CONDITIONING_CACHE_ENTRIES = 16
+
+
+def _time_flag() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S-%f")[:-3]
 
 
 def _parse_one_frame_options(spec: str) -> tuple[int, tuple[int, ...] | None]:
@@ -119,17 +135,56 @@ def _require_path(value: str | None, label: str) -> Path:
     return path
 
 
-def validate_generation_args(args: argparse.Namespace) -> None:
+def validate_session_args(args: argparse.Namespace) -> None:
+    """Validate arguments that hold for the whole invocation (model paths, mode selection)."""
+    mode_flags = [
+        bool(getattr(args, "interactive", False)),
+        bool(getattr(args, "from_file", None)),
+        bool(getattr(args, "latent_path", None)),
+    ]
+    if sum(mode_flags) > 1:
+        raise ValueError("MiniMax-H3 --interactive, --from_file, and --latent_path are mutually exclusive")
+
+    if getattr(args, "latent_path", None):
+        for path in args.latent_path:
+            _require_path(path, "latent_path")
+        _require_path(getattr(args, "video_vae", None), "video_vae")
+        return
+
+    if not args.task:
+        raise ValueError("MiniMax-H3 generation requires --task")
     if args.task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError("MiniMax-H3 --task must be t2va, fl2va, or ref2va")
     for label in ("dit", "video_vae", "audio_vae"):
         _require_path(getattr(args, label, None), label)
-    using_text_cache = getattr(args, "text_cache", None) is not None
-    if not using_text_cache:
+
+    multi_prompt = bool(getattr(args, "interactive", False)) or bool(getattr(args, "from_file", None))
+    if multi_prompt:
+        if getattr(args, "text_cache", None):
+            raise ValueError("MiniMax-H3 --interactive and --from_file do not accept --text_cache")
+        if getattr(args, "trajectory_dir", None):
+            raise ValueError("MiniMax-H3 --interactive and --from_file do not accept --trajectory_dir")
         _require_path(getattr(args, "text_encoder", None), "text_encoder")
     else:
-        _require_path(args.text_cache, "text_cache")
+        if getattr(args, "text_cache", None) is not None:
+            _require_path(args.text_cache, "text_cache")
+        else:
+            _require_path(getattr(args, "text_encoder", None), "text_encoder")
+    if getattr(args, "from_file", None):
+        _require_path(args.from_file, "from_file")
 
+    if not 0 <= args.blocks_to_swap <= 48:
+        raise ValueError("MiniMax-H3 --blocks_to_swap must be between 0 and 48")
+
+    lora_weights = args.lora_weight or []
+    for path in lora_weights:
+        _require_path(path, "lora_weight")
+    if args.lora_multiplier and len(args.lora_multiplier) > len(lora_weights):
+        raise ValueError("MiniMax-H3 has more --lora_multiplier values than --lora_weight files")
+
+
+def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = False) -> None:
+    """Validate per-prompt arguments; with directory_output the output path is an auto-named directory."""
     if args.width <= 0 or args.height <= 0 or args.width % 32 or args.height % 32:
         raise ValueError(f"MiniMax-H3 width and height must be positive and divisible by 32, got {args.width}x{args.height}")
     one_frame = args.frame_count == 1
@@ -157,8 +212,6 @@ def validate_generation_args(args: argparse.Namespace) -> None:
             )
     if args.steps <= 0:
         raise ValueError("MiniMax-H3 --steps must be positive")
-    if not 0 <= args.blocks_to_swap <= 48:
-        raise ValueError("MiniMax-H3 --blocks_to_swap must be between 0 and 48")
     for label in ("h3_shift_video", "h3_shift_audio"):
         value = float(getattr(args, label))
         if not 0.01 <= value <= 100.0:
@@ -167,11 +220,14 @@ def validate_generation_args(args: argparse.Namespace) -> None:
         value = float(getattr(args, label))
         if not 0.0 <= value <= 1.0:
             raise ValueError(f"MiniMax-H3 --{label} must be in [0.0,1.0], got {value}")
-    if one_frame:
-        if Path(args.output).suffix.lower() != ".png":
-            raise ValueError("MiniMax-H3 one-frame generation writes an image; --output must use .png")
-    elif Path(args.output).suffix.lower() not in {".mp4", ".mkv", ".mov"}:
-        raise ValueError("MiniMax-H3 --output must use .mp4, .mkv, or .mov")
+    output_name = Path(getattr(args, "output_name", None)) if directory_output and getattr(args, "output_name", None) else None
+    checked_output = output_name if directory_output else Path(args.output)
+    if checked_output is not None:
+        if one_frame:
+            if checked_output.suffix.lower() != ".png":
+                raise ValueError("MiniMax-H3 one-frame generation writes an image; the output name must use .png")
+        elif checked_output.suffix.lower() not in VIDEO_OUTPUT_SUFFIXES:
+            raise ValueError("MiniMax-H3 output names must use .mp4, .mkv, or .mov")
     if args.trajectory_stride < 1:
         raise ValueError(f"MiniMax-H3 --trajectory_stride must be at least 1, got {args.trajectory_stride}")
 
@@ -181,7 +237,7 @@ def validate_generation_args(args: argparse.Namespace) -> None:
         if args.first_frame or args.last_frame or args.reference_jsonl or args.ref:
             raise ValueError("MiniMax-H3 T2VA does not accept first/last/reference inputs")
     elif args.task == "fl2va":
-        if using_text_cache:
+        if getattr(args, "text_cache", None) is not None:
             raise ValueError("MiniMax-H3 FL2VA generation does not accept --text_cache")
         if not args.prompt:
             raise ValueError("MiniMax-H3 FL2VA requires --prompt")
@@ -211,11 +267,10 @@ def validate_generation_args(args: argparse.Namespace) -> None:
             if args.reference_index < 0:
                 raise ValueError("MiniMax-H3 --reference_index must be nonnegative")
 
-    lora_weights = args.lora_weight or []
-    for path in lora_weights:
-        _require_path(path, "lora_weight")
-    if args.lora_multiplier and len(args.lora_multiplier) > len(lora_weights):
-        raise ValueError("MiniMax-H3 has more --lora_multiplier values than --lora_weight files")
+
+def validate_generation_args(args: argparse.Namespace) -> None:
+    validate_session_args(args)
+    validate_prompt_args(args)
 
 
 def load_cached_text_conditioning(
@@ -250,7 +305,111 @@ def load_cached_text_conditioning(
     return hidden_states.unsqueeze(0), token_tags
 
 
-def _encode_text(args, record: H3Record, text_visuals, device: torch.device):
+@dataclass
+class H3SharedModels:
+    """Session-resident models for --interactive and --from_file.
+
+    The text encoder and transformer keep whatever placement their load flags chose
+    (GPU-resident, or CPU-resident with layer/block streaming); the VAEs idle on the
+    CPU and are borrowed onto the device per use. Stage helpers that receive no
+    container reproduce the single-shot load-use-free behavior instead.
+    """
+
+    device: torch.device
+    processor: object | None = None
+    text_encoder: object | None = None
+    video_vaes: dict[torch.dtype, torch.nn.Module] = field(default_factory=dict)
+    audio_vae: torch.nn.Module | None = None
+    transformer: torch.nn.Module | None = None
+    lora_networks: list[torch.nn.Module] = field(default_factory=list)
+    text_conditioning_cache: OrderedDict[str, tuple[torch.Tensor, torch.Tensor]] = field(default_factory=OrderedDict)
+
+    def release_text_encoder(self) -> None:
+        if self.processor is None and self.text_encoder is None:
+            return
+        self.processor = None
+        self.text_encoder = None
+        gc.collect()
+        clean_memory_on_device(self.device)
+
+    def release_transformer(self) -> None:
+        transformer = self.transformer
+        if transformer is None:
+            return
+        if transformer.offloader is not None:
+            transformer.offloader.set_forward_only(True)
+        self.transformer = None
+        self.lora_networks = []
+        del transformer
+        gc.collect()
+        clean_memory_on_device(self.device)
+
+
+@contextmanager
+def _borrowed_video_vae(args: argparse.Namespace, device: torch.device, dtype: torch.dtype, shared: H3SharedModels | None):
+    if shared is None:
+        vae = load_video_vae(args.video_vae, device=device, dtype=dtype, disable_mmap=args.disable_numpy_memmap)
+        try:
+            yield vae
+        finally:
+            del vae
+            gc.collect()
+            clean_memory_on_device(device)
+        return
+    vae = shared.video_vaes.get(dtype)
+    if vae is None:
+        vae = load_video_vae(args.video_vae, device="cpu", dtype=dtype, disable_mmap=args.disable_numpy_memmap)
+        shared.video_vaes[dtype] = vae
+    vae.to(device)
+    try:
+        yield vae
+    finally:
+        vae.to("cpu")
+        clean_memory_on_device(device)
+
+
+@contextmanager
+def _borrowed_audio_vae(args: argparse.Namespace, device: torch.device, shared: H3SharedModels | None):
+    if shared is None:
+        vae = load_audio_vae(args.audio_vae, device=device, dtype=torch.float32, disable_mmap=args.disable_numpy_memmap)
+        try:
+            yield vae
+        finally:
+            del vae
+            gc.collect()
+            clean_memory_on_device(device)
+        return
+    if shared.audio_vae is None:
+        shared.audio_vae = load_audio_vae(args.audio_vae, device="cpu", dtype=torch.float32, disable_mmap=args.disable_numpy_memmap)
+    shared.audio_vae.to(device)
+    try:
+        yield shared.audio_vae
+    finally:
+        shared.audio_vae.to("cpu")
+        clean_memory_on_device(device)
+
+
+def _text_conditioning_cache_key(args: argparse.Namespace, record: H3Record, presentation) -> str:
+    # the presentation fingerprint hashes text and media shapes; media contents enter through
+    # per-file fingerprints. FL2VA frames are not record references, so they are added here.
+    if args.task == "fl2va":
+        media_fingerprints = {Path(path): fingerprint_file(path) for path in (args.first_frame, args.last_frame) if path}
+    else:
+        media_fingerprints = {
+            reference.path: fingerprint_file(reference.path)
+            for reference in record.references
+            if reference.type in {"image", "video"}
+        }
+    return presentation_fingerprint(presentation, media_fingerprints, frame_count=args.frame_count)
+
+
+def _encode_text(
+    args: argparse.Namespace,
+    record: H3Record,
+    text_visuals,
+    device: torch.device,
+    shared: H3SharedModels | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
     presentation = build_presentation(record, args.task, text_visuals)
     if args.text_cache:
         media_fingerprints = {
@@ -268,22 +427,44 @@ def _encode_text(args, record: H3Record, text_visuals, device: torch.device):
             task=args.task,
             presentation_identity=presentation_identity,
         )
-    logger.info("Loading MiniMax-H3 Qwen3-VL text encoder")
-    processor = load_h3_processor()
-    text_encoder = load_h3_text_encoder(
-        args.text_encoder,
-        device=device,
-        dtype=torch.bfloat16,
-        disable_mmap=args.disable_numpy_memmap,
-        nvfp4_scaled_mm=args.nvfp4_scaled_mm,
-        blocks_to_swap=args.text_encoder_blocks_to_swap,
-        attn_mode=args.text_encoder_attn_mode,
-    )
+    cache_key = None
+    if shared is not None:
+        cache_key = _text_conditioning_cache_key(args, record, presentation)
+        cached = shared.text_conditioning_cache.get(cache_key)
+        if cached is not None:
+            shared.text_conditioning_cache.move_to_end(cache_key)
+            logger.info("Reusing cached MiniMax-H3 text conditioning")
+            return cached
+    if shared is not None and shared.text_encoder is not None:
+        processor = shared.processor
+        text_encoder = shared.text_encoder
+    else:
+        logger.info("Loading MiniMax-H3 Qwen3-VL text encoder")
+        processor = load_h3_processor()
+        text_encoder = load_h3_text_encoder(
+            args.text_encoder,
+            device=device,
+            dtype=torch.bfloat16,
+            disable_mmap=args.disable_numpy_memmap,
+            nvfp4_scaled_mm=args.nvfp4_scaled_mm,
+            blocks_to_swap=args.text_encoder_blocks_to_swap,
+            attn_mode=args.text_encoder_attn_mode,
+        )
+        if shared is not None:
+            shared.processor = processor
+            shared.text_encoder = text_encoder
     hidden_states, token_tags = encode_h3_presentation(processor, text_encoder, presentation)
-    del processor, text_encoder
-    gc.collect()
+    if shared is None:
+        del processor, text_encoder
+        gc.collect()
     clean_memory_on_device(device)
-    return hidden_states.to(torch.bfloat16).unsqueeze(0).cpu(), token_tags.cpu()
+    hidden_states = hidden_states.to(torch.bfloat16).unsqueeze(0).cpu()
+    token_tags = token_tags.cpu()
+    if cache_key is not None:
+        shared.text_conditioning_cache[cache_key] = (hidden_states, token_tags)
+        while len(shared.text_conditioning_cache) > TEXT_CONDITIONING_CACHE_ENTRIES:
+            shared.text_conditioning_cache.popitem(last=False)
+    return hidden_states, token_tags
 
 
 def _load_lora_state_dicts(args) -> list[dict]:
@@ -373,255 +554,7 @@ def _configure_lora_weights(transformer, args, device: torch.device, *, prequant
     return []
 
 
-def setup_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), required=True)
-    parser.add_argument(
-        "--dit",
-        required=True,
-        help="MiniMax-H3 transformer safetensors path or directory (BF16 or ConvRot INT8, each full or pruned; "
-        "pre-quantized and pruned checkpoints are detected automatically)",
-    )
-    parser.add_argument(
-        "--convrot_int8",
-        action="store_true",
-        help="quantize BF16 DiT base weights to ConvRot INT8 at load time (requires triton for the fused kernels; "
-        "falls back to slower dequantized bf16 matmul without it). ComfyUI pre-quantized ConvRot INT8 checkpoints "
-        "are detected automatically and do not need this flag. With a BF16 base, LoRA weights are merged before "
-        "quantization; with a pre-quantized base, LoRAs are attached as runtime branches instead.",
-    )
-    parser.add_argument(
-        "--prune_adaln",
-        action="store_true",
-        help="prune the AdaLN projections of a full BF16 DiT at load time (mean-centered rank-8 basis, time "
-        "embedder retained). Published pruned checkpoints do not need this flag; pre-quantized ConvRot INT8 "
-        "checkpoints are rejected. Combines with --convrot_int8.",
-    )
-    parser.add_argument("--video_vae", required=True, help="MiniMax-H3 video VAE safetensors path or directory")
-    parser.add_argument("--audio_vae", required=True, help="MiniMax-H3 audio VAE safetensors path or directory")
-    parser.add_argument(
-        "--text_encoder", default=None, help="MiniMax-H3 Qwen3-VL safetensors path (BF16, ConvRot INT8 or NVFP4, auto-detected)"
-    )
-    parser.add_argument(
-        "--nvfp4_scaled_mm",
-        action="store_true",
-        help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
-    )
-    parser.add_argument(
-        "--text_encoder_blocks_to_swap",
-        type=int,
-        default=0,
-        help="number of the 50 Qwen3-VL decoder layers to stream from CPU instead of keeping them on the GPU"
-        " (0 = disabled, 50 = minimum VRAM; requires CUDA)",
-    )
-    parser.add_argument(
-        "--text_encoder_attn_mode",
-        choices=("sdpa", "flash_attention_2", "eager"),
-        default=None,
-        help="attention implementation for the text encoder (default: transformers default, sdpa)."
-        " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
-    )
-    parser.add_argument("--text_cache", default=None, help="optional precomputed mmh3 text cache")
-    parser.add_argument("--prompt", default=None)
-    parser.add_argument("--first_frame", default=None)
-    parser.add_argument("--last_frame", default=None)
-    parser.add_argument("--reference_jsonl", default=None)
-    parser.add_argument("--reference_index", type=int, default=0)
-    parser.add_argument(
-        "--ref",
-        action="append",
-        default=None,
-        metavar="PATH[;type=image|video|audio][;audio=AUDIO_PATH]",
-        help="Ref2VA inline reference, repeatable; occurrence order is the reference order and the caption comes from"
-        " --prompt, so no JSONL (and no dummy target video_path) is needed. The type is inferred from the file"
-        " extension unless ;type= overrides it; ;audio= attaches an external audio track to a video reference."
-        " Validation matches the JSONL references schema exactly. Mutually exclusive with --reference_jsonl.",
-    )
-    parser.add_argument("--width", type=int, default=768)
-    parser.add_argument("--height", type=int, default=1344)
-    parser.add_argument(
-        "--frame_count",
-        type=int,
-        default=124,
-        help="pixel frame count, 17*n+5 for video; 1 enables the experimental one-frame (image) mode, which writes"
-        " a PNG and skips audio decoding",
-    )
-    parser.add_argument(
-        "--one_frame",
-        default=None,
-        metavar="target_index=N,control_index=A;B",
-        help="one-frame mode time options (requires --frame_count 1): 0-based 24 fps pixel-frame indices on the"
-        " nominal timeline, converted to RoPE times relative to the target-block cursor. target_index (default 0)"
-        " places the generated frame; control_index places the FL2VA condition frames in --first_frame/--last_frame"
-        " order and is required when conditions are present. The base model reads these as trainable time inputs;"
-        " see docs/minimax_h3_1f.md",
-    )
-    parser.add_argument("--allow_experimental_duration", action="store_true")
-    parser.add_argument("--steps", type=int, default=30)
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--output", required=True)
-    parser.add_argument("--device", default=None)
-    parser.add_argument(
-        "--attn_mode",
-        choices=("torch", "sdpa", "flash", "flash3", "sageattn", "xformers"),
-        default="torch",
-    )
-    parser.add_argument("--split_attn", action="store_true")
-    parser.add_argument("--blocks_to_swap", type=int, default=0)
-    parser.add_argument("--use_pinned_memory_for_block_swap", action="store_true")
-    parser.add_argument("--h3_shift_video", type=float, default=12.0)
-    parser.add_argument("--h3_shift_audio", type=float, default=3.0)
-    parser.add_argument("--h3_visual_cond_clean", type=float, default=0.999)
-    parser.add_argument("--h3_audio_cond_clean", type=float, default=1.0)
-    parser.add_argument("--lora_weight", nargs="*", default=None)
-    parser.add_argument("--lora_multiplier", type=float, nargs="*", default=None)
-    parser.add_argument(
-        "--lora_runtime_attach",
-        action="store_true",
-        help="attach LoRAs as runtime additive branches instead of merging them into the base weights"
-        " (always the case for pre-quantized INT8 bases). Merging rounds the fused weights to the base"
-        " storage grid, which silently erases LoRAs whose deltas are below the BF16 mantissa step --"
-        " small-magnitude adapters such as teacher-matching LoRAs. Slightly slower, exact.",
-    )
-    parser.add_argument("--include_patterns", nargs="*", default=None)
-    parser.add_argument("--exclude_patterns", nargs="*", default=None)
-    parser.add_argument("--disable_numpy_memmap", action="store_true")
-    parser.add_argument(
-        "--trajectory_dir",
-        default=None,
-        help="diagnostic: decode each denoising step's clean estimate (x0_hat = x_t + sigma*v) to a"
-        " video-only mp4 in this directory and write the per-step sigma schedule to sigma_schedule.csv,"
-        " showing at which step the video content settles. The per-step latents are held on the CPU and"
-        " decoded after the normal output, so peak VRAM is unchanged; decode time grows with the step count",
-    )
-    parser.add_argument(
-        "--trajectory_stride",
-        type=int,
-        default=1,
-        help="decode every N-th step into --trajectory_dir (the last step is always included)",
-    )
-    return parser
-
-
-def run_generation(args: argparse.Namespace) -> Path:
-    validate_generation_args(args)
-    one_frame = args.frame_count == 1
-    device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
-    decoder = PyAVH3MediaDecoder()
-    record = load_generation_record(args)
-    if one_frame and any(reference.type == "audio" for reference in record.references):
-        raise ValueError(
-            "MiniMax-H3 one-frame generation does not accept standalone audio references"
-            " (their window is defined by the target duration); video references keep their embedded audio"
-        )
-    raw_visuals, text_visuals = decode_generation_visuals(args, record, decoder)
-    text_hidden_states, text_token_tags = _encode_text(args, record, text_visuals, device)
-
-    visual_conditions = ()
-    visual_geometries = ()
-    reference_visual_geometries = {}
-    if args.task != "t2va":
-        logger.info("Loading MiniMax-H3 video VAE for visual conditions")
-        condition_video_vae = load_video_vae(
-            args.video_vae,
-            device=device,
-            dtype=VIDEO_VAE_ENCODE_DTYPE,
-            disable_mmap=args.disable_numpy_memmap,
-        )
-        if condition_video_vae.vae_ratio != VIDEO_VAE_SPATIAL_RATIO:
-            raise ValueError(
-                f"MiniMax-H3 video VAE spatial ratio must be {VIDEO_VAE_SPATIAL_RATIO}, got {condition_video_vae.vae_ratio}"
-            )
-        visual_conditions, visual_geometries, reference_visual_geometries = encode_visual_conditions(
-            args,
-            record,
-            raw_visuals,
-            condition_video_vae,
-        )
-        del condition_video_vae
-        gc.collect()
-        clean_memory_on_device(device)
-
-    audio_conditions = ()
-    reference_audio_frames = {}
-    if args.task == "ref2va" and any(reference.audio is not None for reference in record.references):
-        logger.info("Loading MiniMax-H3 audio VAE for audio conditions")
-        condition_audio_vae = load_audio_vae(
-            args.audio_vae,
-            device=device,
-            dtype=torch.float32,
-            disable_mmap=args.disable_numpy_memmap,
-        )
-        audio_conditions, reference_audio_frames = encode_audio_conditions(
-            args,
-            record,
-            decoder,
-            condition_audio_vae,
-            reference_video_frame_counts={
-                index: int(raw_visuals[reference.path].shape[0])
-                for index, reference in enumerate(record.references)
-                if reference.type == "video"
-            },
-        )
-        del condition_audio_vae
-        gc.collect()
-        clean_memory_on_device(device)
-    reference_geometries = (
-        build_reference_geometries(record, reference_visual_geometries, reference_audio_frames) if args.task == "ref2va" else ()
-    )
-    del raw_visuals, text_visuals
-    clean_memory_on_device(device)
-
-    condition_roles = None
-    if args.task == "fl2va":
-        condition_roles = tuple(role for role, path in (("first", args.first_frame), ("last", args.last_frame)) if path)
-    layout = build_h3_layout(
-        task=args.task,
-        text_length=text_hidden_states.shape[1],
-        target_video=H3VideoGeometry(
-            ONE_FRAME_VIDEO_LATENT_FRAMES if one_frame else video_latent_frames(args.frame_count),
-            args.height // VIDEO_VAE_SPATIAL_RATIO,
-            args.width // VIDEO_VAE_SPATIAL_RATIO,
-        ),
-        target_audio_frames=ONE_FRAME_AUDIO_LATENT_FRAMES if one_frame else audio_latent_frames(args.frame_count),
-        visual_conditions=visual_geometries,
-        references=reference_geometries,
-        one_frame=one_frame,
-        condition_roles=condition_roles,
-        time_overrides=_one_frame_time_overrides(args),
-    )
-    logger.info(
-        "MiniMax-H3 layout: task=%s video=%s audio_frames=%d text_rows=%d packed_rows=%d",
-        args.task,
-        layout.target_video,
-        layout.target_audio_frames,
-        layout.text_length,
-        layout.row_count,
-    )
-    generator = create_sampling_generator(args.seed)
-    initial_video, initial_audio = initialize_target_latents(
-        video_shape=(
-            1,
-            24,
-            layout.target_video.frames,
-            layout.target_video.height,
-            layout.target_video.width,
-        ),
-        audio_shape=(1, 32, 2, layout.target_audio_frames),
-        generator=generator,
-        device=device,
-        video_dtype=torch.float32,
-        audio_dtype=torch.float32,
-    )
-    visual_conditions, audio_conditions = augment_condition_latents(
-        visual_conditions,
-        audio_conditions,
-        generator=generator,
-        visual_clean=args.h3_visual_cond_clean,
-        audio_clean=args.h3_audio_cond_clean,
-        device=device,
-    )
-
+def _load_transformer(args: argparse.Namespace, device: torch.device) -> tuple[torch.nn.Module, list[torch.nn.Module]]:
     # Three LoRA routes, keyed on the base artifact:
     # - BF16 base + --convrot_int8: merge into BF16 during the streaming load, then quantize.
     # - Pre-quantized INT8 base (auto-detected): attach LoRAs as runtime additive branches;
@@ -662,40 +595,191 @@ def run_generation(args: argparse.Namespace) -> Path:
     else:
         transformer.to(device)
     transformer.eval().requires_grad_(False)
-
-    trajectory_dir = Path(args.trajectory_dir).expanduser() if args.trajectory_dir else None
-    trajectory_schedule = None
-    trajectory: list[tuple[int, torch.Tensor]] = []
-    x0_callback = None
-    if trajectory_dir is not None:
-        trajectory_dir.mkdir(parents=True, exist_ok=True)
-        trajectory_schedule = build_shifted_schedule(
-            args.steps,
-            video_shift=args.h3_shift_video,
-            audio_shift=args.h3_shift_audio,
+    if getattr(args, "compile", False):
+        # mirrors minimax_h3_train_network.compile_transformer: ConvRot INT8 Linears are
+        # excluded (custom autograd.Function + autotuned Triton kernels are not
+        # dynamo-traceable), as are the Linears of swapped blocks
+        transformer = compile_transformer(
+            args,
+            transformer,
+            [transformer.blocks],
+            disable_linear=bool(args.blocks_to_swap) or bool(getattr(transformer, "is_convrot_int8", False)),
         )
-        with open(trajectory_dir / "sigma_schedule.csv", "w", encoding="utf-8", newline="") as handle:
-            handle.write("step,base_sigma,sigma_video,sigma_audio\n")
-            for index in range(args.steps):
-                handle.write(
-                    f"{index},{trajectory_schedule.base[index]:.6f},"
-                    f"{trajectory_schedule.video[index]:.6f},{trajectory_schedule.audio[index]:.6f}\n"
+    return transformer, attached_lora_networks
+
+
+def _acquire_transformer(
+    args: argparse.Namespace, device: torch.device, shared: H3SharedModels | None
+) -> tuple[torch.nn.Module, list[torch.nn.Module]]:
+    if shared is not None and shared.transformer is not None:
+        shared.transformer.prepare_block_swap_before_forward()
+        return shared.transformer, shared.lora_networks
+    transformer, lora_networks = _load_transformer(args, device)
+    if shared is not None:
+        shared.transformer = transformer
+        shared.lora_networks = lora_networks
+    return transformer, lora_networks
+
+
+def _reject_one_frame_audio_references(args: argparse.Namespace, record: H3Record) -> None:
+    if args.frame_count == 1 and any(reference.type == "audio" for reference in record.references):
+        raise ValueError(
+            "MiniMax-H3 one-frame generation does not accept standalone audio references"
+            " (their window is defined by the target duration); video references keep their embedded audio"
+        )
+
+
+def _encode_conditions(
+    args: argparse.Namespace,
+    record: H3Record,
+    raw_visuals,
+    decoder: PyAVH3MediaDecoder,
+    device: torch.device,
+    shared: H3SharedModels | None = None,
+):
+    visual_conditions = ()
+    visual_geometries = ()
+    reference_visual_geometries = {}
+    if args.task != "t2va":
+        logger.info("Encoding MiniMax-H3 visual conditions")
+        with _borrowed_video_vae(args, device, VIDEO_VAE_ENCODE_DTYPE, shared) as condition_video_vae:
+            if condition_video_vae.vae_ratio != VIDEO_VAE_SPATIAL_RATIO:
+                raise ValueError(
+                    f"MiniMax-H3 video VAE spatial ratio must be {VIDEO_VAE_SPATIAL_RATIO}, got {condition_video_vae.vae_ratio}"
                 )
-        for index in range(args.steps):
-            logger.info(
-                "MiniMax-H3 step %d/%d: base sigma %.4f, video sigma %.4f, audio sigma %.4f",
-                index,
-                args.steps,
-                trajectory_schedule.base[index],
-                trajectory_schedule.video[index],
-                trajectory_schedule.audio[index],
+            visual_conditions, visual_geometries, reference_visual_geometries = encode_visual_conditions(
+                args,
+                record,
+                raw_visuals,
+                condition_video_vae,
             )
 
-        def x0_callback(index: int, x0_video: torch.Tensor, x0_audio: torch.Tensor) -> None:
-            del x0_audio  # the diagnostic decodes video only
-            if index % args.trajectory_stride == 0 or index == args.steps - 1:
-                trajectory.append((index, x0_video.detach().to(device="cpu", dtype=torch.float32)))
+    audio_conditions = ()
+    reference_audio_frames = {}
+    if args.task == "ref2va" and any(reference.audio is not None for reference in record.references):
+        logger.info("Encoding MiniMax-H3 audio conditions")
+        with _borrowed_audio_vae(args, device, shared) as condition_audio_vae:
+            audio_conditions, reference_audio_frames = encode_audio_conditions(
+                args,
+                record,
+                decoder,
+                condition_audio_vae,
+                reference_video_frame_counts={
+                    index: int(raw_visuals[reference.path].shape[0])
+                    for index, reference in enumerate(record.references)
+                    if reference.type == "video"
+                },
+            )
+    reference_geometries = (
+        build_reference_geometries(record, reference_visual_geometries, reference_audio_frames) if args.task == "ref2va" else ()
+    )
+    return visual_conditions, visual_geometries, reference_geometries, audio_conditions
 
+
+def _build_layout(args: argparse.Namespace, text_length: int, visual_geometries, reference_geometries):
+    one_frame = args.frame_count == 1
+    condition_roles = None
+    if args.task == "fl2va":
+        condition_roles = tuple(role for role, path in (("first", args.first_frame), ("last", args.last_frame)) if path)
+    layout = build_h3_layout(
+        task=args.task,
+        text_length=text_length,
+        target_video=H3VideoGeometry(
+            ONE_FRAME_VIDEO_LATENT_FRAMES if one_frame else video_latent_frames(args.frame_count),
+            args.height // VIDEO_VAE_SPATIAL_RATIO,
+            args.width // VIDEO_VAE_SPATIAL_RATIO,
+        ),
+        target_audio_frames=ONE_FRAME_AUDIO_LATENT_FRAMES if one_frame else audio_latent_frames(args.frame_count),
+        visual_conditions=visual_geometries,
+        references=reference_geometries,
+        one_frame=one_frame,
+        condition_roles=condition_roles,
+        time_overrides=_one_frame_time_overrides(args),
+    )
+    logger.info(
+        "MiniMax-H3 layout: task=%s video=%s audio_frames=%d text_rows=%d packed_rows=%d",
+        args.task,
+        layout.target_video,
+        layout.target_audio_frames,
+        layout.text_length,
+        layout.row_count,
+    )
+    return layout
+
+
+def _setup_trajectory(args: argparse.Namespace):
+    if not args.trajectory_dir:
+        return None, None, [], None
+    trajectory_dir = Path(args.trajectory_dir).expanduser()
+    trajectory_dir.mkdir(parents=True, exist_ok=True)
+    trajectory_schedule = build_shifted_schedule(
+        args.steps,
+        video_shift=args.h3_shift_video,
+        audio_shift=args.h3_shift_audio,
+    )
+    with open(trajectory_dir / "sigma_schedule.csv", "w", encoding="utf-8", newline="") as handle:
+        handle.write("step,base_sigma,sigma_video,sigma_audio\n")
+        for index in range(args.steps):
+            handle.write(
+                f"{index},{trajectory_schedule.base[index]:.6f},"
+                f"{trajectory_schedule.video[index]:.6f},{trajectory_schedule.audio[index]:.6f}\n"
+            )
+    for index in range(args.steps):
+        logger.info(
+            "MiniMax-H3 step %d/%d: base sigma %.4f, video sigma %.4f, audio sigma %.4f",
+            index,
+            args.steps,
+            trajectory_schedule.base[index],
+            trajectory_schedule.video[index],
+            trajectory_schedule.audio[index],
+        )
+    trajectory: list[tuple[int, torch.Tensor]] = []
+
+    def x0_callback(index: int, x0_video: torch.Tensor, x0_audio: torch.Tensor) -> None:
+        del x0_audio  # the diagnostic decodes video only
+        if index % args.trajectory_stride == 0 or index == args.steps - 1:
+            trajectory.append((index, x0_video.detach().to(device="cpu", dtype=torch.float32)))
+
+    return trajectory_dir, trajectory_schedule, trajectory, x0_callback
+
+
+def _sample_latents(
+    args: argparse.Namespace,
+    *,
+    layout,
+    seed: int,
+    text_hidden_states: torch.Tensor,
+    text_token_tags: torch.Tensor,
+    visual_conditions,
+    audio_conditions,
+    device: torch.device,
+    shared: H3SharedModels | None = None,
+    x0_callback=None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    generator = create_sampling_generator(seed)
+    initial_video, initial_audio = initialize_target_latents(
+        video_shape=(
+            1,
+            24,
+            layout.target_video.frames,
+            layout.target_video.height,
+            layout.target_video.width,
+        ),
+        audio_shape=(1, 32, 2, layout.target_audio_frames),
+        generator=generator,
+        device=device,
+        video_dtype=torch.float32,
+        audio_dtype=torch.float32,
+    )
+    visual_conditions, audio_conditions = augment_condition_latents(
+        visual_conditions,
+        audio_conditions,
+        generator=generator,
+        visual_clean=args.h3_visual_cond_clean,
+        audio_clean=args.h3_audio_cond_clean,
+        device=device,
+    )
+    transformer, lora_networks = _acquire_transformer(args, device, shared)
     text_hidden_states = text_hidden_states.to(device=device, dtype=torch.bfloat16)
     text_token_tags = text_token_tags.unsqueeze(0).to(device)
     with tqdm(total=args.steps, desc="MiniMax-H3", unit="step") as progress:
@@ -716,62 +800,66 @@ def run_generation(args: argparse.Namespace) -> Path:
             step_callback=lambda completed, total: progress.update(1),
             x0_callback=x0_callback,
         )
-    if transformer.offloader is not None:
+    video_latents = sample.video.detach().cpu()
+    audio_latents = sample.audio.detach().cpu()
+    if shared is None and transformer.offloader is not None:
         transformer.offloader.set_forward_only(True)
-    del transformer, attached_lora_networks, text_hidden_states, text_token_tags, visual_conditions, audio_conditions
+    del transformer, lora_networks, sample, text_hidden_states, text_token_tags
+    del visual_conditions, audio_conditions, initial_video, initial_audio
     gc.collect()
     clean_memory_on_device(device)
+    return video_latents, audio_latents
 
-    video_latents = sample.video
-    audio_latents = sample.audio
-    del sample
 
+def _decode_and_save(
+    args: argparse.Namespace,
+    video_latents: torch.Tensor,
+    audio_latents: torch.Tensor | None,
+    output_path: str | Path,
+    device: torch.device,
+    shared: H3SharedModels | None = None,
+    *,
+    trajectory=None,
+    trajectory_dir: Path | None = None,
+    trajectory_schedule=None,
+) -> Path:
+    one_frame = args.frame_count == 1
     logger.info("Decoding MiniMax-H3 video")
-    video_vae = load_video_vae(
-        args.video_vae,
-        device=device,
-        dtype=VIDEO_VAE_DECODE_DTYPE,
-        disable_mmap=args.disable_numpy_memmap,
-    )
-    with torch.no_grad():
-        decoded_video = video_vae.decode(video_latents.to(device=device, dtype=VIDEO_VAE_DECODE_DTYPE)).cpu()
-    if trajectory_dir is not None:
-        logger.info("Decoding MiniMax-H3 trajectory (%d of %d steps)", len(trajectory), args.steps)
-        for index, x0_latents in trajectory:
-            with torch.no_grad():
-                step_video = video_vae.decode(x0_latents.to(device=device, dtype=VIDEO_VAE_DECODE_DTYPE)).cpu()
-            step_stem = f"step{index:03d}_base{trajectory_schedule.base[index]:.4f}_sigv{trajectory_schedule.video[index]:.4f}"
-            if one_frame:
-                step_path = trajectory_dir / f"{step_stem}.png"
-                write_image(decoded_video_to_uint8(step_video, frame_limit=1)[0], step_path)
-            else:
-                step_path = trajectory_dir / f"{step_stem}.mp4"
-                write_video_only(decoded_video_to_uint8(step_video, frame_limit=args.frame_count), step_path)
-            del step_video
-            clean_memory_on_device(device)
-            logger.info("Saved MiniMax-H3 trajectory step: %s", step_path)
-    trajectory.clear()
-    del video_vae, video_latents
+    with _borrowed_video_vae(args, device, VIDEO_VAE_DECODE_DTYPE, shared) as video_vae:
+        with torch.no_grad():
+            decoded_video = video_vae.decode(video_latents.to(device=device, dtype=VIDEO_VAE_DECODE_DTYPE)).cpu()
+        if trajectory_dir is not None and trajectory:
+            logger.info("Decoding MiniMax-H3 trajectory (%d of %d steps)", len(trajectory), args.steps)
+            for index, x0_latents in trajectory:
+                with torch.no_grad():
+                    step_video = video_vae.decode(x0_latents.to(device=device, dtype=VIDEO_VAE_DECODE_DTYPE)).cpu()
+                step_stem = f"step{index:03d}_base{trajectory_schedule.base[index]:.4f}_sigv{trajectory_schedule.video[index]:.4f}"
+                if one_frame:
+                    step_path = trajectory_dir / f"{step_stem}.png"
+                    write_image(decoded_video_to_uint8(step_video, frame_limit=1)[0], step_path)
+                else:
+                    step_path = trajectory_dir / f"{step_stem}.mp4"
+                    write_video_only(decoded_video_to_uint8(step_video, frame_limit=args.frame_count), step_path)
+                del step_video
+                clean_memory_on_device(device)
+                logger.info("Saved MiniMax-H3 trajectory step: %s", step_path)
+            trajectory.clear()
+    del video_latents
     gc.collect()
     clean_memory_on_device(device)
 
     if one_frame:
-        # the 2-frame audio target is a byproduct of the joint layout, not an output
-        del audio_latents
-        write_image(decoded_video_to_uint8(decoded_video, frame_limit=1)[0], args.output)
-        logger.info("Saved MiniMax-H3 output: %s", args.output)
-        return Path(args.output)
+        write_image(decoded_video_to_uint8(decoded_video, frame_limit=1)[0], output_path)
+        logger.info("Saved MiniMax-H3 output: %s", output_path)
+        return Path(output_path)
 
+    if audio_latents is None:
+        raise ValueError("MiniMax-H3 video decoding requires audio latents")
     logger.info("Decoding MiniMax-H3 audio")
-    audio_vae = load_audio_vae(
-        args.audio_vae,
-        device=device,
-        dtype=torch.float32,
-        disable_mmap=args.disable_numpy_memmap,
-    )
-    with torch.no_grad():
-        decoded_audio = audio_vae.decode(audio_latents.to(device=device, dtype=torch.float32)).cpu()
-    del audio_vae, audio_latents
+    with _borrowed_audio_vae(args, device, shared) as audio_vae:
+        with torch.no_grad():
+            decoded_audio = audio_vae.decode(audio_latents.to(device=device, dtype=torch.float32)).cpu()
+    del audio_latents
     gc.collect()
     clean_memory_on_device(device)
 
@@ -780,13 +868,588 @@ def run_generation(args: argparse.Namespace) -> Path:
         decoded_audio,
         frame_count=args.frame_count,
     )
-    write_joint_av(decoded, args.output)
-    logger.info("Saved MiniMax-H3 output: %s", args.output)
-    return Path(args.output)
+    write_joint_av(decoded, output_path)
+    logger.info("Saved MiniMax-H3 output: %s", output_path)
+    return Path(output_path)
+
+
+def _resolve_seed(args: argparse.Namespace) -> int:
+    if args.seed is not None:
+        return int(args.seed)
+    seed = random.randint(0, 2**32 - 1)
+    logger.info("MiniMax-H3 using random seed %d", seed)
+    return seed
+
+
+def _resolve_output_path(args: argparse.Namespace, seed: int, *, directory_mode: bool) -> Path:
+    if not directory_mode:
+        return Path(args.output)
+    output_dir = Path(args.output).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_name = getattr(args, "output_name", None)
+    if output_name:
+        return output_dir / output_name
+    suffix = ".png" if args.frame_count == 1 else ".mp4"
+    return output_dir / f"{_time_flag()}_{seed}{suffix}"
+
+
+def _save_latent_file(
+    path: Path, video_latents: torch.Tensor, audio_latents: torch.Tensor | None, args: argparse.Namespace, seed: int
+) -> Path:
+    tensors = {"latent_video": video_latents.contiguous()}
+    if audio_latents is not None:
+        tensors["latent_audio"] = audio_latents.contiguous()
+    metadata = {
+        "format": LATENT_FILE_FORMAT,
+        "seeds": str(seed),
+        "prompt": args.prompt or "",
+        "task": args.task,
+        "width": str(args.width),
+        "height": str(args.height),
+        "frame_count": str(args.frame_count),
+        "steps": str(args.steps),
+        "h3_shift_video": str(args.h3_shift_video),
+        "h3_shift_audio": str(args.h3_shift_audio),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(path), metadata=metadata)
+    logger.info("Saved MiniMax-H3 intermediate latents: %s", path)
+    return path
+
+
+def _load_latent_file(path: Path) -> tuple[torch.Tensor, torch.Tensor | None, int, dict]:
+    with safe_open(str(path), framework="pt", device="cpu") as handle:
+        metadata = handle.metadata() or {}
+        keys = set(handle.keys())
+        if "latent_video" not in keys or not keys <= {"latent_video", "latent_audio"}:
+            raise ValueError(f"MiniMax-H3 latent file {path} has unexpected tensors {sorted(keys)}")
+        video_latents = handle.get_tensor("latent_video")
+        audio_latents = handle.get_tensor("latent_audio") if "latent_audio" in keys else None
+    if metadata.get("format") != LATENT_FILE_FORMAT:
+        raise ValueError(f"MiniMax-H3 latent file {path} format must be {LATENT_FILE_FORMAT!r}, got {metadata.get('format')!r}")
+    frame_count = metadata.get("frame_count")
+    if frame_count is None:
+        raise ValueError(f"MiniMax-H3 latent file {path} is missing its frame_count metadata")
+    frame_count = int(frame_count)
+    if frame_count > 1 and audio_latents is None:
+        raise ValueError(f"MiniMax-H3 latent file {path} is missing latent_audio for a {frame_count}-frame video")
+    return video_latents, audio_latents, frame_count, metadata
+
+
+def parse_prompt_line(line: str) -> dict:
+    """Parse an interactive/from-file prompt line into argument overrides.
+
+    Format: "prompt text --w 768 --h 1344 --f 1 --d 42 --s 30 --fs 12.0 --fsa 3.0
+    --i first.png --ei last.png --ref face.png --of target_index=24 --o name.png".
+    --ref is repeatable and replaces any session-level --ref list. A line starting
+    with "--" carries only options; without prompt text the command-line --prompt
+    (when given) stays in effect. The literal string "\\n" in the prompt text becomes
+    a newline, for the multi-line official prompt format.
+    """
+    line = line.strip()
+    parts = ["", *line[2:].split(" --")] if line.startswith("--") else line.split(" --")
+    overrides: dict = {}
+    if parts[0].strip():
+        overrides["prompt"] = parts[0].strip().replace("\\n", "\n")
+    refs: list[str] = []
+    for part in parts[1:]:
+        part = part.strip()
+        if not part:
+            continue
+        option, _, value = part.partition(" ")
+        value = value.strip()
+        if option == "w":
+            overrides["width"] = int(value)
+        elif option == "h":
+            overrides["height"] = int(value)
+        elif option == "f":
+            overrides["frame_count"] = int(value)
+        elif option == "d":
+            overrides["seed"] = int(value)
+        elif option == "s":
+            overrides["steps"] = int(value)
+        elif option == "fs":
+            overrides["h3_shift_video"] = float(value)
+        elif option == "fsa":
+            overrides["h3_shift_audio"] = float(value)
+        elif option == "i":
+            overrides["first_frame"] = value
+        elif option == "ei":
+            overrides["last_frame"] = value
+        elif option == "ref":
+            refs.append(value)
+        elif option == "of":
+            overrides["one_frame"] = value
+        elif option == "o":
+            overrides["output_name"] = value
+        else:
+            raise ValueError(f"MiniMax-H3 prompt line has unknown option --{option}")
+    if refs:
+        overrides["ref"] = refs
+    return overrides
+
+
+def apply_overrides(args: argparse.Namespace, overrides: dict) -> argparse.Namespace:
+    prompt_args = copy.deepcopy(args)
+    prompt_args.output_name = None
+    for key, value in overrides.items():
+        setattr(prompt_args, key, value)
+    return prompt_args
+
+
+def run_generation(
+    args: argparse.Namespace,
+    device: torch.device | None = None,
+    *,
+    shared: H3SharedModels | None = None,
+    decoder: PyAVH3MediaDecoder | None = None,
+    directory_output: bool = False,
+) -> Path:
+    validate_prompt_args(args, directory_output=directory_output)
+    one_frame = args.frame_count == 1
+    if device is None:
+        device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    decoder = decoder or PyAVH3MediaDecoder()
+    seed = _resolve_seed(args)
+    args.seed = seed
+
+    record = load_generation_record(args)
+    _reject_one_frame_audio_references(args, record)
+    raw_visuals, text_visuals = decode_generation_visuals(args, record, decoder)
+    text_hidden_states, text_token_tags = _encode_text(args, record, text_visuals, device, shared)
+    visual_conditions, visual_geometries, reference_geometries, audio_conditions = _encode_conditions(
+        args, record, raw_visuals, decoder, device, shared
+    )
+    del raw_visuals, text_visuals
+    clean_memory_on_device(device)
+
+    layout = _build_layout(args, text_hidden_states.shape[1], visual_geometries, reference_geometries)
+    trajectory_dir, trajectory_schedule, trajectory, x0_callback = _setup_trajectory(args)
+    video_latents, audio_latents = _sample_latents(
+        args,
+        layout=layout,
+        seed=seed,
+        text_hidden_states=text_hidden_states,
+        text_token_tags=text_token_tags,
+        visual_conditions=visual_conditions,
+        audio_conditions=audio_conditions,
+        device=device,
+        shared=shared,
+        x0_callback=x0_callback,
+    )
+    if one_frame:
+        # the 2-frame audio target is a byproduct of the joint layout, not an output
+        audio_latents = None
+    output_path = _resolve_output_path(args, seed, directory_mode=directory_output)
+    return _decode_and_save(
+        args,
+        video_latents,
+        audio_latents,
+        output_path,
+        device,
+        shared,
+        trajectory=trajectory,
+        trajectory_dir=trajectory_dir,
+        trajectory_schedule=trajectory_schedule,
+    )
+
+
+@dataclass
+class _BatchItem:
+    index: int
+    args: argparse.Namespace
+    seed: int = 0
+    record: H3Record | None = None
+    text_visuals: dict | None = None
+    text_hidden_states: torch.Tensor | None = None
+    text_token_tags: torch.Tensor | None = None
+    visual_conditions: tuple = ()
+    visual_geometries: tuple = ()
+    reference_geometries: tuple = ()
+    audio_conditions: tuple = ()
+    video_latents: torch.Tensor | None = None
+    audio_latents: torch.Tensor | None = None
+    latent_file: Path | None = None
+    error: str | None = None
+
+
+def _mark_failed(item: _BatchItem, stage: str, error: Exception) -> None:
+    item.error = f"{stage}: {error}"
+    logger.error("MiniMax-H3 prompt %d failed during %s: %s", item.index + 1, stage, error, exc_info=True)
+
+
+def process_from_file(args: argparse.Namespace, device: torch.device) -> None:
+    """Phased batch: each model family is loaded once and serves every prompt, so the
+    peak VRAM matches single-shot generation. Sampled latents are written to disk
+    immediately; a crash before decoding loses nothing (--latent_path decodes them)."""
+    with open(args.from_file, "r", encoding="utf-8") as handle:
+        lines = handle.readlines()
+    items: list[_BatchItem] = []
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        prompt_args = apply_overrides(args, parse_prompt_line(line))
+        validate_prompt_args(prompt_args, directory_output=True)
+        items.append(_BatchItem(index=len(items), args=prompt_args))
+    if not items:
+        logger.warning("MiniMax-H3 --from_file %s contains no prompts", args.from_file)
+        return
+    output_dir = Path(args.output).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shared = H3SharedModels(device=device)
+    decoder = PyAVH3MediaDecoder()
+
+    logger.info("MiniMax-H3 batch phase 1/4: preparing inputs for %d prompts", len(items))
+    for item in items:
+        try:
+            item.seed = _resolve_seed(item.args)
+            item.args.seed = item.seed
+            item.record = load_generation_record(item.args)
+            _reject_one_frame_audio_references(item.args, item.record)
+            raw_visuals, item.text_visuals = decode_generation_visuals(item.args, item.record, decoder)
+            (
+                item.visual_conditions,
+                item.visual_geometries,
+                item.reference_geometries,
+                item.audio_conditions,
+            ) = _encode_conditions(item.args, item.record, raw_visuals, decoder, device, shared)
+            del raw_visuals
+        except Exception as error:
+            _mark_failed(item, "input preparation", error)
+    clean_memory_on_device(device)
+
+    logger.info("MiniMax-H3 batch phase 2/4: text encoding")
+    for item in items:
+        if item.error:
+            continue
+        try:
+            item.text_hidden_states, item.text_token_tags = _encode_text(item.args, item.record, item.text_visuals, device, shared)
+            item.text_visuals = None
+        except Exception as error:
+            _mark_failed(item, "text encoding", error)
+    shared.release_text_encoder()
+
+    logger.info("MiniMax-H3 batch phase 3/4: sampling")
+    for item in items:
+        if item.error:
+            continue
+        try:
+            layout = _build_layout(item.args, item.text_hidden_states.shape[1], item.visual_geometries, item.reference_geometries)
+            item.video_latents, item.audio_latents = _sample_latents(
+                item.args,
+                layout=layout,
+                seed=item.seed,
+                text_hidden_states=item.text_hidden_states,
+                text_token_tags=item.text_token_tags,
+                visual_conditions=item.visual_conditions,
+                audio_conditions=item.audio_conditions,
+                device=device,
+                shared=shared,
+            )
+            if item.args.frame_count == 1:
+                # the 2-frame audio target is a byproduct of the joint layout, not an output
+                item.audio_latents = None
+            item.latent_file = _save_latent_file(
+                output_dir / f"{_time_flag()}_{item.index:03d}_{item.seed}_latent.safetensors",
+                item.video_latents,
+                item.audio_latents,
+                item.args,
+                item.seed,
+            )
+            item.text_hidden_states = None
+            item.text_token_tags = None
+            item.visual_conditions = ()
+            item.audio_conditions = ()
+        except Exception as error:
+            _mark_failed(item, "sampling", error)
+    shared.release_transformer()
+
+    logger.info("MiniMax-H3 batch phase 4/4: decoding")
+    for item in items:
+        if item.error:
+            continue
+        try:
+            output_path = _resolve_output_path(item.args, item.seed, directory_mode=True)
+            _decode_and_save(item.args, item.video_latents, item.audio_latents, output_path, device, shared)
+            item.video_latents = None
+            item.audio_latents = None
+            if item.latent_file is not None:
+                item.latent_file.unlink(missing_ok=True)
+                item.latent_file = None
+        except Exception as error:
+            _mark_failed(item, "decoding", error)
+            if item.latent_file is not None:
+                logger.info("MiniMax-H3 intermediate latents kept for --latent_path decoding: %s", item.latent_file)
+
+    failed = [item for item in items if item.error]
+    logger.info("MiniMax-H3 batch finished: %d/%d prompts succeeded", len(items) - len(failed), len(items))
+    for item in failed:
+        logger.error("MiniMax-H3 prompt %d (%s) failed: %s", item.index + 1, item.args.prompt, item.error)
+
+
+def process_interactive(args: argparse.Namespace, device: torch.device) -> None:
+    """Interactive loop with all models session-resident. The text encoder and the
+    transformer coexist on the accelerator, so VRAM-limited setups should pass
+    --text_encoder_blocks_to_swap 50 and a generous --blocks_to_swap."""
+    shared = H3SharedModels(device=device)
+    decoder = PyAVH3MediaDecoder()
+    Path(args.output).expanduser().mkdir(parents=True, exist_ok=True)
+
+    print("Interactive mode. Enter prompts (Ctrl+D or Ctrl+Z (Windows) to exit):")
+    try:
+        import prompt_toolkit
+    except ImportError:
+        logger.warning("prompt_toolkit not found. Using basic input instead.")
+        prompt_toolkit = None
+
+    if prompt_toolkit:
+        session = prompt_toolkit.PromptSession()
+
+        def input_line(prompt: str) -> str:
+            return session.prompt(prompt)
+
+    else:
+
+        def input_line(prompt: str) -> str:
+            return input(prompt)
+
+    try:
+        while True:
+            try:
+                line = input_line("> ")
+                if not line.strip():
+                    continue
+                if len(line.strip()) == 1 and line.strip() in ["\x04", "\x1a"]:  # Ctrl+D or Ctrl+Z with prompt_toolkit
+                    raise EOFError
+                prompt_args = apply_overrides(args, parse_prompt_line(line))
+                run_generation(prompt_args, device, shared=shared, decoder=decoder, directory_output=True)
+                if args.bell:
+                    print("\a")
+            except KeyboardInterrupt:
+                print("\nInterrupted. Continue (Ctrl+D or Ctrl+Z (Windows) to exit)")
+                continue
+            except EOFError:
+                raise
+            except Exception as error:
+                logger.error("MiniMax-H3 generation failed: %s", error, exc_info=True)
+    except EOFError:
+        print("\nExiting interactive mode")
+
+
+def process_latent_decode(args: argparse.Namespace, device: torch.device) -> None:
+    """Decode-only mode for --from_file intermediate latents; only the VAEs are loaded."""
+    output_dir = Path(args.output).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    loaded = []
+    for path in args.latent_path:
+        source = Path(path).expanduser()
+        loaded.append((source, *_load_latent_file(source)))
+    if any(audio_latents is not None for _, _, audio_latents, _, _ in loaded):
+        _require_path(getattr(args, "audio_vae", None), "audio_vae")
+    shared = H3SharedModels(device=device)
+    for source, video_latents, audio_latents, frame_count, metadata in loaded:
+        logger.info("Decoding MiniMax-H3 latents from %s", source)
+        item_args = copy.deepcopy(args)
+        item_args.frame_count = frame_count
+        seed = metadata.get("seeds", "0")
+        suffix = ".png" if frame_count == 1 else ".mp4"
+        output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}{suffix}"
+        _decode_and_save(item_args, video_latents, audio_latents, output_path, device, shared)
+
+
+def setup_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--task",
+        choices=("t2va", "fl2va", "ref2va"),
+        default=None,
+        help="generation task; required except with --latent_path",
+    )
+    parser.add_argument(
+        "--dit",
+        default=None,
+        help="MiniMax-H3 transformer safetensors path or directory (BF16 or ConvRot INT8, each full or pruned; "
+        "pre-quantized and pruned checkpoints are detected automatically). Required except with --latent_path",
+    )
+    parser.add_argument(
+        "--convrot_int8",
+        action="store_true",
+        help="quantize BF16 DiT base weights to ConvRot INT8 at load time (requires triton for the fused kernels; "
+        "falls back to slower dequantized bf16 matmul without it). ComfyUI pre-quantized ConvRot INT8 checkpoints "
+        "are detected automatically and do not need this flag. With a BF16 base, LoRA weights are merged before "
+        "quantization; with a pre-quantized base, LoRAs are attached as runtime branches instead.",
+    )
+    parser.add_argument(
+        "--prune_adaln",
+        action="store_true",
+        help="prune the AdaLN projections of a full BF16 DiT at load time (mean-centered rank-8 basis, time "
+        "embedder retained). Published pruned checkpoints do not need this flag; pre-quantized ConvRot INT8 "
+        "checkpoints are rejected. Combines with --convrot_int8.",
+    )
+    parser.add_argument("--video_vae", default=None, help="MiniMax-H3 video VAE safetensors path or directory")
+    parser.add_argument(
+        "--audio_vae",
+        default=None,
+        help="MiniMax-H3 audio VAE safetensors path or directory; required except for --latent_path files without audio",
+    )
+    parser.add_argument(
+        "--text_encoder", default=None, help="MiniMax-H3 Qwen3-VL safetensors path (BF16, ConvRot INT8 or NVFP4, auto-detected)"
+    )
+    parser.add_argument(
+        "--nvfp4_scaled_mm",
+        action="store_true",
+        help="use W4A4 scaled_mm for an NVFP4 text encoder (requires PyTorch 2.10+ and Blackwell; default is weight-only dequantization)",
+    )
+    parser.add_argument(
+        "--text_encoder_blocks_to_swap",
+        type=int,
+        default=0,
+        help="number of the 50 Qwen3-VL decoder layers to stream from CPU instead of keeping them on the GPU"
+        " (0 = disabled, 50 = minimum VRAM; requires CUDA)",
+    )
+    parser.add_argument(
+        "--text_encoder_attn_mode",
+        choices=("sdpa", "flash_attention_2", "eager"),
+        default=None,
+        help="attention implementation for the text encoder (default: transformers default, sdpa)."
+        " Use flash_attention_2 for long presentations: sdpa falls back to the O(L^2) math kernel and can OOM",
+    )
+    parser.add_argument("--text_cache", default=None, help="optional precomputed mmh3 text cache (single generation only)")
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help='the literal string "\\n" becomes a newline, for the multi-line official prompt format',
+    )
+    parser.add_argument("--first_frame", default=None)
+    parser.add_argument("--last_frame", default=None)
+    parser.add_argument("--reference_jsonl", default=None)
+    parser.add_argument("--reference_index", type=int, default=0)
+    parser.add_argument(
+        "--ref",
+        action="append",
+        default=None,
+        metavar="PATH[;type=image|video|audio][;audio=AUDIO_PATH]",
+        help="Ref2VA inline reference, repeatable; occurrence order is the reference order and the caption comes from"
+        " --prompt, so no JSONL (and no dummy target video_path) is needed. The type is inferred from the file"
+        " extension unless ;type= overrides it; ;audio= attaches an external audio track to a video reference."
+        " Validation matches the JSONL references schema exactly. Mutually exclusive with --reference_jsonl.",
+    )
+    parser.add_argument("--width", type=int, default=768)
+    parser.add_argument("--height", type=int, default=1344)
+    parser.add_argument(
+        "--frame_count",
+        type=int,
+        default=124,
+        help="pixel frame count, 17*n+5 for video; 1 enables the experimental one-frame (image) mode, which writes"
+        " a PNG and skips audio decoding",
+    )
+    parser.add_argument(
+        "--one_frame",
+        default=None,
+        metavar="target_index=N,control_index=A;B",
+        help="one-frame mode time options (requires --frame_count 1): 0-based 24 fps pixel-frame indices on the"
+        " nominal timeline, converted to RoPE times relative to the target-block cursor. target_index (default 0)"
+        " places the generated frame; control_index places the FL2VA condition frames in --first_frame/--last_frame"
+        " order and is required when conditions are present. The base model reads these as trainable time inputs;"
+        " see docs/minimax_h3_1f.md",
+    )
+    parser.add_argument("--allow_experimental_duration", action="store_true")
+    parser.add_argument("--steps", type=int, default=30)
+    parser.add_argument("--seed", type=int, default=None, help="random when omitted")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="output file for a single generation (.png for one-frame, .mp4/.mkv/.mov otherwise);"
+        " output directory with --interactive, --from_file, and --latent_path (auto-named files)",
+    )
+    parser.add_argument(
+        "--from_file",
+        default=None,
+        help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--i/--ei/--ref/--of/--o"
+        " options) from a file and run them in phases, loading each model family once. Sampled latents are saved"
+        " to the --output directory before decoding so a crash loses nothing; the files are removed after their"
+        " output is written. See docs/minimax_h3.md",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="interactive mode: read prompt lines from the console with all models kept resident."
+        " VRAM-limited setups should pass --text_encoder_blocks_to_swap 50 and a generous --blocks_to_swap",
+    )
+    parser.add_argument(
+        "--latent_path",
+        nargs="*",
+        default=None,
+        help="decode-only mode: decode intermediate latents safetensors saved by --from_file into the --output"
+        " directory (only the VAEs are loaded)",
+    )
+    parser.add_argument(
+        "--bell",
+        action="store_true",
+        help="ring a terminal bell when done (after each generation in interactive mode)",
+    )
+    parser.add_argument("--device", default=None)
+    parser.add_argument(
+        "--attn_mode",
+        choices=("torch", "sdpa", "flash", "flash3", "sageattn", "xformers"),
+        default="torch",
+    )
+    parser.add_argument("--split_attn", action="store_true")
+    parser.add_argument("--blocks_to_swap", type=int, default=0)
+    parser.add_argument("--use_pinned_memory_for_block_swap", action="store_true")
+    setup_parser_compile(parser)  # torch.compile for the DiT, same flags as training
+    parser.add_argument("--h3_shift_video", type=float, default=12.0)
+    parser.add_argument("--h3_shift_audio", type=float, default=3.0)
+    parser.add_argument("--h3_visual_cond_clean", type=float, default=0.999)
+    parser.add_argument("--h3_audio_cond_clean", type=float, default=1.0)
+    parser.add_argument("--lora_weight", nargs="*", default=None)
+    parser.add_argument("--lora_multiplier", type=float, nargs="*", default=None)
+    parser.add_argument(
+        "--lora_runtime_attach",
+        action="store_true",
+        help="attach LoRAs as runtime additive branches instead of merging them into the base weights"
+        " (always the case for pre-quantized INT8 bases). Merging rounds the fused weights to the base"
+        " storage grid, which silently erases LoRAs whose deltas are below the BF16 mantissa step --"
+        " small-magnitude adapters such as teacher-matching LoRAs. Slightly slower, exact.",
+    )
+    parser.add_argument("--include_patterns", nargs="*", default=None)
+    parser.add_argument("--exclude_patterns", nargs="*", default=None)
+    parser.add_argument("--disable_numpy_memmap", action="store_true")
+    parser.add_argument(
+        "--trajectory_dir",
+        default=None,
+        help="diagnostic: decode each denoising step's clean estimate (x0_hat = x_t + sigma*v) to a"
+        " video-only mp4 in this directory and write the per-step sigma schedule to sigma_schedule.csv,"
+        " showing at which step the video content settles. The per-step latents are held on the CPU and"
+        " decoded after the normal output, so peak VRAM is unchanged; decode time grows with the step count",
+    )
+    parser.add_argument(
+        "--trajectory_stride",
+        type=int,
+        default=1,
+        help="decode every N-th step into --trajectory_dir (the last step is always included)",
+    )
+    return parser
 
 
 def main() -> None:
-    run_generation(setup_parser().parse_args())
+    args = setup_parser().parse_args()
+    args.output_name = None
+    if args.prompt:
+        args.prompt = args.prompt.replace("\\n", "\n")
+    validate_session_args(args)
+    device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    if args.latent_path:
+        process_latent_decode(args, device)
+    elif args.from_file:
+        process_from_file(args, device)
+    elif args.interactive:
+        process_interactive(args, device)
+    else:
+        run_generation(args, device)
+    if args.bell and not args.interactive:
+        print("\a")
 
 
 if __name__ == "__main__":

--- a/src/musubi_tuner/utils/model_utils.py
+++ b/src/musubi_tuner/utils/model_utils.py
@@ -259,6 +259,53 @@ def disable_linear_from_compile(module: torch.nn.Module):
             sub_module.forward = sub_module._eager_forward  # override forward to disable compile
 
 
+def setup_parser_compile(parser: argparse.ArgumentParser) -> None:
+    """Add the torch.compile argument set consumed by compile_transformer below.
+
+    Same arguments as hv_generate_video.setup_parser_compile and the compile slice of
+    training's parser_common, placed here so scripts can add them without importing an
+    architecture module or the training-only dynamo/tf32 arguments.
+    """
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        help="Enable torch.compile (requires Triton) / torch.compileを有効にする（Tritonが必要）",
+    )
+    parser.add_argument(
+        "--compile_backend",
+        type=str,
+        default="inductor",
+        help="torch.compile backend (default: inductor) / torch.compileのバックエンド（デフォルト: inductor）",
+    )
+    parser.add_argument(
+        "--compile_mode",
+        type=str,
+        default="default",
+        choices=["default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"],
+        help="torch.compile mode (default: default) / torch.compileのモード（デフォルト: default）",
+    )
+    parser.add_argument(
+        "--compile_dynamic",
+        type=str,
+        default=None,
+        choices=["true", "false", "auto"],
+        help="Dynamic shapes mode for torch.compile (default: None, same as auto)"
+        " / torch.compileの動的形状モード（デフォルト: None、autoと同じ動作）",
+    )
+    parser.add_argument(
+        "--compile_fullgraph",
+        action="store_true",
+        help="Enable fullgraph mode in torch.compile / torch.compileでフルグラフモードを有効にする",
+    )
+    parser.add_argument(
+        "--compile_cache_size_limit",
+        type=int,
+        default=None,
+        help="Set torch._dynamo.config.cache_size_limit (default: PyTorch default, typically 8-32)"
+        " / torch._dynamo.config.cache_size_limitを設定（デフォルト: PyTorchのデフォルト、通常8-32）",
+    )
+
+
 def compile_transformer(
     args: argparse.Namespace,
     transformer: torch.nn.Module,

--- a/tests/test_minimax_h3_generation_modes.py
+++ b/tests/test_minimax_h3_generation_modes.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+import musubi_tuner.minimax_h3_generate_video as generate
+from musubi_tuner.minimax_h3_generate_video import (
+    apply_overrides,
+    parse_prompt_line,
+    validate_prompt_args,
+    validate_session_args,
+)
+
+
+def _session_args(tmp_path, *, task="t2va", **overrides):
+    paths = {}
+    for name in ("dit", "video_vae", "audio_vae", "text_encoder"):
+        path = tmp_path / f"{name}.safetensors"
+        path.touch()
+        paths[name] = str(path)
+    values = {
+        **paths,
+        "task": task,
+        "prompt": "a test prompt",
+        "text_cache": None,
+        "first_frame": None,
+        "last_frame": None,
+        "reference_jsonl": None,
+        "reference_index": 0,
+        "ref": None,
+        "one_frame": None,
+        "width": 64,
+        "height": 64,
+        "frame_count": 124,
+        "allow_experimental_duration": False,
+        "steps": 2,
+        "seed": 1,
+        "output": str(tmp_path / "output.mp4"),
+        "output_name": None,
+        "blocks_to_swap": 0,
+        "h3_shift_video": 12.0,
+        "h3_shift_audio": 3.0,
+        "h3_visual_cond_clean": 0.999,
+        "h3_audio_cond_clean": 1.0,
+        "lora_weight": None,
+        "lora_multiplier": None,
+        "convrot_int8": False,
+        "prune_adaln": False,
+        "trajectory_dir": None,
+        "trajectory_stride": 1,
+        "interactive": False,
+        "from_file": None,
+        "latent_path": None,
+        "bell": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_parse_prompt_line_maps_inline_options_and_collects_refs():
+    overrides = parse_prompt_line(
+        "a cat sings --w 768 --h 1344 --f 1 --d 42 --s 20 --fs 10.5 --fsa 2.5"
+        " --i first.png --ei last.png --of target_index=24,control_index=0;12 --o cat.png"
+    )
+    assert overrides == {
+        "prompt": "a cat sings",
+        "width": 768,
+        "height": 1344,
+        "frame_count": 1,
+        "seed": 42,
+        "steps": 20,
+        "h3_shift_video": 10.5,
+        "h3_shift_audio": 2.5,
+        "first_frame": "first.png",
+        "last_frame": "last.png",
+        "one_frame": "target_index=24,control_index=0;12",
+        "output_name": "cat.png",
+    }
+
+    refs = parse_prompt_line("a duet --ref face.png --ref voice.mp4;audio=voice.wav")
+    assert refs == {"prompt": "a duet", "ref": ["face.png", "voice.mp4;audio=voice.wav"]}
+
+    # a line starting with "--" carries only options, so the CLI --prompt stays in effect
+    # (and an invalid value still reaches validation instead of becoming the prompt text)
+    assert parse_prompt_line("--w 0") == {"width": 0}
+    assert parse_prompt_line("--d 43 --s 20") == {"seed": 43, "steps": 20}
+
+    # the literal "\n" becomes a newline, so the multi-line official prompt format fits on one line
+    assert parse_prompt_line("line one\\nline two --d 1") == {"prompt": "line one\nline two", "seed": 1}
+
+    with pytest.raises(ValueError, match="unknown option --x"):
+        parse_prompt_line("a cat --x 1")
+
+
+def test_apply_overrides_keeps_the_base_args_untouched_and_resets_output_name():
+    base = SimpleNamespace(prompt="base", width=64, ref=["session.png"], output_name="stale.png")
+    prompt_args = apply_overrides(base, {"prompt": "override", "ref": ["line.png"]})
+    assert prompt_args.prompt == "override"
+    assert prompt_args.ref == ["line.png"]
+    assert prompt_args.output_name is None
+    assert prompt_args.width == 64
+    assert base.prompt == "base" and base.ref == ["session.png"] and base.output_name == "stale.png"
+
+
+def test_session_validation_enforces_mode_exclusivity_and_multi_prompt_restrictions(tmp_path):
+    prompts = tmp_path / "prompts.txt"
+    prompts.touch()
+    latents = tmp_path / "latents.safetensors"
+    latents.touch()
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        validate_session_args(_session_args(tmp_path, interactive=True, from_file=str(prompts)))
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        validate_session_args(_session_args(tmp_path, from_file=str(prompts), latent_path=[str(latents)]))
+
+    cache = tmp_path / "text.safetensors"
+    cache.touch()
+    with pytest.raises(ValueError, match="do not accept --text_cache"):
+        validate_session_args(_session_args(tmp_path, interactive=True, text_cache=str(cache)))
+    with pytest.raises(ValueError, match="do not accept --trajectory_dir"):
+        validate_session_args(_session_args(tmp_path, from_file=str(prompts), trajectory_dir=str(tmp_path)))
+    with pytest.raises(ValueError, match="requires --text_encoder"):
+        validate_session_args(_session_args(tmp_path, interactive=True, text_encoder=None))
+    validate_session_args(_session_args(tmp_path, interactive=True))
+    validate_session_args(_session_args(tmp_path, from_file=str(prompts)))
+
+    # decode-only mode needs just the latents and the video VAE
+    validate_session_args(_session_args(tmp_path, latent_path=[str(latents)], task=None, dit=None, text_encoder=None))
+    with pytest.raises(ValueError, match="requires --video_vae"):
+        validate_session_args(_session_args(tmp_path, latent_path=[str(latents)], video_vae=None))
+
+    with pytest.raises(ValueError, match="requires --task"):
+        validate_session_args(_session_args(tmp_path, task=None))
+
+
+def test_prompt_validation_checks_output_name_suffixes_in_directory_modes(tmp_path):
+    args = _session_args(tmp_path, output=str(tmp_path))
+    validate_prompt_args(args, directory_output=True)
+
+    args.output_name = "clip.mp4"
+    validate_prompt_args(args, directory_output=True)
+    args.output_name = "clip.txt"
+    with pytest.raises(ValueError, match="must use .mp4"):
+        validate_prompt_args(args, directory_output=True)
+
+    image_args = _session_args(tmp_path, frame_count=1, output=str(tmp_path))
+    image_args.output_name = "image.png"
+    validate_prompt_args(image_args, directory_output=True)
+    image_args.output_name = "image.mp4"
+    with pytest.raises(ValueError, match="must use .png"):
+        validate_prompt_args(image_args, directory_output=True)
+
+
+def test_latent_file_roundtrip_preserves_tensors_and_rejects_missing_audio(tmp_path):
+    args = _session_args(tmp_path, frame_count=39, allow_experimental_duration=True)
+    video = torch.randn(1, 24, 3, 4, 4)
+    audio = torch.randn(1, 32, 2, 65)
+
+    path = generate._save_latent_file(tmp_path / "video_latent.safetensors", video, audio, args, 7)
+    loaded_video, loaded_audio, frame_count, metadata = generate._load_latent_file(path)
+    assert torch.equal(loaded_video, video)
+    assert torch.equal(loaded_audio, audio)
+    assert frame_count == 39
+    assert metadata["seeds"] == "7"
+    assert metadata["prompt"] == "a test prompt"
+
+    image_args = _session_args(tmp_path, frame_count=1)
+    image_path = generate._save_latent_file(tmp_path / "image_latent.safetensors", video, None, image_args, 8)
+    _, loaded_audio, frame_count, _ = generate._load_latent_file(image_path)
+    assert loaded_audio is None
+    assert frame_count == 1
+
+    broken = generate._save_latent_file(tmp_path / "broken_latent.safetensors", video, None, args, 9)
+    with pytest.raises(ValueError, match="missing latent_audio"):
+        generate._load_latent_file(broken)
+
+
+class _StubTransformer:
+    offloader = None
+    blocks: list = []
+
+    def to(self, device):
+        return self
+
+    def prepare_block_swap_before_forward(self):
+        return None
+
+    def eval(self):
+        return self
+
+    def requires_grad_(self, value):
+        return self
+
+    def __call__(self, **kwargs):
+        return SimpleNamespace(
+            video=torch.zeros_like(kwargs["video_latents"]),
+            audio=torch.zeros_like(kwargs["audio_latents"]),
+        )
+
+
+class _StubVAE:
+    def __init__(self, decoded):
+        self._decoded = decoded
+
+    def to(self, device):
+        return self
+
+    def decode(self, latents):
+        return self._decoded()
+
+
+def _stub_generation_models(monkeypatch, counters):
+    monkeypatch.setattr(generate, "resolve_safetensors_files", lambda path: [path])
+    monkeypatch.setattr(generate, "has_comfy_quant_tensors", lambda files, **kwargs: False)
+    monkeypatch.setattr(
+        generate,
+        "_encode_text",
+        lambda *unused: (
+            counters.__setitem__("text", counters["text"] + 1),
+            (torch.zeros(1, 3, 5120, dtype=torch.bfloat16), torch.ones(3, dtype=torch.int64)),
+        )[1],
+    )
+    monkeypatch.setattr(
+        generate,
+        "load_h3_transformer",
+        lambda *unused, **kwargs: counters.__setitem__("transformer", counters["transformer"] + 1) or _StubTransformer(),
+    )
+    monkeypatch.setattr(
+        generate,
+        "load_video_vae",
+        lambda *unused, **kwargs: (
+            counters.__setitem__("video_vae", counters["video_vae"] + 1) or _StubVAE(lambda: torch.zeros(1, 3, 5, 4, 4))
+        ),
+    )
+    monkeypatch.setattr(
+        generate,
+        "load_audio_vae",
+        lambda *unused, **kwargs: (
+            counters.__setitem__("audio_vae", counters["audio_vae"] + 1) or _StubVAE(lambda: torch.zeros(1, 2, 6667))
+        ),
+    )
+
+
+def _batch_args(tmp_path, prompt_lines):
+    prompts = tmp_path / "prompts.txt"
+    prompts.write_text("\n".join(prompt_lines), encoding="utf-8")
+    output_dir = tmp_path / "outputs"
+    return _session_args(
+        tmp_path,
+        frame_count=5,
+        allow_experimental_duration=True,
+        output=str(output_dir),
+        from_file=str(prompts),
+        device="cpu",
+        attn_mode="torch",
+        split_attn=False,
+        use_pinned_memory_for_block_swap=False,
+        include_patterns=None,
+        exclude_patterns=None,
+        disable_numpy_memmap=False,
+        seed=3,
+    )
+
+
+def test_from_file_batch_loads_each_model_family_once_and_removes_latents_on_success(tmp_path, monkeypatch):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+    written = []
+    monkeypatch.setattr(generate, "write_joint_av", lambda decoded, output: written.append(Path(output)))
+
+    args = _batch_args(tmp_path, ["# comment", "", "a cat sings --d 11", "a dog barks --d 22 --s 3"])
+    generate.process_from_file(args, torch.device("cpu"))
+
+    assert counters == {"text": 2, "transformer": 1, "video_vae": 1, "audio_vae": 1}
+    assert len(written) == 2
+    assert sorted(path.name.split("_")[-1] for path in written) == ["11.mp4", "22.mp4"]
+    # intermediate latents were written during sampling and removed after their decode
+    assert list((tmp_path / "outputs").glob("*_latent.safetensors")) == []
+
+
+def test_from_file_batch_keeps_the_latents_of_a_failed_decode(tmp_path, monkeypatch):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+
+    def failing_mux(decoded, output):
+        raise RuntimeError("mux exploded")
+
+    monkeypatch.setattr(generate, "write_joint_av", failing_mux)
+
+    args = _batch_args(tmp_path, ["a cat sings --d 11"])
+    generate.process_from_file(args, torch.device("cpu"))
+
+    kept = list((tmp_path / "outputs").glob("*_latent.safetensors"))
+    assert len(kept) == 1
+    _, audio_latents, frame_count, metadata = generate._load_latent_file(kept[0])
+    assert audio_latents is not None
+    assert frame_count == 5
+    assert metadata["seeds"] == "11"
+
+
+def test_compile_wraps_the_dit_once_with_training_parity_exclusions(tmp_path, monkeypatch):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+    monkeypatch.setattr(generate, "write_joint_av", lambda decoded, output: None)
+    compiled = []
+    monkeypatch.setattr(
+        generate,
+        "compile_transformer",
+        lambda args, transformer, target_blocks, disable_linear: compiled.append(disable_linear) or transformer,
+    )
+
+    args = _session_args(
+        tmp_path,
+        frame_count=5,
+        allow_experimental_duration=True,
+        output=str(tmp_path / "result.mp4"),
+        device="cpu",
+        attn_mode="torch",
+        split_attn=False,
+        use_pinned_memory_for_block_swap=False,
+        include_patterns=None,
+        exclude_patterns=None,
+        disable_numpy_memmap=False,
+    )
+    args.compile = True
+    generate.run_generation(args, torch.device("cpu"))
+
+    # blocks_to_swap=0 and a stub without is_convrot_int8 keep the Linears compiled
+    assert compiled == [False]
+
+
+def test_latent_decode_mode_loads_only_the_vaes(tmp_path, monkeypatch):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+    written = []
+    monkeypatch.setattr(generate, "write_joint_av", lambda decoded, output: written.append(Path(output)))
+    monkeypatch.setattr(generate, "write_image", lambda frame, output: written.append(Path(output)))
+
+    video_args = _session_args(tmp_path, frame_count=5, allow_experimental_duration=True)
+    video_file = generate._save_latent_file(
+        tmp_path / "video_latent.safetensors", torch.randn(1, 24, 2, 4, 4), torch.randn(1, 32, 2, 9), video_args, 5
+    )
+    image_args = _session_args(tmp_path, frame_count=1)
+    image_file = generate._save_latent_file(tmp_path / "image_latent.safetensors", torch.randn(1, 24, 1, 4, 4), None, image_args, 6)
+
+    args = _session_args(
+        tmp_path,
+        output=str(tmp_path / "decoded"),
+        latent_path=[str(video_file), str(image_file)],
+        disable_numpy_memmap=False,
+    )
+    generate.process_latent_decode(args, torch.device("cpu"))
+
+    assert counters["text"] == 0 and counters["transformer"] == 0
+    assert counters["video_vae"] == 1 and counters["audio_vae"] == 1
+    assert [path.suffix for path in written] == [".mp4", ".png"]
+    assert all(path.parent == tmp_path / "decoded" for path in written)

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -642,7 +642,7 @@ def test_generation_orchestrates_t2va_sampling_decode_and_mux_without_co_residen
     assert next(event for event in events if event[0] == "load_video_vae")[2] is torch.float16
     assert captured["decoded"].video.shape == (5, 4, 4, 3)
     assert captured["decoded"].audio.shape == (2, 6667)
-    assert captured["output"] == args.output
+    assert captured["output"] == Path(args.output)
 
 
 def test_generation_trajectory_dump_writes_sigma_schedule_and_per_step_videos(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Repeated MiniMax-H3 generation paid the full model-load overhead (and ConvRot INT8 requantization) on every CLI invocation. This PR restructures `minimax_h3_generate_video.py` into stage functions around an optional `H3SharedModels` container — no container reproduces the previous single-shot load-use-free behavior exactly — and adds shared-model generation modes.

### `--from_file` (phased batch)

Prompt lines run in four phases, loading each model family exactly once: all condition VAE encodes → all text encodes → all samplings → all decodes. Peak VRAM matches single-shot generation, so existing `--blocks_to_swap` / `--text_encoder_blocks_to_swap` settings apply unchanged. Each sampled result is written to `<output>/<time>_<index>_<seed>_latent.safetensors` **before** any decoding; the file is removed once its output is written and kept on decode failure, so a crash never loses finished sampling work. A failing line is logged and skipped without aborting the batch.

### `--latent_path` (decode-only)

Decodes the intermediate latents files with only the VAEs loaded (`--audio_vae` optional when every file is a one-frame latent).

### `--interactive`

Console loop with all models session-resident: the text encoder keeps its streaming placement (`--text_encoder_blocks_to_swap 50` on VRAM-limited setups), the DiT stays resident with its block-swap config, and the VAEs idle on the CPU between prompts. Text conditioning is cached (LRU, keyed by presentation fingerprint incl. media file identities), so re-running a prompt with a new seed skips the text encoder entirely.

### Prompt-line syntax

`prompt text --w 768 --h 1344 --f 1 --d 42 --s 30 --fs/--fsa/--i/--ei/--ref/--of/--o`, matching the other architectures' conventions (`--ei` = end image). Unspecified options inherit the CLI values; a line starting with `--` carries only options and keeps the CLI `--prompt` in effect (`--d 43` alone re-runs the session prompt with a new seed). The literal `\n` in prompt text (lines and `--prompt`) becomes a newline for the multi-line official prompt format.

### Other changes

- `--compile` for the DiT, with the same flags and Linear exclusions (block swap / ConvRot INT8) as training. The compile argument set is added as `model_utils.setup_parser_compile` next to its consumer `compile_transformer`; consolidating the hv/wan/parser_common copies is a future cleanup.
- **Behavior change:** `--seed` now draws a random seed when omitted (logged and embedded in auto-named outputs). `--output` doubles as a directory in the new modes.
- Validation splits into `validate_session_args` + `validate_prompt_args`; `validate_generation_args` remains as the combined wrapper.
- `--text_cache` and `--trajectory_dir` are rejected in the multi-prompt modes.

## Testing

- 496 tests pass (`tests/test_minimax_h3_generation_modes.py` is new: line parser, mode validation, latent roundtrip, batch phase sharing and latent cleanup, decode-failure latent retention, decode-only mode, compile wiring).
- Smoke-tested on hardware (3090-class, INT8 DiT + INT8 TE): single-shot regression at fixed seed, batch phases with per-line overrides and multi-resolution, crash recovery via `--latent_path` after killing the batch mid-decode, interactive session within 24 GB VRAM with text-conditioning cache hits, `\n` prompts, and `--compile` (recompile behavior across resolutions confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)