### PR TITLE
Add experimental MiniMax-H3 one-frame (image) LoRA training (t2va)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -50,7 +50,7 @@ The transformer, video VAE, packed-sequence logic, text presentation, and dual s
 
 ## Dataset Configuration
 
-T2VA and FL2VA accept ordinary video directories. FL2VA derives its first and last conditions from each selected target crop.
+T2VA and FL2VA accept ordinary video directories. FL2VA derives its first and last conditions from each selected target crop. Image datasets are supported by the experimental one-frame (image LoRA) training mode — see `docs/minimax_h3_1f.md`.
 
 ```toml
 [general]

--- a/docs/minimax_h3_1f.md
+++ b/docs/minimax_h3_1f.md
@@ -135,6 +135,7 @@ accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 minimax
   ... # remaining flags as in docs/minimax_h3.md
 ```
 
+- **The guidance loss is effectively mandatory for one-frame training.** Without it, de-distillation drift surfaces within ~50 steps as structural degradation — wobbly lines and broken proportions, like low-CFG output of an undistilled model — rather than the washout seen in video training (image steps average over far fewer target rows and repeat a small dataset quickly). `--h3_guidance_loss_scale 4.0 --h3_guidance_loss_sigma_min 0.15` with an uncond cache (see `docs/minimax_h3.md`) restored clean structure in testing; a short LR warmup (e.g. 50 steps) also helps the early phase.
 - `--video_only` is recommended for image-only runs: the silence placeholders are excluded from audio supervision by presence gating either way, so the audio loss would always be 0.
 - Steps are much cheaper than video steps (a 1 MP image is a few hundred target rows); with block swap active, per-step time is dominated by weight streaming rather than compute.
 - Mixed image+video training in one run is expected to work (`--one_frame` only adds acceptance of one-frame batches; video batches are unaffected) but is untested — treat it as experimental.

--- a/docs/minimax_h3_1f.md
+++ b/docs/minimax_h3_1f.md
@@ -14,7 +14,7 @@
 - Standalone `audio` references are rejected in one-frame mode (their window is defined by the target duration, which a single frame does not have); video references keep their embedded audio.
 - The released 5-15 s duration gate does not apply; `--allow_experimental_duration` is not needed.
 
-Training on one-frame targets (image LoRA) is not implemented yet; this mode currently serves inference and dataset-synthesis experiments.
+Training on one-frame targets is available for plain image LoRA (T2VA); see [One-frame training](#one-frame-training-t2va-image-lora) below. FL2VA/Ref2VA one-frame training (editing LoRA with condition images or references) is not implemented yet.
 
 ## Time semantics: `--one_frame`
 
@@ -75,3 +75,75 @@ Ref2VA one-frame combines with inline `--ref` references (see `docs/minimax_h3.m
 With a full-reference-style caption, a single image reference yields novel views of the referenced subject (front/side/back selectable by text) with the environment plausibly extended — useful for synthesizing character-LoRA training data. Note that for dense 2D illustrations the reference is re-drawn rather than preserved pixel-exactly, and unseen-angle environments are plausible inventions, not geometry.
 
 Audio-bearing video references are accepted and keep their own duration; combining them with a one-frame target is untested territory.
+
+## One-frame training (T2VA image LoRA)
+
+> [!WARNING]
+> Experimental, like the rest of this mode. The single-token target is outside the released training distribution; quality expectations come from the one-frame generation results above, and image-trained LoRAs applied to video generation are unvalidated territory.
+
+`--one_frame` on the two cache scripts and the trainer enables plain image LoRA training: each image becomes a single-token video target with a silence audio placeholder. The FL2VA base checkpoint with `--task t2va` is the normal choice, mirroring plain one-frame generation.
+
+### Dataset configuration
+
+Image datasets use the standard image keys. `fp_1f_target_index` (optional, default 0) places the target on the rotary time axis, in the same 0-based 24 fps pixel-frame indices as generation's `--one_frame target_index=N`; for plain image LoRA the default is fine. Control images, `fp_1f_clean_indices`, and `multiple_target` are not supported yet.
+
+```toml
+[general]
+resolution = [1024, 1024]
+batch_size = 1
+enable_bucket = true
+bucket_no_upscale = false
+
+[[datasets]]
+image_directory = "/data/h3/images"
+cache_directory = "/data/h3/cache-images"
+caption_extension = ".txt"
+```
+
+`image_jsonl_file` works as usual (`image_path` + `caption` per line). Buckets snap to the 32-pixel H3 grid. Image and video datasets may share one TOML but must not share a `cache_directory`.
+
+Captions should follow the official T2VA caption format where possible. Because every one-frame item carries silent audio rows (excluded from supervision), it is recommended to state the absence of sound explicitly in the caption (for example a `sound:`-style field describing it as a silent still) so the text stays consistent with what the model sees — this likely also helps the LoRA transfer to normal video generation, where audio is live.
+
+### Caching
+
+```bash
+python minimax_h3_cache_latents.py \
+  --dataset_config /data/h3/images.toml \
+  --task t2va --one_frame \
+  --video_vae /models/minimax_h3_video_vae_fp16.safetensors \
+  --audio_vae /models/minimax_h3_audio_vae_fp32.safetensors \
+  --cache_seed 42 --skip_existing
+
+python minimax_h3_cache_text_encoder_outputs.py \
+  --dataset_config /data/h3/images.toml \
+  --task t2va --one_frame \
+  --text_encoder /models/qwen3vl_32b_minimax_h3_bf16.safetensors \
+  --skip_existing
+```
+
+Each latent cache holds the single-token target (`[24,1,H/16,W/16]`, seeded posterior like video targets), the constant 2-frame silence audio latent (`audio_present=0`, encoded once per run), and the target index as a tensor entry. Text caches are plain T2VA presentations of the caption — time indices never enter the text, so changing `fp_1f_target_index` re-caches latents (cheap) but not text. The duration gate does not apply; `--allow_experimental_duration` is not needed.
+
+### Training
+
+```bash
+accelerate launch --num_cpu_threads_per_process 1 --mixed_precision bf16 minimax_h3_train_network.py \
+  --dataset_config /data/h3/images.toml \
+  --task t2va --one_frame \
+  --dit /models/minimax_h3_fl2va_bf16.safetensors \
+  --network_module networks.lora_minimax_h3 --network_dim 16 \
+  --video_only \
+  ... # remaining flags as in docs/minimax_h3.md
+```
+
+- `--video_only` is recommended for image-only runs: the silence placeholders are excluded from audio supervision by presence gating either way, so the audio loss would always be 0.
+- Steps are much cheaper than video steps (a 1 MP image is a few hundred target rows); with block swap active, per-step time is dominated by weight streaming rather than compute.
+- Mixed image+video training in one run is expected to work (`--one_frame` only adds acceptance of one-frame batches; video batches are unaffected) but is untested — treat it as experimental.
+- `--h3_teacher_matching` is not supported with `--one_frame` yet.
+
+Training-time samples support one-frame outputs: `--f 1` in a sample prompt line switches that sample to a PNG (audio is never decoded), and `--of target_index=N` optionally places it on the time axis:
+
+```text
+A watercolor lighthouse at dusk. --w 1024 --h 1024 --f 1 --s 30 --d 42
+```
+
+The LoRA metadata records `ss_minimax_h3_one_frame` for provenance. The resulting LoRA loads into generation as usual (one-frame or video).

--- a/src/musubi_tuner/dataset/cache_io.py
+++ b/src/musubi_tuner/dataset/cache_io.py
@@ -46,9 +46,20 @@ logger = logging.getLogger(__name__)
 #   policy (loss weights, video-only training) is decided at training time.
 AUDIO_PRESENT_KEY = "audio_present_float32"
 
+# - ONE_FRAME_TARGET_INDEX_KEY holds a scalar int64 tensor with the one-frame target's 24 fps
+#   pixel-frame index. It travels as a tensor (not metadata) because the bucket collator only
+#   loads tensors; the trainer converts it to a RoPE time override at layout-build time.
+ONE_FRAME_TARGET_INDEX_KEY = "one_frame_target_index_int64"
+
 
 def append_audio_present_entry(sd: dict[str, torch.Tensor], audio_present: bool):
     sd[AUDIO_PRESENT_KEY] = torch.tensor(1.0 if audio_present else 0.0, dtype=torch.float32)
+
+
+def append_one_frame_target_index_entry(sd: dict[str, torch.Tensor], target_index: int):
+    if target_index < 0:
+        raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
+    sd[ONE_FRAME_TARGET_INDEX_KEY] = torch.tensor(target_index, dtype=torch.int64)
 
 
 def validate_audio_present_entry(sd: dict[str, torch.Tensor]) -> float:
@@ -548,6 +559,11 @@ def save_latent_cache_minimax_h3(
         if not isinstance(tensor, torch.Tensor):
             raise ValueError(f"MiniMax-H3 cache value must be a tensor: {key}")
         if key == AUDIO_PRESENT_KEY:
+            normalized[key] = tensor.detach().cpu().contiguous()
+            continue
+        if key == ONE_FRAME_TARGET_INDEX_KEY:
+            if tensor.shape != torch.Size([]) or tensor.dtype != torch.int64 or tensor.item() < 0:
+                raise ValueError(f"MiniMax-H3 {ONE_FRAME_TARGET_INDEX_KEY} must be a nonnegative scalar int64 tensor")
             normalized[key] = tensor.detach().cpu().contiguous()
             continue
 

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -323,6 +323,19 @@ class ImageDataset(BaseDataset):
         self.no_resize_control = no_resize_control
         self.control_resolution = control_resolution
 
+        if self.architecture == ARCHITECTURE_MINIMAX_H3:
+            # one-frame (image) training v1: plain t2va targets only. Control images (fl2va
+            # conditions) and their fp_1f_clean_indices arrive with the K=1/2 editing phase.
+            if control_directory is not None or multiple_target:
+                raise ValueError("MiniMax-H3 image datasets do not support control images or multiple targets yet")
+            if fp_1f_clean_indices is not None:
+                raise ValueError(
+                    "MiniMax-H3 image datasets do not use fp_1f_clean_indices yet;"
+                    " only fp_1f_target_index (a 24 fps pixel-frame index) is supported"
+                )
+            if fp_1f_target_index is not None and fp_1f_target_index < 0:
+                raise ValueError(f"MiniMax-H3 fp_1f_target_index must be nonnegative, got {fp_1f_target_index}")
+
         control_count_per_image: Optional[int] = 1
         if self.architecture == ARCHITECTURE_FRAMEPACK or self.architecture == ARCHITECTURE_WAN:
             if fp_1f_clean_indices is not None:
@@ -357,6 +370,9 @@ class ImageDataset(BaseDataset):
         self.batch_manager = None
         self.num_train_items = 0
         self.has_control = self.datasource.has_control
+        if self.architecture == ARCHITECTURE_MINIMAX_H3 and self.has_control:
+            # JSONL control_path entries surface only after datasource construction
+            raise ValueError("MiniMax-H3 image datasets do not support control images yet")
 
     def get_metadata(self):
         metadata = super().get_metadata()

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -28,6 +28,39 @@ VIDEO_VAE_SPATIAL_RATIO = 16
 ONE_FRAME_REFERENCE_FRAME_CAP = 15 * 24
 
 
+def parse_one_frame_options(spec: str) -> tuple[int, tuple[int, ...] | None]:
+    """Parses --one_frame "target_index=N,control_index=A;B" into 24 fps pixel-frame indices."""
+
+    def nonnegative_index(value: str, label: str) -> int:
+        try:
+            index = int(value)
+        except ValueError as error:
+            raise ValueError(f"MiniMax-H3 --one_frame {label} must be an integer, got {value!r}") from error
+        if index < 0:
+            raise ValueError(f"MiniMax-H3 --one_frame {label} must be nonnegative, got {index}")
+        return index
+
+    target_index = 0
+    control_indices = None
+    seen = set()
+    for part in spec.split(","):
+        key, separator, value = part.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not separator or not key or not value:
+            raise ValueError(f"MiniMax-H3 --one_frame options must be key=value, got {part!r}")
+        if key not in {"target_index", "control_index"}:
+            raise ValueError(f"MiniMax-H3 --one_frame has unknown option {key!r} (allowed: target_index, control_index)")
+        if key in seen:
+            raise ValueError(f"MiniMax-H3 --one_frame has duplicate option {key!r}")
+        seen.add(key)
+        if key == "target_index":
+            target_index = nonnegative_index(value, "target_index")
+        else:
+            control_indices = tuple(nonnegative_index(item, "control_index") for item in value.split(";"))
+    return target_index, control_indices
+
+
 def dummy_record(prompt: str) -> H3Record:
     return H3Record(
         video_path=Path("."),

--- a/src/musubi_tuner/minimax_h3/sampling.py
+++ b/src/musubi_tuner/minimax_h3/sampling.py
@@ -298,6 +298,12 @@ def write_image(frame: torch.Tensor, output_path: str | Path) -> None:
     Image.fromarray(frame.cpu().numpy()).save(output_path)
 
 
+# Without an explicit rate control, PyAV encodes libx264 at its ~1 Mbps ABR default — far too
+# low for 1 MP/24 fps outputs and enough to masquerade as generation artifacts (mushy lines).
+# CRF keeps quality resolution- and content-independent; 16 is evaluation-grade.
+H3_VIDEO_CRF = 16
+
+
 def write_video_only(video: torch.Tensor, output_path: str | Path, *, fps: int = 24) -> None:
     """Write a silent video-only container; the diagnostic trajectory dumps have no audio track."""
     if video.ndim != 4 or video.shape[-1] != 3 or video.dtype != torch.uint8:
@@ -305,7 +311,7 @@ def write_video_only(video: torch.Tensor, output_path: str | Path, *, fps: int =
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with av.open(str(output_path), mode="w") as container:
-        video_stream = container.add_stream("libx264", rate=fps)
+        video_stream = container.add_stream("libx264", rate=fps, options={"crf": str(H3_VIDEO_CRF)})
         video_stream.width = video.shape[2]
         video_stream.height = video.shape[1]
         video_stream.pix_fmt = "yuv420p"
@@ -332,7 +338,7 @@ def mux_audio_video(
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with av.open(str(output_path), mode="w") as container:
-        video_stream = container.add_stream("libx264", rate=fps)
+        video_stream = container.add_stream("libx264", rate=fps, options={"crf": str(H3_VIDEO_CRF)})
         video_stream.width = video.shape[2]
         video_stream.height = video.shape[1]
         video_stream.pix_fmt = "yuv420p"

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -452,9 +452,7 @@ def build_one_frame_latent_tensors(
     canonical_item_key = f"{item_key}#1f"
     target_video = _encode_target_video(video_vae, target_pixels, cache_seed, canonical_item_key)[0]
     if target_video.shape[1] != ONE_FRAME_VIDEO_LATENT_FRAMES:
-        raise ValueError(
-            f"MiniMax-H3 video VAE returned {target_video.shape[1]} frames, expected {ONE_FRAME_VIDEO_LATENT_FRAMES}"
-        )
+        raise ValueError(f"MiniMax-H3 video VAE returned {target_video.shape[1]} frames, expected {ONE_FRAME_VIDEO_LATENT_FRAMES}")
 
     tensors = {
         _visual_key("", target_video): target_video,
@@ -599,9 +597,7 @@ def main() -> None:
         audio_sources_by_dir[key] = dataset.datasource.audio_sources
     colliding = image_dirs & set(records_by_dir)
     if colliding:
-        raise ValueError(
-            f"MiniMax-H3 image and video datasets cannot share a cache_directory: {sorted(colliding)}"
-        )
+        raise ValueError(f"MiniMax-H3 image and video datasets cannot share a cache_directory: {sorted(colliding)}")
 
     if args.debug_mode is not None:
         cache_latents.show_datasets(

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -23,12 +23,17 @@ from musubi_tuner.dataset import config_utils
 from musubi_tuner.dataset.architectures import ARCHITECTURE_MINIMAX_H3
 from musubi_tuner.dataset.audio_utils import decode_audio as decode_audio_waveform
 from musubi_tuner.dataset.audio_utils import slice_audio_window
-from musubi_tuner.dataset.cache_io import append_audio_present_entry, save_latent_cache_minimax_h3
+from musubi_tuner.dataset.cache_io import (
+    append_audio_present_entry,
+    append_one_frame_target_index_entry,
+    save_latent_cache_minimax_h3,
+)
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
-from musubi_tuner.dataset.image_video_dataset import ItemInfo, VideoDataset
+from musubi_tuner.dataset.image_video_dataset import ImageDataset, ItemInfo, VideoDataset
 from musubi_tuner.dataset.media_utils import load_video
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode, load_audio_vae
 from musubi_tuner.minimax_h3.checkpoint import resolve_safetensors_files
+from musubi_tuner.minimax_h3.packing import ONE_FRAME_AUDIO_LATENT_FRAMES, ONE_FRAME_VIDEO_LATENT_FRAMES
 from musubi_tuner.minimax_h3.media import (
     AUDIO_SAMPLE_RATE,
     AUDIO_TERMINAL_TOLERANCE_SAMPLES,
@@ -266,8 +271,9 @@ def build_latent_metadata(
     video_vae_fingerprint: str,
     audio_vae_fingerprint: str,
     media_fingerprints: Mapping[Path, str],
+    one_frame_target_index: int | None = None,
 ) -> dict[str, str]:
-    return {
+    metadata = {
         "task": task,
         "cache_seed": str(cache_seed),
         "crop_start_frame": str(crop_start_frame),
@@ -276,6 +282,12 @@ def build_latent_metadata(
         "audio_vae_fingerprint": audio_vae_fingerprint,
         "media_fingerprints": _media_fingerprint_metadata(media_fingerprints),
     }
+    if one_frame_target_index is not None:
+        # duplicated from the tensor entry so --skip_existing rebuilds when the dataset's
+        # fp_1f_target_index changes
+        metadata["one_frame"] = "1"
+        metadata["one_frame_target_index"] = str(one_frame_target_index)
+    return metadata
 
 
 def cache_metadata_matches(path: str | Path, expected: Mapping[str, str]) -> bool:
@@ -395,6 +407,74 @@ def build_latent_tensors(
     return H3LatentCachePayload(tensors=tensors, metadata=metadata)
 
 
+def encode_one_frame_silence_latent(audio_vae) -> torch.Tensor:
+    """The [32,2,2] silence placeholder shared by every one-frame item (a constant per audio VAE)."""
+    silence = torch.zeros(2, waveform_samples(ONE_FRAME_AUDIO_LATENT_FRAMES), dtype=torch.float32)
+    latent = _encode_audio(audio_vae, silence)[0]
+    if latent.shape[2] != ONE_FRAME_AUDIO_LATENT_FRAMES:
+        raise ValueError(
+            f"MiniMax-H3 audio VAE returned {latent.shape[2]} silence frames, expected {ONE_FRAME_AUDIO_LATENT_FRAMES}"
+        )
+    return latent
+
+
+def build_one_frame_latent_tensors(
+    *,
+    image_frames: torch.Tensor | np.ndarray,
+    target_index: int,
+    video_vae,
+    silence_audio_latent: torch.Tensor,
+    cache_seed: int,
+    item_key: str,
+    video_vae_fingerprint: str,
+    audio_vae_fingerprint: str,
+    media_fingerprints: Mapping[Path, str],
+) -> H3LatentCachePayload:
+    """One-frame (image) target: a single video latent token, the silence audio placeholder,
+    and the target's 24 fps pixel-frame index as a tensor entry for the trainer's RoPE override."""
+    if target_index < 0:
+        raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
+    image_frames = torch.as_tensor(image_frames)
+    if image_frames.ndim == 3:
+        image_frames = image_frames.unsqueeze(0)
+    if image_frames.ndim != 4 or image_frames.shape[0] != 1:
+        raise ValueError(f"MiniMax-H3 one-frame target must be a single [H,W,C] image, got {tuple(image_frames.shape)}")
+    height, width = image_frames.shape[1:3]
+    if width % 32 or height % 32:
+        raise ValueError(f"MiniMax-H3 target axes must be divisible by 32, got {width}x{height}")
+    if silence_audio_latent.shape != (32, 2, ONE_FRAME_AUDIO_LATENT_FRAMES):
+        raise ValueError(
+            f"MiniMax-H3 one-frame silence latent must be [32,2,{ONE_FRAME_AUDIO_LATENT_FRAMES}],"
+            f" got {tuple(silence_audio_latent.shape)}"
+        )
+
+    target_pixels = _prepare_pixels(image_frames)
+    canonical_item_key = f"{item_key}#1f"
+    target_video = _encode_target_video(video_vae, target_pixels, cache_seed, canonical_item_key)[0]
+    if target_video.shape[1] != ONE_FRAME_VIDEO_LATENT_FRAMES:
+        raise ValueError(
+            f"MiniMax-H3 video VAE returned {target_video.shape[1]} frames, expected {ONE_FRAME_VIDEO_LATENT_FRAMES}"
+        )
+
+    tensors = {
+        _visual_key("", target_video): target_video,
+        _audio_key("", silence_audio_latent): silence_audio_latent,
+    }
+    append_audio_present_entry(tensors, False)
+    append_one_frame_target_index_entry(tensors, target_index)
+
+    metadata = build_latent_metadata(
+        task="t2va",
+        crop_start_frame=0,
+        cache_seed=cache_seed,
+        video_vae_fingerprint=video_vae_fingerprint,
+        audio_vae_fingerprint=audio_vae_fingerprint,
+        media_fingerprints=media_fingerprints,
+        one_frame_target_index=target_index,
+    )
+    return H3LatentCachePayload(tensors=tensors, metadata=metadata)
+
+
 def fingerprint_file(path: str | Path) -> str:
     """Lightweight file identity (size + mtime) for cache-staleness checks; deliberately not a content hash."""
     stat = Path(path).resolve().stat()
@@ -464,6 +544,12 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--video_vae", type=str, required=True, help="MiniMax-H3 video VAE safetensors path or directory")
     parser.add_argument("--audio_vae", type=str, required=True, help="MiniMax-H3 audio VAE safetensors path or directory")
     parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), required=True)
+    parser.add_argument(
+        "--one_frame",
+        action="store_true",
+        help="experimental one-frame (image) training caches: accept image datasets whose items become single-token"
+        " video targets with a silence audio placeholder (currently --task t2va only)",
+    )
     parser.add_argument("--cache_seed", type=int, default=0, help="seed used for reproducible target-video posterior samples")
     parser.add_argument(
         "--allow_experimental_duration",
@@ -486,11 +572,12 @@ def main() -> None:
     blueprint = blueprint_generator.generate(user_config, args, architecture=ARCHITECTURE_MINIMAX_H3)
     dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group, audio_spec=H3_AUDIO_SPEC)
     datasets = dataset_group.datasets
-    if not all(isinstance(dataset, VideoDataset) for dataset in datasets):
-        raise ValueError("MiniMax-H3 latent caching accepts only video datasets")
+    if args.one_frame and args.task != "t2va":
+        raise ValueError("MiniMax-H3 one-frame caching currently supports --task t2va only")
 
     records_by_dir: dict[str, list[H3Record]] = {}
     audio_sources_by_dir: dict[str, list] = {}
+    image_dirs: set[str] = set()
     for dataset_index, dataset in enumerate(datasets):
         validate_h3_dataset(dataset)
         if int(dataset.batch_size) != 1:
@@ -501,8 +588,20 @@ def main() -> None:
                 int(dataset.batch_size),
             )
         key = dataset_cache_dir_key(dataset.cache_directory)
+        if isinstance(dataset, ImageDataset):
+            if not args.one_frame:
+                raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
+            image_dirs.add(key)
+            continue
+        if not isinstance(dataset, VideoDataset):
+            raise ValueError("MiniMax-H3 latent caching accepts only image and video datasets")
         records_by_dir[key] = h3_records_from_datasource(dataset.datasource, args.task)
         audio_sources_by_dir[key] = dataset.datasource.audio_sources
+    colliding = image_dirs & set(records_by_dir)
+    if colliding:
+        raise ValueError(
+            f"MiniMax-H3 image and video datasets cannot share a cache_directory: {sorted(colliding)}"
+        )
 
     if args.debug_mode is not None:
         cache_latents.show_datasets(
@@ -536,14 +635,57 @@ def main() -> None:
     logger.info("Loading MiniMax-H3 audio VAE from %s", args.audio_vae)
     audio_vae = load_audio_vae(args.audio_vae, device=device, dtype=torch.float32, disable_mmap=args.disable_mmap)
 
+    silence_audio_latent: torch.Tensor | None = None
+    if image_dirs:
+        # the silence placeholder is a constant per audio VAE, so encode it once for every item
+        silence_audio_latent = encode_one_frame_silence_latent(audio_vae)
+
     decoder = PyAVH3MediaDecoder()
     skip_matching_cache = args.skip_existing
     args.skip_existing = False
     presence_counts: Counter[bool] = Counter()
+    one_frame_item_count = 0
+
+    def encode_one_frame(item: ItemInfo) -> None:
+        nonlocal one_frame_item_count
+        one_frame_item_count += 1
+        image_path = Path(item.item_key).resolve()
+        image_fingerprints = {image_path: media_fingerprints.setdefault(image_path, fingerprint_file(image_path))}
+        target_index = 0 if item.fp_1f_target_index is None else int(item.fp_1f_target_index)
+        expected_metadata = build_latent_metadata(
+            task="t2va",
+            crop_start_frame=0,
+            cache_seed=args.cache_seed,
+            video_vae_fingerprint=video_vae_fingerprint,
+            audio_vae_fingerprint=audio_vae_fingerprint,
+            media_fingerprints=image_fingerprints,
+            one_frame_target_index=target_index,
+        )
+        if skip_matching_cache and Path(item.latent_cache_path).is_file():
+            if cache_metadata_matches(item.latent_cache_path, expected_metadata):
+                logger.info("Skipping matching MiniMax-H3 latent cache: %s", item.latent_cache_path)
+                return
+            logger.info("Rebuilding stale MiniMax-H3 latent cache: %s", item.latent_cache_path)
+        payload = build_one_frame_latent_tensors(
+            image_frames=item.content,
+            target_index=target_index,
+            video_vae=video_vae,
+            silence_audio_latent=silence_audio_latent,
+            cache_seed=args.cache_seed,
+            item_key=str(image_path),
+            video_vae_fingerprint=video_vae_fingerprint,
+            audio_vae_fingerprint=audio_vae_fingerprint,
+            media_fingerprints=image_fingerprints,
+        )
+        logger.info("Saving MiniMax-H3 one-frame latent cache for %s to %s", item.item_key, item.latent_cache_path)
+        save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
 
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:
             key = item_cache_dir_key(item)
+            if key in image_dirs:
+                encode_one_frame(item)
+                continue
             datasource_index, crop_start = item_record_inputs(item)
             record = records_by_dir[key][datasource_index]
             audio_source = audio_sources_by_dir[key][datasource_index]
@@ -587,7 +729,13 @@ def main() -> None:
             save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
 
     cache_latents.encode_datasets(datasets, encode, args)
-    log_audio_presence_summary(presence_counts)
+    if one_frame_item_count:
+        logger.info(
+            "MiniMax-H3 one-frame cache summary: %d image items (silence audio placeholder, excluded from audio supervision)",
+            one_frame_item_count,
+        )
+    if presence_counts:
+        log_audio_presence_summary(presence_counts)
 
 
 if __name__ == "__main__":

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -11,7 +11,7 @@ from musubi_tuner.dataset import config_utils
 from musubi_tuner.dataset.architectures import ARCHITECTURE_MINIMAX_H3
 from musubi_tuner.dataset.cache_io import save_text_encoder_output_cache_minimax_h3
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
-from musubi_tuner.dataset.image_video_dataset import ItemInfo, VideoDataset
+from musubi_tuner.dataset.image_video_dataset import ImageDataset, ItemInfo, VideoDataset
 from musubi_tuner.minimax_h3.text_encoder import (
     H3Presentation,
     H3TextVisual,
@@ -200,6 +200,12 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), required=True)
     parser.add_argument(
+        "--one_frame",
+        action="store_true",
+        help="experimental one-frame (image) training caches: accept image datasets, whose captions are encoded"
+        " as plain T2VA presentations (currently --task t2va only)",
+    )
+    parser.add_argument(
         "--teacher_conditions",
         type=str,
         default=None,
@@ -233,7 +239,11 @@ def main() -> None:
     if args.teacher_conditions is not None:
         if args.task != "t2va":
             raise ValueError("--teacher_conditions requires --task t2va (teacher matching trains a T2VA student)")
+        if args.one_frame:
+            raise ValueError("--teacher_conditions does not support --one_frame yet")
         teacher_conditions = normalize_teacher_conditions(args.teacher_conditions)
+    if args.one_frame and args.task != "t2va":
+        raise ValueError("MiniMax-H3 one-frame caching currently supports --task t2va only")
 
     blueprint_generator = BlueprintGenerator(ConfigSanitizer())
     logger.info("Loading dataset config from %s", args.dataset_config)
@@ -241,14 +251,23 @@ def main() -> None:
     blueprint = blueprint_generator.generate(user_config, args, architecture=ARCHITECTURE_MINIMAX_H3)
     dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group)
     datasets = dataset_group.datasets
-    if not all(isinstance(dataset, VideoDataset) for dataset in datasets):
-        raise ValueError("MiniMax-H3 text caching accepts only video datasets")
 
     decoder = PyAVH3MediaDecoder()
     records_by_dir = {}
+    image_dirs: set[str] = set()
     for dataset in datasets:
         validate_h3_dataset(dataset)
+        if isinstance(dataset, ImageDataset):
+            if not args.one_frame:
+                raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
+            image_dirs.add(dataset_cache_dir_key(dataset.cache_directory))
+            continue
+        if not isinstance(dataset, VideoDataset):
+            raise ValueError("MiniMax-H3 text caching accepts only image and video datasets")
         records_by_dir[dataset_cache_dir_key(dataset.cache_directory)] = h3_records_from_datasource(dataset.datasource, args.task)
+    colliding = image_dirs & set(records_by_dir)
+    if colliding:
+        raise ValueError(f"MiniMax-H3 image and video datasets cannot share a cache_directory: {sorted(colliding)}")
 
     all_cache_files, all_cache_paths = cache_text_encoder_outputs.prepare_cache_files_and_paths(datasets)
     text_paths = {
@@ -300,16 +319,32 @@ def main() -> None:
 
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:
-            records = records_by_dir[dataset_cache_dir_key(str(Path(item.text_encoder_output_cache_path).parent))]
-            datasource_index, crop_start = item_record_inputs(item)
-            record = records[datasource_index]
-            visuals = _build_visuals(record, args.task, item, decoder, decoded_reference_cache)
-            presentation = build_presentation(record, args.task, visuals)
+            cache_dir_key = dataset_cache_dir_key(str(Path(item.text_encoder_output_cache_path).parent))
+            if cache_dir_key in image_dirs:
+                # one-frame image item: a plain T2VA presentation of the caption; the target
+                # time index lives in the latent cache, never in the text rows
+                record = H3Record(
+                    video_path=Path(item.item_key).resolve(),
+                    caption=item.caption,
+                    references=(),
+                    jsonl_line=0,
+                )
+                crop_start = 0
+                frame_count = 1
+                visuals = {}
+                presentation = build_presentation(record, "t2va", visuals)
+            else:
+                records = records_by_dir[cache_dir_key]
+                datasource_index, crop_start = item_record_inputs(item)
+                record = records[datasource_index]
+                frame_count = item.frame_count
+                visuals = _build_visuals(record, args.task, item, decoder, decoded_reference_cache)
+                presentation = build_presentation(record, args.task, visuals)
             record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
             presentation_identity = presentation_fingerprint(
                 presentation,
                 record_media_fingerprints,
-                frame_count=item.frame_count,
+                frame_count=frame_count,
             )
             teacher_presentation = None
             teacher_presentation_identity = None

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -24,6 +24,7 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     encode_audio_conditions,
     encode_visual_conditions,
     load_generation_record,
+    parse_one_frame_options,
 )
 from musubi_tuner.minimax_h3.media import (
     H3Record,
@@ -83,43 +84,10 @@ def _time_flag() -> str:
     return datetime.now().strftime("%Y%m%d-%H%M%S-%f")[:-3]
 
 
-def _parse_one_frame_options(spec: str) -> tuple[int, tuple[int, ...] | None]:
-    """Parses --one_frame "target_index=N,control_index=A;B" into 24 fps pixel-frame indices."""
-
-    def nonnegative_index(value: str, label: str) -> int:
-        try:
-            index = int(value)
-        except ValueError as error:
-            raise ValueError(f"MiniMax-H3 --one_frame {label} must be an integer, got {value!r}") from error
-        if index < 0:
-            raise ValueError(f"MiniMax-H3 --one_frame {label} must be nonnegative, got {index}")
-        return index
-
-    target_index = 0
-    control_indices = None
-    seen = set()
-    for part in spec.split(","):
-        key, separator, value = part.partition("=")
-        key = key.strip()
-        value = value.strip()
-        if not separator or not key or not value:
-            raise ValueError(f"MiniMax-H3 --one_frame options must be key=value, got {part!r}")
-        if key not in {"target_index", "control_index"}:
-            raise ValueError(f"MiniMax-H3 --one_frame has unknown option {key!r} (allowed: target_index, control_index)")
-        if key in seen:
-            raise ValueError(f"MiniMax-H3 --one_frame has duplicate option {key!r}")
-        seen.add(key)
-        if key == "target_index":
-            target_index = nonnegative_index(value, "target_index")
-        else:
-            control_indices = tuple(nonnegative_index(item, "control_index") for item in value.split(";"))
-    return target_index, control_indices
-
-
 def _one_frame_time_overrides(args: argparse.Namespace) -> H3TimeOverrides | None:
     if args.frame_count != 1:
         return None
-    target_index, control_indices = _parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
+    target_index, control_indices = parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
     return H3TimeOverrides(
         condition_times=tuple(FRAME_RESCALE * index for index in (control_indices or ())),
         target_time=FRAME_RESCALE * target_index,
@@ -189,7 +157,7 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
         raise ValueError(f"MiniMax-H3 width and height must be positive and divisible by 32, got {args.width}x{args.height}")
     one_frame = args.frame_count == 1
     if one_frame:
-        _, control_indices = _parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
+        _, control_indices = parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
         if args.task == "fl2va":
             provided_frames = int(bool(args.first_frame)) + int(bool(args.last_frame))
             # a missing-frames error is raised by the task input checks below

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -1371,6 +1371,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 f"MiniMax-H3 guidance-loss uncond cache width {uncond_hidden.shape[1]} does not match"
                 f" the text cache width {runtime.text_hidden_states.shape[2]}"
             )
+        # the probe swaps only the text rows; the one-frame times stay valid because they
+        # are relative to the target-block cursor, which moves with the text length
         uncond_layout = build_h3_layout(
             task=runtime.layout.task,
             text_length=uncond_hidden.shape[0],
@@ -1378,6 +1380,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             target_audio_frames=runtime.layout.target_audio_frames,
             visual_conditions=runtime.layout.visual_conditions,
             references=runtime.layout.references,
+            one_frame=runtime.layout.target_video.frames == ONE_FRAME_VIDEO_LATENT_FRAMES,
+            time_overrides=runtime.layout.time_overrides,
         )
         autocast = accelerator.autocast if hasattr(accelerator, "autocast") else nullcontext
         with torch.no_grad(), autocast():

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -30,21 +30,28 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     encode_visual_conditions,
     load_generation_record,
     module_device_dtype,
+    parse_one_frame_options,
 )
 from musubi_tuner.minimax_h3.media import H3_AUDIO_SPEC, audio_latent_frames, parse_inline_references, video_latent_frames
 from musubi_tuner.minimax_h3.model import load_h3_transformer
 from musubi_tuner.minimax_h3.packing import (
+    FRAME_RESCALE,
     H3PackedLayout,
     H3ReferenceGeometry,
+    H3TimeOverrides,
     H3VideoGeometry,
+    ONE_FRAME_AUDIO_LATENT_FRAMES,
+    ONE_FRAME_VIDEO_LATENT_FRAMES,
     build_h3_layout,
 )
 from musubi_tuner.minimax_h3.sampling import (
     augment_condition_latents,
     create_sampling_generator,
+    decoded_video_to_uint8,
     initialize_target_latents,
     sample_joint_av,
     synchronize_decoded_av,
+    write_image,
     write_joint_av,
 )
 from musubi_tuner.minimax_h3.text_encoder import (
@@ -97,26 +104,39 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
     width = int(sample.get("width", 768))
     height = int(sample.get("height", 1344))
     requested_frame_count = int(sample.get("frame_count", 124))
-    frame_count = round_down_frame_count(requested_frame_count, ARCHITECTURE_MINIMAX_H3, 17)
-    if frame_count != requested_frame_count:
-        logger.warning(
-            "MiniMax-H3 sample frame count %d was rounded down to %d (17*n+5)",
-            requested_frame_count,
-            frame_count,
+    one_frame_spec = sample.get("one_frame")
+    if requested_frame_count == 1:
+        # experimental one-frame (image) sample: single-token target, no duration semantics
+        if args.task != "t2va":
+            raise ValueError("MiniMax-H3 one-frame training samples (--f 1) currently support --task t2va only")
+        frame_count = 1
+        target_index, control_indices = parse_one_frame_options(one_frame_spec) if one_frame_spec else (0, None)
+        if control_indices is not None:
+            raise ValueError("MiniMax-H3 T2VA one-frame training sample does not accept control_index")
+        sample["one_frame_target_index"] = target_index
+    else:
+        if one_frame_spec is not None:
+            raise ValueError("MiniMax-H3 sample --of options require --f 1")
+        frame_count = round_down_frame_count(requested_frame_count, ARCHITECTURE_MINIMAX_H3, 17)
+        if frame_count != requested_frame_count:
+            logger.warning(
+                "MiniMax-H3 sample frame count %d was rounded down to %d (17*n+5)",
+                requested_frame_count,
+                frame_count,
+            )
+        video_latent_frames(frame_count)
+        duration = frame_count / 24.0
+        allow_experimental = bool(
+            getattr(args, "h3_allow_experimental_sample_duration", False) or sample.get("allow_experimental_duration", False)
         )
+        if not allow_experimental and not 5.0 <= duration <= 15.0:
+            raise ValueError(
+                f"MiniMax-H3 sample duration {duration:.3f}s is outside the released 5-15s range; "
+                "pass --h3_allow_experimental_sample_duration to proceed"
+            )
     sample_steps = int(sample.get("sample_steps", 30))
     if width <= 0 or height <= 0 or width % 32 or height % 32:
         raise ValueError(f"MiniMax-H3 sample width and height must be positive and divisible by 32, got {width}x{height}")
-    video_latent_frames(frame_count)
-    duration = frame_count / 24.0
-    allow_experimental = bool(
-        getattr(args, "h3_allow_experimental_sample_duration", False) or sample.get("allow_experimental_duration", False)
-    )
-    if not allow_experimental and not 5.0 <= duration <= 15.0:
-        raise ValueError(
-            f"MiniMax-H3 sample duration {duration:.3f}s is outside the released 5-15s range; "
-            "pass --h3_allow_experimental_sample_duration to proceed"
-        )
     if sample_steps <= 0:
         raise ValueError("MiniMax-H3 sample_steps must be positive")
 
@@ -262,6 +282,7 @@ def _runtime_batch_plan(
     video_latents: torch.Tensor,
     *,
     teacher_conditions: str | None = None,
+    one_frame: bool = False,
 ) -> _H3RuntimeBatch:
     if video_latents.ndim != 5 or video_latents.shape[1] != 24:
         raise ValueError(f"MiniMax-H3 target video latents must be [B,24,F,H,W], got {tuple(video_latents.shape)}")
@@ -299,6 +320,30 @@ def _runtime_batch_plan(
             reference_roles.setdefault(int(match.group(1)), {})[match.group(2)] = value
     if has_fl_condition and reference_roles:
         raise ValueError("MiniMax-H3 batch cannot mix FL2VA and Ref2VA condition roles")
+
+    is_one_frame_batch = video_latents.shape[2] == 1
+    one_frame_index_value = batch.get("one_frame_target_index")
+    time_overrides = None
+    if is_one_frame_batch:
+        if not one_frame:
+            raise ValueError("MiniMax-H3 batch carries a one-frame latent cache; pass --one_frame to train on image targets")
+        if has_fl_condition or reference_roles or teacher_conditions is not None:
+            raise ValueError("MiniMax-H3 one-frame training currently supports plain T2VA caches only")
+        if (
+            not isinstance(one_frame_index_value, torch.Tensor)
+            or one_frame_index_value.shape != (batch_size,)
+            or one_frame_index_value.dtype != torch.int64
+        ):
+            raise ValueError(
+                "MiniMax-H3 one-frame batch requires an int64 one_frame_target_index tensor;"
+                " re-run minimax_h3_cache_latents.py --one_frame"
+            )
+        target_index = int(one_frame_index_value.item())
+        if target_index < 0:
+            raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
+        time_overrides = H3TimeOverrides(condition_times=(), target_time=FRAME_RESCALE * target_index)
+    elif one_frame_index_value is not None:
+        raise ValueError("MiniMax-H3 video batch cannot carry one_frame_target_index; re-run latent caching")
 
     visual_conditions = []
     audio_conditions = []
@@ -424,6 +469,8 @@ def _runtime_batch_plan(
         target_audio_frames=audio_latents.shape[-1],
         visual_conditions=tuple(condition_geometries),
         references=tuple(references),
+        one_frame=is_one_frame_batch,
+        time_overrides=time_overrides,
     )
     return _H3RuntimeBatch(
         layout=layout,
@@ -597,6 +644,16 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         self.default_discrete_flow_shift = 1.0
         if getattr(args, "task", None) not in {"t2va", "fl2va", "ref2va"}:
             raise ValueError("MiniMax-H3 requires --task t2va, fl2va, or ref2va")
+        if getattr(args, "one_frame", False):
+            if args.task != "t2va":
+                raise ValueError("MiniMax-H3 one-frame training currently requires --task t2va")
+            if getattr(args, "h3_teacher_matching", False):
+                raise ValueError("--h3_teacher_matching does not support --one_frame yet")
+            logger.info(
+                "MiniMax-H3 one-frame training: image batches carry a silence audio placeholder that presence"
+                " gating excludes from the audio loss; pass --video_only for image-only runs to skip the"
+                " audio-loss bookkeeping entirely"
+            )
         if args.timestep_sampling != "uniform":
             raise ValueError("MiniMax-H3 supports --timestep_sampling uniform only")
         if args.weighting_scheme != "none":
@@ -861,17 +918,26 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 if args.task == "ref2va"
                 else ()
             )
+            one_frame_sample = parameter["frame_count"] == 1
             parameter["h3_layout"] = build_h3_layout(
                 task=args.task,
                 text_length=parameter["h3_text_hidden_states"].shape[1],
                 target_video=H3VideoGeometry(
-                    video_latent_frames(parameter["frame_count"]),
+                    ONE_FRAME_VIDEO_LATENT_FRAMES if one_frame_sample else video_latent_frames(parameter["frame_count"]),
                     parameter["height"] // VIDEO_VAE_SPATIAL_RATIO,
                     parameter["width"] // VIDEO_VAE_SPATIAL_RATIO,
                 ),
-                target_audio_frames=audio_latent_frames(parameter["frame_count"]),
+                target_audio_frames=(
+                    ONE_FRAME_AUDIO_LATENT_FRAMES if one_frame_sample else audio_latent_frames(parameter["frame_count"])
+                ),
                 visual_conditions=parameter["_h3_visual_geometries"],
                 references=references,
+                one_frame=one_frame_sample,
+                time_overrides=(
+                    H3TimeOverrides(condition_times=(), target_time=FRAME_RESCALE * parameter["one_frame_target_index"])
+                    if one_frame_sample
+                    else None
+                ),
             )
             layout = parameter["h3_layout"]
             logger.info(
@@ -1001,24 +1067,33 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             del video_latents
             clean_memory_on_device(device)
 
-            logger.info("Decoding MiniMax-H3 training sample audio")
-            audio_vae.to(device).eval()
-            _, audio_dtype = module_device_dtype(audio_vae, torch.float32)
-            decoded_audio = audio_vae.decode(audio_latents.to(device=device, dtype=audio_dtype)).cpu()
-            audio_vae.to("cpu")
-            del audio_latents
-            clean_memory_on_device(device)
-
-            decoded = synchronize_decoded_av(decoded_video, decoded_audio, frame_count=frame_count)
             timestamp = time.strftime("%Y%m%d%H%M%S", time.localtime())
             number = f"e{epoch:06d}" if epoch is not None else f"{steps:06d}"
             original_seed = sample_parameter.get("seed")
             seed_suffix = "" if original_seed is None else f"_{original_seed}"
             prompt_index = sample_parameter.get("enum", 0)
             prefix = "" if args.output_name is None else f"{args.output_name}_"
-            output_path = Path(save_dir) / f"{prefix}{number}_{prompt_index:02d}_{timestamp}{seed_suffix}.mp4"
-            write_joint_av(decoded, output_path)
-            logger.info("Saved MiniMax-H3 joint training sample: %s", output_path)
+            output_stem = f"{prefix}{number}_{prompt_index:02d}_{timestamp}{seed_suffix}"
+
+            if frame_count == 1:
+                # one-frame sample: the audio rows are a byproduct and are never decoded
+                del audio_latents
+                output_path = Path(save_dir) / f"{output_stem}.png"
+                write_image(decoded_video_to_uint8(decoded_video, frame_limit=1)[0], output_path)
+                logger.info("Saved MiniMax-H3 one-frame training sample: %s", output_path)
+            else:
+                logger.info("Decoding MiniMax-H3 training sample audio")
+                audio_vae.to(device).eval()
+                _, audio_dtype = module_device_dtype(audio_vae, torch.float32)
+                decoded_audio = audio_vae.decode(audio_latents.to(device=device, dtype=audio_dtype)).cpu()
+                audio_vae.to("cpu")
+                del audio_latents
+                clean_memory_on_device(device)
+
+                decoded = synchronize_decoded_av(decoded_video, decoded_audio, frame_count=frame_count)
+                output_path = Path(save_dir) / f"{output_stem}.mp4"
+                write_joint_av(decoded, output_path)
+                logger.info("Saved MiniMax-H3 joint training sample: %s", output_path)
 
             try:
                 wandb_tracker = accelerator.get_tracker("wandb")
@@ -1030,7 +1105,10 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 except ImportError:
                     logger.warning("wandb tracker is active but wandb is not installed")
                 else:
-                    wandb_tracker.log({f"sample_{prompt_index}": wandb.Video(str(output_path), fps=24)}, step=steps)
+                    if frame_count == 1:
+                        wandb_tracker.log({f"sample_{prompt_index}": wandb.Image(str(output_path))}, step=steps)
+                    else:
+                        wandb_tracker.log({f"sample_{prompt_index}": wandb.Video(str(output_path), fps=24)}, step=steps)
             return output_path
         finally:
             video_vae.to("cpu")
@@ -1068,6 +1146,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             "ss_minimax_h3_latent_cache_version": "2",
             "ss_minimax_h3_text_cache_version": "1",
         }
+        if getattr(args, "one_frame", False):
+            metadata["ss_minimax_h3_one_frame"] = True
         if float(args.h3_guidance_loss_scale) > 0.0:
             metadata["ss_minimax_h3_guidance_loss_scale"] = args.h3_guidance_loss_scale
             metadata["ss_minimax_h3_guidance_loss_scale_audio"] = self._guidance_audio_scale(args)
@@ -1452,7 +1532,12 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             normalize_teacher_conditions(args.h3_teacher_conditions) if getattr(args, "h3_teacher_matching", False) else None
         )
         # _runtime_batch_plan rejects batches larger than one item (batch_size=1 rule)
-        runtime = _runtime_batch_plan(batch, latents, teacher_conditions=teacher_conditions)
+        runtime = _runtime_batch_plan(
+            batch,
+            latents,
+            teacher_conditions=teacher_conditions,
+            one_frame=bool(getattr(args, "one_frame", False)),
+        )
         self._audio_items_seen += int(runtime.audio_present.numel())
         self._audio_supervised_seen += int(runtime.audio_present.sum().item())
         if runtime.layout.task != args.task:
@@ -1590,6 +1675,13 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         network_module="networks.lora_minimax_h3",
     )
     parser.add_argument("--task", choices=("t2va", "fl2va", "ref2va"), default=None, help="MiniMax-H3 training task")
+    parser.add_argument(
+        "--one_frame",
+        action="store_true",
+        help="experimental one-frame (image) training: accept single-token latent caches written by"
+        " minimax_h3_cache_latents.py --one_frame (currently --task t2va only; video batches are unaffected,"
+        " so image and video datasets can mix in one run)",
+    )
     add_audio_train_args(parser)
     parser.add_argument("--h3_shift_video", type=float, default=12.0, help="MiniMax-H3 target-video flow shift")
     parser.add_argument("--h3_shift_audio", type=float, default=3.0, help="MiniMax-H3 target-audio flow shift")

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -24,7 +24,9 @@ from musubi_tuner.minimax_h3.media import (
 )
 from musubi_tuner.minimax_h3_cache_latents import (
     build_latent_tensors,
+    build_one_frame_latent_tensors,
     cache_metadata_matches,
+    encode_one_frame_silence_latent,
     log_audio_presence_summary,
     record_media_paths,
     setup_parser,
@@ -32,6 +34,7 @@ from musubi_tuner.minimax_h3_cache_latents import (
 from musubi_tuner.dataset.bucket import BucketBatchManager
 from musubi_tuner.dataset.cache_io import (
     AUDIO_PRESENT_KEY,
+    ONE_FRAME_TARGET_INDEX_KEY,
     save_latent_cache_minimax_h3,
     save_text_encoder_output_cache_minimax_h3,
 )
@@ -919,3 +922,119 @@ def test_build_ref2va_revalidates_limits_before_any_model_work(tmp_path: Path):
     assert audio_vae.calls == []
     assert decoder.audio_calls == []
     assert decoder.visual_calls == []
+
+
+def test_one_frame_silence_latent_is_the_two_frame_placeholder():
+    audio_vae = _FakeH3AudioVAE()
+
+    latent = encode_one_frame_silence_latent(audio_vae)
+
+    assert latent.shape == (32, 2, 2)
+    assert len(audio_vae.calls) == 1
+    assert audio_vae.calls[0].shape == (1, 2, 1600)
+    assert torch.count_nonzero(audio_vae.calls[0]) == 0
+
+
+def test_build_one_frame_latents_pack_silence_and_the_target_index(tmp_path: Path):
+    image_path = _touch(tmp_path / "portrait.png")
+    video_vae = _FakeH3VideoVAE()
+    silence = torch.zeros(32, 2, 2)
+
+    payload = build_one_frame_latent_tensors(
+        image_frames=torch.zeros(64, 64, 3, dtype=torch.uint8),
+        target_index=24,
+        video_vae=video_vae,
+        silence_audio_latent=silence,
+        cache_seed=123,
+        item_key=str(image_path),
+        video_vae_fingerprint="video-fingerprint",
+        audio_vae_fingerprint="audio-fingerprint",
+        media_fingerprints={image_path: "portrait-image"},
+    )
+
+    assert set(payload.tensors) == {
+        "latents_1x4x4_float32",
+        "latents_audio_32x2x2_float32",
+        AUDIO_PRESENT_KEY,
+        ONE_FRAME_TARGET_INDEX_KEY,
+    }
+    assert payload.tensors[AUDIO_PRESENT_KEY].item() == 0.0
+    index = payload.tensors[ONE_FRAME_TARGET_INDEX_KEY]
+    assert index.dtype == torch.int64 and index.shape == torch.Size([]) and index.item() == 24
+    assert [call.shape for call in video_vae.calls] == [(1, 3, 1, 64, 64)]
+    assert payload.metadata["task"] == "t2va"
+    assert payload.metadata["crop_start_frame"] == "0"
+    assert payload.metadata["one_frame"] == "1"
+    assert payload.metadata["one_frame_target_index"] == "24"
+    assert json.loads(payload.metadata["media_fingerprints"]) == {str(image_path): "portrait-image"}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"target_index": -1}, "nonnegative"),
+        ({"image_frames": torch.zeros(60, 64, 3, dtype=torch.uint8)}, "divisible by 32"),
+        ({"image_frames": torch.zeros(2, 64, 64, 3, dtype=torch.uint8)}, "single"),
+        ({"silence_audio_latent": torch.zeros(32, 2, 8)}, r"\[32,2,2\]"),
+    ],
+)
+def test_build_one_frame_latents_reject_invalid_inputs(tmp_path: Path, overrides: dict, message: str):
+    image_path = _touch(tmp_path / "portrait.png")
+    inputs = dict(
+        image_frames=torch.zeros(64, 64, 3, dtype=torch.uint8),
+        target_index=0,
+        video_vae=_FakeH3VideoVAE(),
+        silence_audio_latent=torch.zeros(32, 2, 2),
+        cache_seed=0,
+        item_key=str(image_path),
+        video_vae_fingerprint="video-fingerprint",
+        audio_vae_fingerprint="audio-fingerprint",
+        media_fingerprints={image_path: "portrait-image"},
+    )
+    inputs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        build_one_frame_latent_tensors(**inputs)
+
+
+def test_one_frame_cache_keys_round_trip_through_the_bucket_collator(tmp_path: Path):
+    item = ItemInfo("portrait", "an image caption", (64, 64), (64, 64))
+    item.latent_cache_path = str(tmp_path / "portrait_0064x0064_mmh3.safetensors")
+    item.text_encoder_output_cache_path = str(tmp_path / "portrait_mmh3_te.safetensors")
+    latent_tensors = {
+        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
+        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
+        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
+        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
+    }
+    text_tensors = {
+        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
+        "varlen_mmh3_token_tags_int64": torch.tensor([1, 1, 1], dtype=torch.int64),
+    }
+    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "t2va", "one_frame": "1"})
+    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "t2va"})
+
+    manager = BucketBatchManager({(64, 64): [item]}, batch_size=1)
+    batch = manager[0]
+
+    assert batch["latents"].shape == (1, 24, 1, 4, 4)
+    assert batch["latents_audio"].shape == (1, 32, 2, 2)
+    torch.testing.assert_close(batch["audio_present"], torch.tensor([0.0]))
+    torch.testing.assert_close(batch["one_frame_target_index"], torch.tensor([24], dtype=torch.int64))
+
+
+def test_h3_latent_writer_rejects_invalid_one_frame_target_indices(tmp_path: Path):
+    item = _h3_item(tmp_path)
+    base = {
+        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
+        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
+        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
+    }
+    invalid = (
+        torch.tensor([24], dtype=torch.int64),
+        torch.tensor(24, dtype=torch.int32),
+        torch.tensor(-1, dtype=torch.int64),
+    )
+    for index in invalid:
+        with pytest.raises(ValueError, match=ONE_FRAME_TARGET_INDEX_KEY):
+            save_latent_cache_minimax_h3(item, {**base, ONE_FRAME_TARGET_INDEX_KEY: index}, {"task": "t2va"})

--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -38,6 +38,7 @@ def _load_training_module(monkeypatch):
         encode_visual_conditions=noop,
         load_generation_record=noop,
         module_device_dtype=noop,
+        parse_one_frame_options=noop,
     )
     _stub(
         monkeypatch,
@@ -52,9 +53,11 @@ def _load_training_module(monkeypatch):
         "musubi_tuner.minimax_h3.sampling",
         augment_condition_latents=noop,
         create_sampling_generator=noop,
+        decoded_video_to_uint8=noop,
         initialize_target_latents=noop,
         sample_joint_av=noop,
         synchronize_decoded_av=noop,
+        write_image=noop,
         write_joint_av=noop,
     )
     _stub(
@@ -190,6 +193,7 @@ def _load_generation_module(monkeypatch):
         encode_audio_conditions=noop,
         encode_visual_conditions=noop,
         load_generation_record=noop,
+        parse_one_frame_options=noop,
     )
     _stub(
         monkeypatch,

--- a/tests/test_minimax_h3_dataset.py
+++ b/tests/test_minimax_h3_dataset.py
@@ -19,7 +19,7 @@ from musubi_tuner.dataset.architectures import (
     round_down_frame_count,
 )
 from musubi_tuner.dataset.bucket import BucketSelector
-from musubi_tuner.dataset.image_video_dataset import VideoDataset
+from musubi_tuner.dataset.image_video_dataset import ImageDataset, VideoDataset
 from musubi_tuner.training import trainer_base
 from musubi_tuner.training.trainer_base import NetworkTrainer
 
@@ -141,6 +141,61 @@ def test_h3_full_frame_extraction_preserves_valid_frame_count(tmp_path: Path):
     assert items[0].frame_count == 56
     assert items[0].content.shape[0] == 56
     assert Path(items[0].text_encoder_output_cache_path).name == "clip_00000-056_mmh3_te.safetensors"
+
+
+def _h3_image_dataset(tmp_path: Path, **overrides):
+    parameters = dict(
+        resolution=(64, 64),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=True,
+        bucket_no_upscale=False,
+        image_directory=str(tmp_path),
+        cache_directory=str(tmp_path),
+        architecture=ARCHITECTURE_MINIMAX_H3,
+    )
+    parameters.update(overrides)
+    return ImageDataset(**parameters)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"control_directory": "controls"}, "control images"),
+        ({"multiple_target": True}, "multiple targets"),
+        ({"fp_1f_clean_indices": [0]}, "fp_1f_clean_indices"),
+        ({"fp_1f_target_index": -1}, "nonnegative"),
+    ],
+)
+def test_h3_image_dataset_rejects_unsupported_one_frame_features(tmp_path: Path, overrides: dict, message: str):
+    with pytest.raises(ValueError, match=message):
+        _h3_image_dataset(tmp_path, **overrides)
+
+
+def test_h3_image_dataset_forwards_the_target_index_to_items(tmp_path: Path):
+    dataset = _h3_image_dataset(tmp_path, fp_1f_target_index=24)
+
+    class FakeImageDatasource:
+        has_control = False
+
+        def __iter__(self):
+            from PIL import Image
+
+            image = Image.new("RGB", (64, 64))
+            yield lambda: (str(tmp_path / "portrait.png"), [image], "caption", None)
+
+    dataset.datasource = FakeImageDatasource()
+
+    batches = list(dataset.retrieve_latent_cache_batches(num_workers=1))
+
+    assert len(batches) == 1
+    bucket, items = batches[0]
+    assert bucket == (64, 64)
+    assert items[0].fp_1f_target_index == 24
+    assert items[0].content.shape == (64, 64, 3)
+    assert Path(items[0].latent_cache_path).name == "portrait_0064x0064_mmh3.safetensors"
+    assert Path(items[0].text_encoder_output_cache_path).name == "portrait_mmh3_te.safetensors"
 
 
 def test_h3_prepare_for_training_pairs_each_crop_with_its_own_text_cache(tmp_path: Path):

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -462,6 +462,22 @@ def test_generation_validation_gates_the_one_frame_mode(tmp_path):
         validate_generation_args(_generation_args(tmp_path, task="fl2va", frame_count=1, output=png, one_frame="control_index=0"))
 
 
+def test_mux_encodes_above_the_1mbps_pyav_default(tmp_path):
+    # regression: without an explicit CRF, PyAV's libx264 default is ~1 Mbps ABR, which crushes
+    # fine detail in evaluation outputs. Noise frames at CRF 16 must blow far past that cap.
+    from musubi_tuner.minimax_h3.sampling import mux_audio_video
+
+    generator = torch.Generator().manual_seed(0)
+    video = torch.randint(0, 256, (12, 256, 256, 3), generator=generator, dtype=torch.uint8)
+    audio = torch.zeros(2, 16000)
+    output = tmp_path / "noise.mp4"
+
+    mux_audio_video(video, audio, output, fps=24, sample_rate=32000)
+
+    bits_per_second = output.stat().st_size * 8 / (12 / 24)
+    assert bits_per_second > 3_000_000
+
+
 def test_write_image_saves_a_single_uint8_frame(tmp_path):
     frame = torch.zeros(4, 6, 3, dtype=torch.uint8)
     frame[:, :, 1] = 200

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -21,15 +21,17 @@ from musubi_tuner.minimax_h3.sampling import (
     sample_joint_av,
     write_joint_av,
 )
-from musubi_tuner.minimax_h3.generation_inputs import load_generation_record
+from musubi_tuner.minimax_h3.generation_inputs import load_generation_record, parse_one_frame_options
 from musubi_tuner.minimax_h3.packing import FRAME_RESCALE, H3TimeOverrides
 from musubi_tuner.minimax_h3.sampling import write_image
 from musubi_tuner.minimax_h3_generate_video import (
     _one_frame_time_overrides,
-    _parse_one_frame_options,
     load_cached_text_conditioning,
     validate_generation_args,
 )
+
+# the parser moved to generation_inputs so the trainer's sample prompts share it
+_parse_one_frame_options = parse_one_frame_options
 
 
 def _layout():

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -1528,6 +1528,31 @@ def test_guidance_loss_rewrites_both_targets_around_the_uncond_prediction(tmp_pa
     assert torch.isfinite(loss)
 
 
+def test_guidance_loss_uncond_layout_carries_the_one_frame_overrides(tmp_path, monkeypatch):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(
+        one_frame=True,
+        h3_guidance_loss_scale=3.0,
+        h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
+    )
+    trainer.handle_model_specific_args(args)
+    transformer = _RecordingTransformer()
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
+
+    _, metrics = _one_frame_process_batch(trainer, args, _one_frame_batch(target_index=24), transformer)
+
+    # the no-grad uncond probe first, then the conditional pass, both on one-frame layouts
+    assert len(transformer.calls) == 2
+    uncond_call, cond_call = transformer.calls
+    assert uncond_call["layout"].text_length == 2
+    assert uncond_call["layout"].target_video.frames == 1
+    assert uncond_call["layout"].target_audio_frames == 2
+    assert uncond_call["layout"].time_overrides == cond_call["layout"].time_overrides
+    assert uncond_call["layout"].time_overrides.target_time == FRAME_RESCALE * 24
+    assert metrics["guidance/applied"] == 1.0
+
+
 def test_guidance_loss_audio_scale_can_differ_from_video(tmp_path, monkeypatch):
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from musubi_tuner.hv_train_network import setup_parser_common
 from musubi_tuner.minimax_h3.model import MiniMaxH3Config, MiniMaxH3Model
-from musubi_tuner.minimax_h3.packing import H3ReferenceGeometry, H3VideoGeometry, build_h3_layout
+from musubi_tuner.minimax_h3.packing import FRAME_RESCALE, H3ReferenceGeometry, H3VideoGeometry, build_h3_layout
 from musubi_tuner.modules.convrot_int8_kernels import quantize_int8_convrot_weight
 from musubi_tuner.modules.convrot_int8_utils import apply_convrot_int8_monkey_patch
 from musubi_tuner.minimax_h3_train_network import (
@@ -959,6 +959,168 @@ def test_runtime_rejects_a_batch_from_a_different_authoritative_task():
             None,
             0,
         )
+
+
+def _one_frame_batch(target_index: int | None = 24):
+    batch = {
+        "latents_audio": torch.full((1, 32, 2, 2), 4.0),
+        "audio_present": torch.zeros(1, dtype=torch.float32),
+        "mmh3_hidden_states": [torch.full((3, 12), 0.0)],
+        "mmh3_token_tags": [torch.tensor([1, 0, 1], dtype=torch.int64)],
+        "timesteps": None,
+    }
+    if target_index is not None:
+        batch["one_frame_target_index"] = torch.tensor([target_index], dtype=torch.int64)
+    return batch
+
+
+def _one_frame_process_batch(trainer, args, batch, transformer):
+    video_latents = torch.zeros(1, 24, 1, 4, 4)
+    return trainer.process_batch(
+        args,
+        _Accelerator(),
+        transformer,
+        None,
+        batch,
+        video_latents,
+        torch.zeros_like(video_latents),
+        None,
+        torch.bfloat16,
+        torch.float32,
+        None,
+        0,
+    )
+
+
+def test_one_frame_batch_builds_the_time_override_layout(monkeypatch):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(one_frame=True)
+    trainer.handle_model_specific_args(args)
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    transformer = _RecordingTransformer()
+
+    _one_frame_process_batch(trainer, args, _one_frame_batch(target_index=24), transformer)
+
+    layout = transformer.calls[0]["layout"]
+    assert layout.task == "t2va"
+    assert layout.target_video.frames == 1
+    assert layout.target_audio_frames == 2
+    assert layout.time_overrides is not None
+    assert layout.time_overrides.condition_times == ()
+    assert layout.time_overrides.target_time == FRAME_RESCALE * 24
+    # the silence placeholder stays excluded from audio supervision
+    assert trainer._audio_items_seen == 1
+    assert trainer._audio_supervised_seen == 0
+
+
+def test_one_frame_batch_requires_the_training_flag():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args()
+    trainer.handle_model_specific_args(args)
+
+    with pytest.raises(ValueError, match=r"pass --one_frame"):
+        _one_frame_process_batch(trainer, args, _one_frame_batch(), _RecordingTransformer())
+
+
+@pytest.mark.parametrize(
+    "index",
+    [None, torch.tensor(24, dtype=torch.int64), torch.tensor([24], dtype=torch.int32), torch.tensor([-1], dtype=torch.int64)],
+)
+def test_one_frame_batch_requires_a_valid_index_tensor(index):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_batch(target_index=None)
+    if index is not None:
+        batch["one_frame_target_index"] = index
+
+    with pytest.raises(ValueError, match="one_frame_target_index|nonnegative"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+def test_one_frame_batch_rejects_condition_latents():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_batch()
+    batch["latents_first"] = torch.zeros(1, 24, 1, 4, 4)
+    batch["latents_last"] = torch.zeros(1, 24, 1, 4, 4)
+
+    with pytest.raises(ValueError, match="plain T2VA"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+def test_video_batch_rejects_a_stray_one_frame_index():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(one_frame=True)
+    trainer.handle_model_specific_args(args)
+    video_latents = torch.zeros(1, 24, 2, 4, 4)
+    batch = _training_batch()
+    batch["one_frame_target_index"] = torch.tensor([0], dtype=torch.int64)
+
+    with pytest.raises(ValueError, match="video batch cannot carry one_frame_target_index"):
+        trainer.process_batch(
+            args,
+            _Accelerator(),
+            _RecordingTransformer(),
+            None,
+            batch,
+            video_latents,
+            torch.zeros_like(video_latents),
+            None,
+            torch.bfloat16,
+            torch.float32,
+            None,
+            0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"one_frame": True, "task": "fl2va"}, "requires --task t2va"),
+        ({"one_frame": True, "task": "ref2va"}, "requires --task t2va"),
+        ({"one_frame": True, "h3_teacher_matching": True}, "does not support --one_frame"),
+    ],
+)
+def test_one_frame_training_flag_validations(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        MiniMaxH3NetworkTrainer().handle_model_specific_args(_trainer_args(**overrides))
+
+
+def test_one_frame_training_records_provenance_metadata():
+    args = _trainer_args(one_frame=True)
+    metadata = MiniMaxH3NetworkTrainer().extra_metadata(args)
+    assert metadata["ss_minimax_h3_one_frame"] is True
+    assert "ss_minimax_h3_one_frame" not in MiniMaxH3NetworkTrainer().extra_metadata(_trainer_args())
+
+
+def test_one_frame_sample_normalization_parses_the_of_option():
+    args = _trainer_args(one_frame=True)
+
+    sample = _normalize_h3_sample_parameter(
+        args, {"prompt": "a lighthouse", "frame_count": 1, "one_frame": "target_index=24", "width": 64, "height": 64}
+    )
+
+    assert sample["frame_count"] == 1
+    assert sample["one_frame_target_index"] == 24
+    default = _normalize_h3_sample_parameter(args, {"prompt": "a lighthouse", "frame_count": 1})
+    assert default["one_frame_target_index"] == 0
+
+
+@pytest.mark.parametrize(
+    ("args_overrides", "sample", "message"),
+    [
+        ({"task": "fl2va"}, {"prompt": "x", "frame_count": 1, "first_frame": "a.png", "last_frame": "b.png"}, "t2va only"),
+        ({}, {"prompt": "x", "frame_count": 1, "one_frame": "target_index=0,control_index=0"}, "control_index"),
+        ({}, {"prompt": "x", "frame_count": 124, "one_frame": "target_index=24"}, r"require --f 1"),
+    ],
+)
+def test_one_frame_sample_normalization_rejects_invalid_requests(args_overrides, sample, message):
+    args = _trainer_args(**args_overrides)
+
+    with pytest.raises(ValueError, match=message):
+        _normalize_h3_sample_parameter(args, sample)
 
 
 def test_t2va_draws_no_condition_noise(monkeypatch):


### PR DESCRIPTION
## Overview

`--one_frame` on the two cache scripts and the trainer enables plain image LoRA training for MiniMax-H3: each image becomes a single-token video target (`T_lat=1`) with a constant silence audio placeholder, riding on the one-frame generation groundwork from #1054/#1055. Currently `--task t2va` only; FL2VA/Ref2VA one-frame training (editing LoRA with condition images / references) will follow in a separate PR.

## What's included

- **Latent caching**: image datasets (`image_directory` / `image_jsonl_file`) are accepted with `--one_frame`. Each cache holds the single-token target (seeded posterior, same policy as video targets), the 2-frame silence audio latent (`audio_present=0`, encoded once per run and reused — it is a constant per audio VAE), and the target's 24 fps pixel-frame index as an int64 tensor entry (`fp_1f_target_index` TOML key, default 0). The index is duplicated into the cache metadata so `--skip_existing` rebuilds on a TOML change.
- **Text caching**: image items are encoded as plain T2VA presentations of their captions. Time indices never enter the text rows, so changing `fp_1f_target_index` re-caches latents only.
- **Training**: `--one_frame` accepts F==1 latent caches; the index tensor becomes an `H3TimeOverrides` at layout-build time. The silence placeholder is excluded from audio supervision by the existing presence gating (`--video_only` recommended for image-only runs). Video batches are unaffected, so image and video datasets can mix in one run (per-batch dispatch; experimental). `--h3_teacher_matching` × `--one_frame` is rejected for now.
- **Training-time samples**: `--f 1` in a sample prompt line produces a PNG (audio is never decoded), with optional `--of target_index=N`; the `--one_frame` option parser moved to `generation_inputs` and is shared with the generation CLI.
- **Provenance**: `ss_minimax_h3_one_frame` in the LoRA metadata.

## Fixes found during smoke

- The guidance-loss uncond forward rebuilds the layout for the probe's text length; it now carries `one_frame` + `H3TimeOverrides` through (times are cursor-relative, so they transfer unchanged).
- All H3 mp4 writers were encoding at PyAV's default rate control (~1 Mbps ABR), crushing fine detail at 1 MP/24 fps and masquerading as generation artifacts. Outputs (generation, training samples, trajectory dumps) now encode at CRF 16 (measured on 1024²/24 fps line-heavy content: 1.08 Mbps default vs ~28 Mbps at CRF 16).

## Smoke results (real hardware)

Caching (keys/metadata/staleness), 300-step training runs, PNG samples, and post-train generation all passed. ~2 s/step at 1 MP with `--blocks_to_swap 48` (≈1/3 of a 124-frame video step), ~36 GB VRAM. An image-trained LoRA applied to normal video generation transfers the subject with little disruption.

One important practical finding, now documented in `docs/minimax_h3_1f.md`: **the guidance loss is effectively mandatory for one-frame training.** Without it, de-distillation drift surfaces within ~50 steps as structural degradation (wobbly lines, broken proportions — like low-CFG output), rather than the washout seen in video training; `--h3_guidance_loss_scale 4.0 --h3_guidance_loss_sigma_min 0.15` restored clean structure.

## Docs / tests

- `docs/minimax_h3_1f.md`: new training section (dataset config, commands, index semantics, the guidance-loss requirement, the recommendation to state the absence of sound in image captions); cross-linked from `docs/minimax_h3.md`.
- 17 new tests (cache contract, writer validation, collator round-trip, runtime plan, sample normalization, dataset gates, guidance-loss one-frame layout, encode bitrate regression); 527 total pass.

## Credits

The cache-pair fingerprint concept follows PR #1044 by @sdbds — thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)