### PR TITLE
Add experimental MiniMax-H3 one-frame editing LoRA training (fl2va K=1/2)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -50,7 +50,7 @@ The transformer, video VAE, packed-sequence logic, text presentation, and dual s
 
 ## Dataset Configuration
 
-T2VA and FL2VA accept ordinary video directories. FL2VA derives its first and last conditions from each selected target crop. Image datasets are supported by the experimental one-frame (image LoRA) training mode — see `docs/minimax_h3_1f.md`.
+T2VA and FL2VA accept ordinary video directories. FL2VA derives its first and last conditions from each selected target crop. Image datasets are supported by the experimental one-frame (image LoRA) training mode, including FL2VA editing/inbetween training with time-annotated control images — see `docs/minimax_h3_1f.md`.
 
 ```toml
 [general]

--- a/docs/minimax_h3_1f.md
+++ b/docs/minimax_h3_1f.md
@@ -14,7 +14,7 @@
 - Standalone `audio` references are rejected in one-frame mode (their window is defined by the target duration, which a single frame does not have); video references keep their embedded audio.
 - The released 5-15 s duration gate does not apply; `--allow_experimental_duration` is not needed.
 
-Training on one-frame targets is available for plain image LoRA (T2VA); see [One-frame training](#one-frame-training-t2va-image-lora) below. FL2VA/Ref2VA one-frame training (editing LoRA with condition images or references) is not implemented yet.
+Training on one-frame targets is available for plain image LoRA (T2VA) and for editing/inbetween LoRA with 1-2 control images (FL2VA); see [One-frame training](#one-frame-training-t2va-image-lora) and [One-frame editing training](#one-frame-editing-training-fl2va-control-images) below. Ref2VA one-frame training (reference-driven image LoRA) is not implemented yet.
 
 ## Time semantics: `--one_frame`
 
@@ -85,7 +85,7 @@ Audio-bearing video references are accepted and keep their own duration; combini
 
 ### Dataset configuration
 
-Image datasets use the standard image keys. `fp_1f_target_index` (optional, default 0) places the target on the rotary time axis, in the same 0-based 24 fps pixel-frame indices as generation's `--one_frame target_index=N`; for plain image LoRA the default is fine. Control images, `fp_1f_clean_indices`, and `multiple_target` are not supported yet.
+Image datasets use the standard image keys. `fp_1f_target_index` (optional, default 0) places the target on the rotary time axis, in the same 0-based 24 fps pixel-frame indices as generation's `--one_frame target_index=N`; for plain image LoRA the default is fine. Control images and `fp_1f_clean_indices` belong to the FL2VA editing mode (next section); `multiple_target` is not supported.
 
 ```toml
 [general]
@@ -148,3 +148,45 @@ A watercolor lighthouse at dusk. --w 1024 --h 1024 --f 1 --s 30 --d 42
 ```
 
 The LoRA metadata records `ss_minimax_h3_one_frame` for provenance. The resulting LoRA loads into generation as usual (one-frame or video).
+
+## One-frame editing training (FL2VA, control images)
+
+> [!WARNING]
+> Experimental. This trains the base model's timed-anchor pathway directly; read the index guidance below before building a dataset.
+
+With `--task fl2va`, an image dataset pairs each target image with 1-2 **time-annotated control images**: the controls become FL2VA condition latents (and `<Picture i>` visuals in the text presentation), and their positions on the rotary time axis come from the dataset config. This trains editing LoRAs (control = source image, target = edited image) and inbetween/中割り LoRAs (controls = endpoint frames, target = an intermediate frame).
+
+### Dataset configuration
+
+```toml
+[[datasets]]
+image_directory = "/data/h3/edit/targets"
+control_directory = "/data/h3/edit/sources"
+cache_directory = "/data/h3/cache-edit"
+caption_extension = ".txt"
+fp_1f_clean_indices = [0]     # control image positions (24 fps pixel-frame indices)
+fp_1f_target_index = 24       # target position — REQUIRED when controls are present
+```
+
+- `control_directory` matches controls to targets by filename (`image.png` ↔ `image.png` / `image_0.png`), or use `image_jsonl_file` with `control_path` (or `control_path_0`/`control_path_1`) per line.
+- `fp_1f_clean_indices` gives one index per control image, in packed (first, last) order: control 0 is the "first" slot, control 1 the "last" slot. With one control only the "first" slot is used; the slot name carries no time meaning of its own — only the indices do.
+- Both `fp_1f_clean_indices` and an explicit `fp_1f_target_index` are required when controls are present; there are no defaults. Controls are resized to the target's bucket resolution.
+- Time-order is unconstrained: an anchor **after** the target (`fp_1f_clean_indices = [120]`, `fp_1f_target_index = 24`) trains an L2VA-style LoRA (generate the image that precedes an end state). Note the official pipeline stretches a lone last picture to the canvas at inference while training resizes to the bucket — a minor known divergence.
+
+### Choosing indices
+
+The base model's strongest prior is **verbatim anchor copying at coinciding timestamps**: a control whose index equals the target index is reproduced almost exactly, so such a dataset trains head-on against copying — only do this when copy-at-the-anchor is the desired behavior. The recommended starting recipe for editing is `fp_1f_clean_indices = [0]`, `fp_1f_target_index = 24` (a one-second separation); inference must then use the same relative placement (`--one_frame "target_index=24,control_index=0"`). For inbetween triplets extracted from real videos, use the real frame distances: (first@0, last@N, target@αN) → `fp_1f_clean_indices = [0, N]`, `fp_1f_target_index = round(αN)`. Since the indices live in the dataset config, one α per dataset block; several blocks can share a TOML.
+
+**Captions must follow the official alignment-line formats** (I2VA/L2VA/FL2VA opening lines from the prompt-writing guide): plain captions actively suppress the base model's continuous reading of condition times, which is exactly the pathway this training relies on.
+
+### Caching and training
+
+Same commands as plain image training with `--task fl2va` instead of `--task t2va` on both cache scripts and the trainer. The latent cache additionally holds the condition latents (`latents_first`, plus `latents_last` for two controls) and the control indices as a tensor entry; the text cache embeds the bucket-resized control images in the FL2VA presentation. Changing `fp_1f_target_index` or `fp_1f_clean_indices` re-caches latents only (`--skip_existing` detects it); changing control image files re-caches both.
+
+The guidance-loss recommendation from plain image training applies unchanged. Training-time samples mirror the generation CLI: provide the condition image(s) and the placement per prompt line:
+
+```text
+Official-format caption... --w 1024 --h 1024 --f 1 --s 30 --i source.png --of target_index=24,control_index=0
+```
+
+(`--i` is the first/only condition, `--ei` the last; `control_index` takes one `;`-separated entry per provided image, and is required.)

--- a/src/musubi_tuner/dataset/cache_io.py
+++ b/src/musubi_tuner/dataset/cache_io.py
@@ -51,6 +51,11 @@ AUDIO_PRESENT_KEY = "audio_present_float32"
 #   loads tensors; the trainer converts it to a RoPE time override at layout-build time.
 ONE_FRAME_TARGET_INDEX_KEY = "one_frame_target_index_int64"
 
+# - ONE_FRAME_CONTROL_INDICES_KEY holds an int64 [K] tensor (K = 1..2) with the 24 fps
+#   pixel-frame indices of the one-frame visual conditions, in packed (first, last) order.
+#   Present only when the cache carries condition latents; same tensor-not-metadata rationale.
+ONE_FRAME_CONTROL_INDICES_KEY = "one_frame_control_indices_int64"
+
 
 def append_audio_present_entry(sd: dict[str, torch.Tensor], audio_present: bool):
     sd[AUDIO_PRESENT_KEY] = torch.tensor(1.0 if audio_present else 0.0, dtype=torch.float32)
@@ -60,6 +65,14 @@ def append_one_frame_target_index_entry(sd: dict[str, torch.Tensor], target_inde
     if target_index < 0:
         raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
     sd[ONE_FRAME_TARGET_INDEX_KEY] = torch.tensor(target_index, dtype=torch.int64)
+
+
+def append_one_frame_control_indices_entry(sd: dict[str, torch.Tensor], control_indices: list[int]):
+    if not 1 <= len(control_indices) <= 2:
+        raise ValueError(f"MiniMax-H3 one-frame control indices must have 1 or 2 entries, got {len(control_indices)}")
+    if any(index < 0 for index in control_indices):
+        raise ValueError(f"MiniMax-H3 one-frame control indices must be nonnegative, got {control_indices}")
+    sd[ONE_FRAME_CONTROL_INDICES_KEY] = torch.tensor(list(control_indices), dtype=torch.int64)
 
 
 def validate_audio_present_entry(sd: dict[str, torch.Tensor]) -> float:
@@ -564,6 +577,13 @@ def save_latent_cache_minimax_h3(
         if key == ONE_FRAME_TARGET_INDEX_KEY:
             if tensor.shape != torch.Size([]) or tensor.dtype != torch.int64 or tensor.item() < 0:
                 raise ValueError(f"MiniMax-H3 {ONE_FRAME_TARGET_INDEX_KEY} must be a nonnegative scalar int64 tensor")
+            normalized[key] = tensor.detach().cpu().contiguous()
+            continue
+        if key == ONE_FRAME_CONTROL_INDICES_KEY:
+            if tensor.ndim != 1 or not 1 <= tensor.shape[0] <= 2 or tensor.dtype != torch.int64 or bool((tensor < 0).any()):
+                raise ValueError(
+                    f"MiniMax-H3 {ONE_FRAME_CONTROL_INDICES_KEY} must be a nonnegative int64 [K] tensor with K in 1..2"
+                )
             normalized[key] = tensor.detach().cpu().contiguous()
             continue
 

--- a/src/musubi_tuner/dataset/datasources.py
+++ b/src/musubi_tuner/dataset/datasources.py
@@ -57,6 +57,14 @@ class ImageDatasource(ContentDatasource):
         """
         raise NotImplementedError
 
+    def get_control_paths(self) -> dict[str, list[str]]:
+        """
+        Returns {image_path: [control paths in index order]} for cache fingerprinting.
+        Control pixels travel through ItemInfo.control_content; this accessor exists only so
+        cache scripts can fingerprint the source files behind them.
+        """
+        return {}
+
 
 class ImageDirectoryDatasource(ImageDatasource):
     def __init__(
@@ -247,6 +255,11 @@ class ImageDirectoryDatasource(ImageDatasource):
             caption = f.read().strip()
         return image_path, caption
 
+    def get_control_paths(self) -> dict[str, list[str]]:
+        if not self.has_control:
+            return {}
+        return {image_path: list(paths) for image_path, paths in self.control_paths.items()}
+
     def __iter__(self):
         self.current_idx = 0
         return self
@@ -376,6 +389,20 @@ class ImageJsonlDatasource(ImageDatasource):
         image_path = data.get("image_path", data.get("image_path_0"))
         caption = data["caption"]
         return image_path, caption
+
+    def get_control_paths(self) -> dict[str, list[str]]:
+        if not self.has_control:
+            return {}
+        control_paths: dict[str, list[str]] = {}
+        for data in self.data:
+            image_path = data.get("image_path", data.get("image_path_0"))
+            paths = []
+            for i in range(self.control_count_per_image or 1000):  # same bound rule as get_image_data
+                if f"control_path_{i}" not in data:
+                    break
+                paths.append(data[f"control_path_{i}"])
+            control_paths[image_path] = paths
+        return control_paths
 
     def __iter__(self):
         self.current_idx = 0

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -337,9 +337,7 @@ class ImageDataset(BaseDataset):
                 )
             if fp_1f_clean_indices is not None:
                 if not 1 <= len(fp_1f_clean_indices) <= 2:
-                    raise ValueError(
-                        f"MiniMax-H3 fp_1f_clean_indices must have 1 or 2 entries, got {len(fp_1f_clean_indices)}"
-                    )
+                    raise ValueError(f"MiniMax-H3 fp_1f_clean_indices must have 1 or 2 entries, got {len(fp_1f_clean_indices)}")
                 if any(index < 0 for index in fp_1f_clean_indices):
                     raise ValueError(f"MiniMax-H3 fp_1f_clean_indices must be nonnegative, got {fp_1f_clean_indices}")
                 if fp_1f_target_index is None:

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -324,20 +324,38 @@ class ImageDataset(BaseDataset):
         self.control_resolution = control_resolution
 
         if self.architecture == ARCHITECTURE_MINIMAX_H3:
-            # one-frame (image) training v1: plain t2va targets only. Control images (fl2va
-            # conditions) and their fp_1f_clean_indices arrive with the K=1/2 editing phase.
-            if control_directory is not None or multiple_target:
-                raise ValueError("MiniMax-H3 image datasets do not support control images or multiple targets yet")
-            if fp_1f_clean_indices is not None:
+            # one-frame (image) training: t2va targets (K=0), or fl2va editing/inbetween targets
+            # with 1..2 time-annotated control images. All times are 24 fps pixel-frame indices;
+            # whether control data is present is only known after datasource construction (JSONL
+            # control_path), so control<->indices agreement is validated there.
+            if multiple_target:
+                raise ValueError("MiniMax-H3 image datasets do not support multiple targets")
+            if no_resize_control or control_resolution is not None:
                 raise ValueError(
-                    "MiniMax-H3 image datasets do not use fp_1f_clean_indices yet;"
-                    " only fp_1f_target_index (a 24 fps pixel-frame index) is supported"
+                    "MiniMax-H3 image datasets resize control images to the bucket resolution;"
+                    " no_resize_control and control_resolution are not supported"
                 )
+            if fp_1f_clean_indices is not None:
+                if not 1 <= len(fp_1f_clean_indices) <= 2:
+                    raise ValueError(
+                        f"MiniMax-H3 fp_1f_clean_indices must have 1 or 2 entries, got {len(fp_1f_clean_indices)}"
+                    )
+                if any(index < 0 for index in fp_1f_clean_indices):
+                    raise ValueError(f"MiniMax-H3 fp_1f_clean_indices must be nonnegative, got {fp_1f_clean_indices}")
+                if fp_1f_target_index is None:
+                    # no silent default: a control index coinciding with the target trains against
+                    # the base model's verbatim anchor-copy prior, so the placement must be chosen
+                    raise ValueError("MiniMax-H3 image datasets with fp_1f_clean_indices require an explicit fp_1f_target_index")
             if fp_1f_target_index is not None and fp_1f_target_index < 0:
                 raise ValueError(f"MiniMax-H3 fp_1f_target_index must be nonnegative, got {fp_1f_target_index}")
 
         control_count_per_image: Optional[int] = 1
-        if self.architecture == ARCHITECTURE_FRAMEPACK or self.architecture == ARCHITECTURE_WAN:
+        if (
+            self.architecture == ARCHITECTURE_FRAMEPACK
+            or self.architecture == ARCHITECTURE_WAN
+            or self.architecture == ARCHITECTURE_MINIMAX_H3
+        ):
+            # time-annotated control datasets: the indices define the control count
             if fp_1f_clean_indices is not None:
                 control_count_per_image = len(fp_1f_clean_indices)
             else:
@@ -370,9 +388,15 @@ class ImageDataset(BaseDataset):
         self.batch_manager = None
         self.num_train_items = 0
         self.has_control = self.datasource.has_control
-        if self.architecture == ARCHITECTURE_MINIMAX_H3 and self.has_control:
+        if self.architecture == ARCHITECTURE_MINIMAX_H3:
             # JSONL control_path entries surface only after datasource construction
-            raise ValueError("MiniMax-H3 image datasets do not support control images yet")
+            if self.has_control and self.fp_1f_clean_indices is None:
+                raise ValueError(
+                    "MiniMax-H3 image datasets with control images require fp_1f_clean_indices"
+                    " (24 fps pixel-frame indices, one per control image)"
+                )
+            if self.fp_1f_clean_indices is not None and not self.has_control:
+                raise ValueError("MiniMax-H3 fp_1f_clean_indices requires control images (control_directory or control_path)")
 
     def get_metadata(self):
         metadata = super().get_metadata()
@@ -432,6 +456,9 @@ class ImageDataset(BaseDataset):
                             bucket_reso.append(len(self.fp_1f_clean_indices))
                             bucket_reso.append(self.fp_1f_no_post)
                         bucket_reso = tuple(bucket_reso)
+                    elif self.architecture == ARCHITECTURE_MINIMAX_H3 and self.fp_1f_clean_indices is not None:
+                        # split by the control count so K=0/1/2 items never share a batch
+                        bucket_reso = (*bucket_reso, len(self.fp_1f_clean_indices))
 
                     if controls is not None:
                         item_info.control_content = controls
@@ -561,6 +588,11 @@ class ImageDataset(BaseDataset):
                     bucket_reso.append(len(self.fp_1f_clean_indices))
                     bucket_reso.append(self.fp_1f_no_post)
                 bucket_reso = tuple(bucket_reso)
+            elif self.architecture == ARCHITECTURE_MINIMAX_H3 and self.fp_1f_clean_indices is not None:
+                # split by the control count so K=0/1/2 items never share a batch (K is uniform per
+                # dataset, so the dataset-level setting is authoritative; a stale cache with the
+                # wrong condition keys fails in the trainer with a re-cache hint)
+                bucket_reso = (*bucket_reso, len(self.fp_1f_clean_indices))
             # Split the bucket by control latents so that every item in a batch has the same number of
             # control images AND matching per-control shapes. The collator stacks latents_control_{i}
             # across the batch (see BucketBatchManager.__getitem__), so a count or shape mismatch produces

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -25,6 +25,7 @@ from musubi_tuner.dataset.audio_utils import decode_audio as decode_audio_wavefo
 from musubi_tuner.dataset.audio_utils import slice_audio_window
 from musubi_tuner.dataset.cache_io import (
     append_audio_present_entry,
+    append_one_frame_control_indices_entry,
     append_one_frame_target_index_entry,
     save_latent_cache_minimax_h3,
 )
@@ -272,6 +273,7 @@ def build_latent_metadata(
     audio_vae_fingerprint: str,
     media_fingerprints: Mapping[Path, str],
     one_frame_target_index: int | None = None,
+    one_frame_control_indices: Sequence[int] | None = None,
 ) -> dict[str, str]:
     metadata = {
         "task": task,
@@ -283,10 +285,12 @@ def build_latent_metadata(
         "media_fingerprints": _media_fingerprint_metadata(media_fingerprints),
     }
     if one_frame_target_index is not None:
-        # duplicated from the tensor entry so --skip_existing rebuilds when the dataset's
-        # fp_1f_target_index changes
+        # duplicated from the tensor entries so --skip_existing rebuilds when the dataset's
+        # fp_1f_target_index / fp_1f_clean_indices change (runtime reads the tensors)
         metadata["one_frame"] = "1"
         metadata["one_frame_target_index"] = str(one_frame_target_index)
+        if one_frame_control_indices is not None:
+            metadata["one_frame_control_indices"] = ";".join(str(index) for index in one_frame_control_indices)
     return metadata
 
 
@@ -429,11 +433,19 @@ def build_one_frame_latent_tensors(
     video_vae_fingerprint: str,
     audio_vae_fingerprint: str,
     media_fingerprints: Mapping[Path, str],
+    control_frames: Sequence[torch.Tensor | np.ndarray] | None = None,
+    control_indices: Sequence[int] | None = None,
 ) -> H3LatentCachePayload:
     """One-frame (image) target: a single video latent token, the silence audio placeholder,
-    and the target's 24 fps pixel-frame index as a tensor entry for the trainer's RoPE override."""
+    and the target's 24 fps pixel-frame index as a tensor entry for the trainer's RoPE override.
+
+    With control_frames/control_indices (K=1..2, fl2va editing/inbetween), each bucket-resized
+    control image becomes a condition latent under the packed (first, last) role keys, and the
+    indices ride along as an int64 tensor for the trainer's condition-time overrides."""
     if target_index < 0:
         raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
+    if (control_frames is None) != (control_indices is None):
+        raise ValueError("MiniMax-H3 one-frame control frames and control indices must be provided together")
     image_frames = torch.as_tensor(image_frames)
     if image_frames.ndim == 3:
         image_frames = image_frames.unsqueeze(0)
@@ -447,6 +459,14 @@ def build_one_frame_latent_tensors(
             f"MiniMax-H3 one-frame silence latent must be [32,2,{ONE_FRAME_AUDIO_LATENT_FRAMES}],"
             f" got {tuple(silence_audio_latent.shape)}"
         )
+    if control_frames is not None:
+        if not 1 <= len(control_frames) <= 2:
+            raise ValueError(f"MiniMax-H3 one-frame caching accepts 1 or 2 control images, got {len(control_frames)}")
+        if len(control_frames) != len(control_indices):
+            raise ValueError(
+                f"MiniMax-H3 one-frame control count {len(control_frames)} does not match"
+                f" {len(control_indices)} control indices"
+            )
 
     target_pixels = _prepare_pixels(image_frames)
     canonical_item_key = f"{item_key}#1f"
@@ -458,17 +478,32 @@ def build_one_frame_latent_tensors(
         _visual_key("", target_video): target_video,
         _audio_key("", silence_audio_latent): silence_audio_latent,
     }
+    if control_frames is not None:
+        for role, control in zip(("first", "last"), control_frames):
+            control = torch.as_tensor(control)
+            if control.ndim != 3:
+                raise ValueError(f"MiniMax-H3 one-frame control must be [H,W,C], got {tuple(control.shape)}")
+            if tuple(control.shape[:2]) != (int(height), int(width)):
+                raise ValueError(
+                    f"MiniMax-H3 one-frame control size {control.shape[1]}x{control.shape[0]} does not match"
+                    f" the target {width}x{height} (controls are resized to the bucket resolution)"
+                )
+            condition = _encode_condition_video(video_vae, _prepare_pixels(control.unsqueeze(0)))[0]
+            tensors[_visual_key(role, condition)] = condition
     append_audio_present_entry(tensors, False)
     append_one_frame_target_index_entry(tensors, target_index)
+    if control_indices is not None:
+        append_one_frame_control_indices_entry(tensors, list(control_indices))
 
     metadata = build_latent_metadata(
-        task="t2va",
+        task="t2va" if control_frames is None else "fl2va",
         crop_start_frame=0,
         cache_seed=cache_seed,
         video_vae_fingerprint=video_vae_fingerprint,
         audio_vae_fingerprint=audio_vae_fingerprint,
         media_fingerprints=media_fingerprints,
         one_frame_target_index=target_index,
+        one_frame_control_indices=control_indices,
     )
     return H3LatentCachePayload(tensors=tensors, metadata=metadata)
 
@@ -499,8 +534,10 @@ def record_media_paths(record: H3Record) -> set[Path]:
     return paths
 
 
-def validate_h3_dataset(dataset: VideoDataset) -> None:
-    if dataset.control_directory is not None or dataset.has_control:
+def validate_h3_dataset(dataset: VideoDataset | ImageDataset) -> None:
+    # image datasets use control images as time-annotated fl2va conditions (validated in the
+    # dataset layer); the shared control-VIDEO fields stay unsupported
+    if isinstance(dataset, VideoDataset) and (dataset.control_directory is not None or dataset.has_control):
         raise ValueError("MiniMax-H3 does not use the shared control-video fields")
 
 
@@ -546,7 +583,8 @@ def setup_parser() -> argparse.ArgumentParser:
         "--one_frame",
         action="store_true",
         help="experimental one-frame (image) training caches: accept image datasets whose items become single-token"
-        " video targets with a silence audio placeholder (currently --task t2va only)",
+        " video targets with a silence audio placeholder. --task t2va caches plain image targets; --task fl2va"
+        " additionally encodes 1-2 control images as time-annotated conditions (fp_1f_clean_indices)",
     )
     parser.add_argument("--cache_seed", type=int, default=0, help="seed used for reproducible target-video posterior samples")
     parser.add_argument(
@@ -570,12 +608,13 @@ def main() -> None:
     blueprint = blueprint_generator.generate(user_config, args, architecture=ARCHITECTURE_MINIMAX_H3)
     dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group, audio_spec=H3_AUDIO_SPEC)
     datasets = dataset_group.datasets
-    if args.one_frame and args.task != "t2va":
-        raise ValueError("MiniMax-H3 one-frame caching currently supports --task t2va only")
+    if args.one_frame and args.task == "ref2va":
+        raise ValueError("MiniMax-H3 one-frame caching supports --task t2va and fl2va only")
 
     records_by_dir: dict[str, list[H3Record]] = {}
     audio_sources_by_dir: dict[str, list] = {}
     image_dirs: set[str] = set()
+    control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
     for dataset_index, dataset in enumerate(datasets):
         validate_h3_dataset(dataset)
         if int(dataset.batch_size) != 1:
@@ -589,7 +628,15 @@ def main() -> None:
         if isinstance(dataset, ImageDataset):
             if not args.one_frame:
                 raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
+            if dataset.has_control and args.task != "fl2va":
+                raise ValueError("MiniMax-H3 image datasets with control images require --task fl2va")
+            if not dataset.has_control and args.task != "t2va":
+                raise ValueError(
+                    "MiniMax-H3 --task fl2va requires image datasets with control images"
+                    " (plain image datasets cache with --task t2va)"
+                )
             image_dirs.add(key)
+            control_paths_by_dir[key] = dataset.datasource.get_control_paths()
             continue
         if not isinstance(dataset, VideoDataset):
             raise ValueError("MiniMax-H3 latent caching accepts only image and video datasets")
@@ -642,20 +689,35 @@ def main() -> None:
     presence_counts: Counter[bool] = Counter()
     one_frame_item_count = 0
 
-    def encode_one_frame(item: ItemInfo) -> None:
+    def encode_one_frame(item: ItemInfo, cache_dir_key: str) -> None:
         nonlocal one_frame_item_count
         one_frame_item_count += 1
         image_path = Path(item.item_key).resolve()
         image_fingerprints = {image_path: media_fingerprints.setdefault(image_path, fingerprint_file(image_path))}
+        control_frames = None
+        control_indices = None
+        if args.task == "fl2va":
+            control_frames = item.control_content
+            control_indices = item.fp_1f_clean_indices
+            if not control_indices or control_frames is None or len(control_frames) != len(control_indices):
+                raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control images: {item.item_key}")
+            control_indices = [int(index) for index in control_indices]
+            control_paths = control_paths_by_dir.get(cache_dir_key, {}).get(item.item_key)
+            if control_paths is None or len(control_paths) != len(control_indices):
+                raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control paths: {item.item_key}")
+            for control_path in control_paths:
+                resolved = Path(control_path).resolve()
+                image_fingerprints[resolved] = media_fingerprints.setdefault(resolved, fingerprint_file(resolved))
         target_index = 0 if item.fp_1f_target_index is None else int(item.fp_1f_target_index)
         expected_metadata = build_latent_metadata(
-            task="t2va",
+            task=args.task,
             crop_start_frame=0,
             cache_seed=args.cache_seed,
             video_vae_fingerprint=video_vae_fingerprint,
             audio_vae_fingerprint=audio_vae_fingerprint,
             media_fingerprints=image_fingerprints,
             one_frame_target_index=target_index,
+            one_frame_control_indices=control_indices,
         )
         if skip_matching_cache and Path(item.latent_cache_path).is_file():
             if cache_metadata_matches(item.latent_cache_path, expected_metadata):
@@ -672,6 +734,8 @@ def main() -> None:
             video_vae_fingerprint=video_vae_fingerprint,
             audio_vae_fingerprint=audio_vae_fingerprint,
             media_fingerprints=image_fingerprints,
+            control_frames=control_frames,
+            control_indices=control_indices,
         )
         logger.info("Saving MiniMax-H3 one-frame latent cache for %s to %s", item.item_key, item.latent_cache_path)
         save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
@@ -680,7 +744,7 @@ def main() -> None:
         for item in batch:
             key = item_cache_dir_key(item)
             if key in image_dirs:
-                encode_one_frame(item)
+                encode_one_frame(item, key)
                 continue
             datasource_index, crop_start = item_record_inputs(item)
             record = records_by_dir[key][datasource_index]

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -464,8 +464,7 @@ def build_one_frame_latent_tensors(
             raise ValueError(f"MiniMax-H3 one-frame caching accepts 1 or 2 control images, got {len(control_frames)}")
         if len(control_frames) != len(control_indices):
             raise ValueError(
-                f"MiniMax-H3 one-frame control count {len(control_frames)} does not match"
-                f" {len(control_indices)} control indices"
+                f"MiniMax-H3 one-frame control count {len(control_frames)} does not match {len(control_indices)} control indices"
             )
 
     target_pixels = _prepare_pixels(image_frames)

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -202,8 +202,8 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--one_frame",
         action="store_true",
-        help="experimental one-frame (image) training caches: accept image datasets, whose captions are encoded"
-        " as plain T2VA presentations (currently --task t2va only)",
+        help="experimental one-frame (image) training caches: accept image datasets. --task t2va encodes plain"
+        " caption presentations; --task fl2va embeds the bucket-resized control images as <Picture i> visuals",
     )
     parser.add_argument(
         "--teacher_conditions",
@@ -242,8 +242,8 @@ def main() -> None:
         if args.one_frame:
             raise ValueError("--teacher_conditions does not support --one_frame yet")
         teacher_conditions = normalize_teacher_conditions(args.teacher_conditions)
-    if args.one_frame and args.task != "t2va":
-        raise ValueError("MiniMax-H3 one-frame caching currently supports --task t2va only")
+    if args.one_frame and args.task == "ref2va":
+        raise ValueError("MiniMax-H3 one-frame caching supports --task t2va and fl2va only")
 
     blueprint_generator = BlueprintGenerator(ConfigSanitizer())
     logger.info("Loading dataset config from %s", args.dataset_config)
@@ -255,12 +255,22 @@ def main() -> None:
     decoder = PyAVH3MediaDecoder()
     records_by_dir = {}
     image_dirs: set[str] = set()
+    control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
     for dataset in datasets:
         validate_h3_dataset(dataset)
         if isinstance(dataset, ImageDataset):
             if not args.one_frame:
                 raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
-            image_dirs.add(dataset_cache_dir_key(dataset.cache_directory))
+            if dataset.has_control and args.task != "fl2va":
+                raise ValueError("MiniMax-H3 image datasets with control images require --task fl2va")
+            if not dataset.has_control and args.task != "t2va":
+                raise ValueError(
+                    "MiniMax-H3 --task fl2va requires image datasets with control images"
+                    " (plain image datasets cache with --task t2va)"
+                )
+            key = dataset_cache_dir_key(dataset.cache_directory)
+            image_dirs.add(key)
+            control_paths_by_dir[key] = dataset.datasource.get_control_paths()
             continue
         if not isinstance(dataset, VideoDataset):
             raise ValueError("MiniMax-H3 text caching accepts only image and video datasets")
@@ -276,6 +286,13 @@ def main() -> None:
         for record in records
         for path in _text_media_paths(record, args.task, teacher_conditions)
     }
+    # one-frame fl2va presentations embed the control images, so their files join the identity
+    text_paths.update(
+        Path(path).resolve()
+        for control_paths in control_paths_by_dir.values()
+        for paths in control_paths.values()
+        for path in paths
+    )
     media_fingerprints = {path: fingerprint_file(path) for path in text_paths}
 
     logger.info("Loading MiniMax-H3 Qwen3-VL processor")
@@ -321,8 +338,9 @@ def main() -> None:
         for item in batch:
             cache_dir_key = dataset_cache_dir_key(str(Path(item.text_encoder_output_cache_path).parent))
             if cache_dir_key in image_dirs:
-                # one-frame image item: a plain T2VA presentation of the caption; the target
-                # time index lives in the latent cache, never in the text rows
+                # one-frame image item: the caption as a T2VA presentation, or an FL2VA
+                # presentation embedding the bucket-resized control images; all time indices
+                # live in the latent cache, never in the text rows
                 record = H3Record(
                     video_path=Path(item.item_key).resolve(),
                     caption=item.caption,
@@ -332,7 +350,22 @@ def main() -> None:
                 crop_start = 0
                 frame_count = 1
                 visuals = {}
-                presentation = build_presentation(record, "t2va", visuals)
+                record_media_fingerprints = {}
+                if args.task == "fl2va":
+                    controls = item.control_content
+                    control_indices = item.fp_1f_clean_indices
+                    if not control_indices or controls is None or len(controls) != len(control_indices):
+                        raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control images: {item.item_key}")
+                    for role, control in zip(("first", "last"), controls):
+                        visuals[role] = H3TextVisual(torch.as_tensor(control).unsqueeze(0))
+                    control_paths = control_paths_by_dir.get(cache_dir_key, {}).get(item.item_key)
+                    if control_paths is None or len(control_paths) != len(control_indices):
+                        raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control paths: {item.item_key}")
+                    record_media_fingerprints = {
+                        Path(control_path).resolve(): media_fingerprints[Path(control_path).resolve()]
+                        for control_path in control_paths
+                    }
+                presentation = build_presentation(record, args.task, visuals)
             else:
                 records = records_by_dir[cache_dir_key]
                 datasource_index, crop_start = item_record_inputs(item)
@@ -340,7 +373,7 @@ def main() -> None:
                 frame_count = item.frame_count
                 visuals = _build_visuals(record, args.task, item, decoder, decoded_reference_cache)
                 presentation = build_presentation(record, args.task, visuals)
-            record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
+                record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
             presentation_identity = presentation_fingerprint(
                 presentation,
                 record_media_fingerprints,

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -162,8 +162,11 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
             provided_frames = int(bool(args.first_frame)) + int(bool(args.last_frame))
             # a missing-frames error is raised by the task input checks below
             if provided_frames and (control_indices is None or len(control_indices) != provided_frames):
+                given = 0 if control_indices is None else len(control_indices)
+                provided = " and ".join(label for label in ("first_frame", "last_frame") if getattr(args, label))
                 raise ValueError(
-                    "MiniMax-H3 one-frame FL2VA requires --one_frame control_index with one entry per provided frame, "
+                    "MiniMax-H3 one-frame FL2VA requires --one_frame control_index with one entry per provided frame:"
+                    f" got {given} control_index entries for {provided_frames} condition frames ({provided}), "
                     'e.g. --one_frame "target_index=24,control_index=0" for a first frame at index 0'
                 )
         elif control_indices is not None:
@@ -1053,12 +1056,15 @@ def process_from_file(args: argparse.Namespace, device: torch.device) -> None:
     with open(args.from_file, "r", encoding="utf-8") as handle:
         lines = handle.readlines()
     items: list[_BatchItem] = []
-    for line in lines:
+    for line_number, line in enumerate(lines, start=1):
         line = line.strip()
         if not line or line.startswith("#"):
             continue
-        prompt_args = apply_overrides(args, parse_prompt_line(line))
-        validate_prompt_args(prompt_args, directory_output=True)
+        try:
+            prompt_args = apply_overrides(args, parse_prompt_line(line))
+            validate_prompt_args(prompt_args, directory_output=True)
+        except ValueError as error:
+            raise ValueError(f"MiniMax-H3 --from_file line {line_number} is invalid: {error}") from error
         items.append(_BatchItem(index=len(items), args=prompt_args))
     if not items:
         logger.warning("MiniMax-H3 --from_file %s contains no prompts", args.from_file)

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -107,13 +107,14 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
     one_frame_spec = sample.get("one_frame")
     if requested_frame_count == 1:
         # experimental one-frame (image) sample: single-token target, no duration semantics
-        if args.task != "t2va":
-            raise ValueError("MiniMax-H3 one-frame training samples (--f 1) currently support --task t2va only")
+        if args.task not in {"t2va", "fl2va"}:
+            raise ValueError("MiniMax-H3 one-frame training samples (--f 1) support --task t2va and fl2va only")
         frame_count = 1
         target_index, control_indices = parse_one_frame_options(one_frame_spec) if one_frame_spec else (0, None)
-        if control_indices is not None:
+        if args.task == "t2va" and control_indices is not None:
             raise ValueError("MiniMax-H3 T2VA one-frame training sample does not accept control_index")
         sample["one_frame_target_index"] = target_index
+        sample["one_frame_control_indices"] = control_indices
     else:
         if one_frame_spec is not None:
             raise ValueError("MiniMax-H3 sample --of options require --f 1")
@@ -159,8 +160,24 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
             raise ValueError("MiniMax-H3 FL2VA training sample requires a prompt")
         if reference_jsonl or ref_specs:
             raise ValueError("MiniMax-H3 FL2VA training sample does not accept reference_jsonl or --ref")
-        _require_sampling_path(first_frame, "first_frame")
-        _require_sampling_path(last_frame, "last_frame")
+        if frame_count == 1:
+            # mirror the generation rules: any subset of first/last, one control_index per
+            # provided frame (mandatory — the placement is the training signal)
+            if not first_frame and not last_frame:
+                raise ValueError("MiniMax-H3 one-frame FL2VA training sample requires first_frame and/or last_frame")
+            provided_frames = int(bool(first_frame)) + int(bool(last_frame))
+            control_indices = sample.get("one_frame_control_indices")
+            if control_indices is None or len(control_indices) != provided_frames:
+                raise ValueError(
+                    "MiniMax-H3 one-frame FL2VA training sample requires --of control_index with one entry"
+                    " per provided frame, e.g. --of target_index=24,control_index=0"
+                )
+            for label, value in (("first_frame", first_frame), ("last_frame", last_frame)):
+                if value:
+                    _require_sampling_path(value, label)
+        else:
+            _require_sampling_path(first_frame, "first_frame")
+            _require_sampling_path(last_frame, "last_frame")
     else:
         if first_frame or last_frame:
             raise ValueError("MiniMax-H3 Ref2VA training sample does not accept first/last frames")
@@ -241,22 +258,51 @@ def _stack_single_text_rows(value, label: str) -> torch.Tensor:
     return value[0].unsqueeze(0)
 
 
+_coinciding_one_frame_indices_warned = False
+
+
+def _warn_once_coinciding_indices(control_indices: list[int], target_index: int) -> None:
+    global _coinciding_one_frame_indices_warned
+    if _coinciding_one_frame_indices_warned or target_index not in control_indices:
+        return
+    _coinciding_one_frame_indices_warned = True
+    logger.warning(
+        "MiniMax-H3 one-frame FL2VA data places a control at the target index (%d): the base model's"
+        " prior at coinciding timestamps is verbatim anchor copying, so make sure that is the intended"
+        " training signal (see docs/minimax_h3_1f.md)",
+        target_index,
+    )
+
+
 def _collect_fl_conditions(
     batch: dict[str, Any],
     batch_size: int,
     visual_conditions: list[torch.Tensor],
     condition_geometries: list[H3VideoGeometry],
-) -> None:
-    if "latents_first" not in batch or "latents_last" not in batch:
-        raise ValueError("MiniMax-H3 FL2VA batch requires both first and last conditions")
-    for role in ("latents_first", "latents_last"):
-        tensor = batch[role]
+    *,
+    allow_single_first: bool = False,
+) -> tuple[str, ...]:
+    roles = tuple(role for role in ("first", "last") if f"latents_{role}" in batch)
+    if not allow_single_first:
+        if roles != ("first", "last"):
+            raise ValueError("MiniMax-H3 FL2VA batch requires both first and last conditions")
+    elif roles not in {("first",), ("first", "last")}:
+        # a single one-frame condition is always packed as latents_first; its temporal
+        # position is carried by one_frame_control_indices, not the role name
+        raise ValueError(
+            "MiniMax-H3 one-frame FL2VA batch requires latents_first (plus optional latents_last);"
+            " re-run minimax_h3_cache_latents.py --one_frame --task fl2va"
+        )
+    for role in roles:
+        key = f"latents_{role}"
+        tensor = batch[key]
         if not isinstance(tensor, torch.Tensor) or tensor.ndim != 5 or tensor.shape[1] != 24:
-            raise ValueError(f"MiniMax-H3 {role} must be [B,24,F,H,W]")
+            raise ValueError(f"MiniMax-H3 {key} must be [B,24,F,H,W]")
         if tensor.shape[0] != batch_size:
-            raise ValueError(f"MiniMax-H3 {role} batch size does not match the targets")
+            raise ValueError(f"MiniMax-H3 {key} batch size does not match the targets")
         visual_conditions.append(tensor)
         condition_geometries.append(H3VideoGeometry(*tensor.shape[2:]))
+    return roles
 
 
 def _validate_teacher_text_rows(
@@ -323,12 +369,13 @@ def _runtime_batch_plan(
 
     is_one_frame_batch = video_latents.shape[2] == 1
     one_frame_index_value = batch.get("one_frame_target_index")
+    one_frame_control_value = batch.get("one_frame_control_indices")
     time_overrides = None
     if is_one_frame_batch:
         if not one_frame:
             raise ValueError("MiniMax-H3 batch carries a one-frame latent cache; pass --one_frame to train on image targets")
-        if has_fl_condition or reference_roles or teacher_conditions is not None:
-            raise ValueError("MiniMax-H3 one-frame training currently supports plain T2VA caches only")
+        if reference_roles or teacher_conditions is not None:
+            raise ValueError("MiniMax-H3 one-frame training currently supports plain T2VA and FL2VA caches only")
         if (
             not isinstance(one_frame_index_value, torch.Tensor)
             or one_frame_index_value.shape != (batch_size,)
@@ -341,14 +388,34 @@ def _runtime_batch_plan(
         target_index = int(one_frame_index_value.item())
         if target_index < 0:
             raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
-        time_overrides = H3TimeOverrides(condition_times=(), target_time=FRAME_RESCALE * target_index)
-    elif one_frame_index_value is not None:
-        raise ValueError("MiniMax-H3 video batch cannot carry one_frame_target_index; re-run latent caching")
+        condition_times: tuple[float, ...] = ()
+        if has_fl_condition:
+            if (
+                not isinstance(one_frame_control_value, torch.Tensor)
+                or one_frame_control_value.ndim != 2
+                or one_frame_control_value.shape[0] != batch_size
+                or one_frame_control_value.dtype != torch.int64
+            ):
+                raise ValueError(
+                    "MiniMax-H3 one-frame FL2VA batch requires an int64 one_frame_control_indices tensor;"
+                    " re-run minimax_h3_cache_latents.py --one_frame --task fl2va"
+                )
+            control_indices = [int(index) for index in one_frame_control_value[0].tolist()]
+            if any(index < 0 for index in control_indices):
+                raise ValueError(f"MiniMax-H3 one-frame control indices must be nonnegative, got {control_indices}")
+            _warn_once_coinciding_indices(control_indices, target_index)
+            condition_times = tuple(FRAME_RESCALE * index for index in control_indices)
+        elif one_frame_control_value is not None:
+            raise ValueError("MiniMax-H3 one-frame T2VA batch cannot carry one_frame_control_indices; re-run latent caching")
+        time_overrides = H3TimeOverrides(condition_times=condition_times, target_time=FRAME_RESCALE * target_index)
+    elif one_frame_index_value is not None or one_frame_control_value is not None:
+        raise ValueError("MiniMax-H3 video batch cannot carry one-frame index tensors; re-run latent caching")
 
     visual_conditions = []
     audio_conditions = []
     condition_geometries = []
     references = []
+    fl_condition_roles: tuple[str, ...] | None = None
     teacher_layout = None
     teacher_hidden_states = None
     teacher_token_tags = None
@@ -422,7 +489,9 @@ def _runtime_batch_plan(
         )
     elif has_fl_condition:
         task = "fl2va"
-        _collect_fl_conditions(batch, batch_size, visual_conditions, condition_geometries)
+        fl_condition_roles = _collect_fl_conditions(
+            batch, batch_size, visual_conditions, condition_geometries, allow_single_first=is_one_frame_batch
+        )
     elif reference_roles:
         task = "ref2va"
         if set(reference_roles) != set(range(len(reference_roles))):
@@ -462,6 +531,11 @@ def _runtime_batch_plan(
     else:
         task = "t2va"
 
+    if is_one_frame_batch and task == "fl2va" and len(condition_geometries) != len(time_overrides.condition_times):
+        raise ValueError(
+            f"MiniMax-H3 one-frame FL2VA batch has {len(condition_geometries)} condition latents for"
+            f" {len(time_overrides.condition_times)} control indices; re-run latent caching"
+        )
     layout = build_h3_layout(
         task=task,
         text_length=hidden_states.shape[1],
@@ -470,6 +544,7 @@ def _runtime_batch_plan(
         visual_conditions=tuple(condition_geometries),
         references=tuple(references),
         one_frame=is_one_frame_batch,
+        condition_roles=fl_condition_roles if is_one_frame_batch else None,
         time_overrides=time_overrides,
     )
     return _H3RuntimeBatch(
@@ -645,8 +720,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         if getattr(args, "task", None) not in {"t2va", "fl2va", "ref2va"}:
             raise ValueError("MiniMax-H3 requires --task t2va, fl2va, or ref2va")
         if getattr(args, "one_frame", False):
-            if args.task != "t2va":
-                raise ValueError("MiniMax-H3 one-frame training currently requires --task t2va")
+            if args.task not in {"t2va", "fl2va"}:
+                raise ValueError("MiniMax-H3 one-frame training requires --task t2va or fl2va")
             if getattr(args, "h3_teacher_matching", False):
                 raise ValueError("--h3_teacher_matching does not support --one_frame yet")
             logger.info(
@@ -919,6 +994,22 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 else ()
             )
             one_frame_sample = parameter["frame_count"] == 1
+            condition_roles = None
+            time_overrides = None
+            if one_frame_sample:
+                # roles follow the provided frames (mirrors the generation CLI); condition
+                # times come from --of control_index, one per provided frame
+                control_indices = parameter.get("one_frame_control_indices")
+                if args.task == "fl2va":
+                    condition_roles = tuple(
+                        role for role, key in (("first", "first_frame"), ("last", "last_frame")) if parameter.get(key)
+                    )
+                time_overrides = H3TimeOverrides(
+                    condition_times=(
+                        tuple(FRAME_RESCALE * index for index in control_indices) if control_indices is not None else ()
+                    ),
+                    target_time=FRAME_RESCALE * parameter["one_frame_target_index"],
+                )
             parameter["h3_layout"] = build_h3_layout(
                 task=args.task,
                 text_length=parameter["h3_text_hidden_states"].shape[1],
@@ -933,11 +1024,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 visual_conditions=parameter["_h3_visual_geometries"],
                 references=references,
                 one_frame=one_frame_sample,
-                time_overrides=(
-                    H3TimeOverrides(condition_times=(), target_time=FRAME_RESCALE * parameter["one_frame_target_index"])
-                    if one_frame_sample
-                    else None
-                ),
+                condition_roles=condition_roles,
+                time_overrides=time_overrides,
             )
             layout = parameter["h3_layout"]
             logger.info(
@@ -1372,7 +1460,12 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 f" the text cache width {runtime.text_hidden_states.shape[2]}"
             )
         # the probe swaps only the text rows; the one-frame times stay valid because they
-        # are relative to the target-block cursor, which moves with the text length
+        # are relative to the target-block cursor, which moves with the text length. The
+        # condition roles are recovered from the segments so a one-frame FL2VA layout with a
+        # single condition rebuilds identically (roles are required for K=1).
+        uncond_condition_roles = tuple(
+            segment.role for segment in runtime.layout.segments if segment.kind == "visual_condition"
+        )
         uncond_layout = build_h3_layout(
             task=runtime.layout.task,
             text_length=uncond_hidden.shape[0],
@@ -1381,6 +1474,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             visual_conditions=runtime.layout.visual_conditions,
             references=runtime.layout.references,
             one_frame=runtime.layout.target_video.frames == ONE_FRAME_VIDEO_LATENT_FRAMES,
+            condition_roles=uncond_condition_roles or None,
             time_overrides=runtime.layout.time_overrides,
         )
         autocast = accelerator.autocast if hasattr(accelerator, "autocast") else nullcontext
@@ -1683,8 +1777,9 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         "--one_frame",
         action="store_true",
         help="experimental one-frame (image) training: accept single-token latent caches written by"
-        " minimax_h3_cache_latents.py --one_frame (currently --task t2va only; video batches are unaffected,"
-        " so image and video datasets can mix in one run)",
+        " minimax_h3_cache_latents.py --one_frame — plain image targets (t2va) or editing/inbetween targets"
+        " with 1-2 time-annotated control images (fl2va). Video batches are unaffected, so image and video"
+        " datasets can mix in one run",
     )
     add_audio_train_args(parser)
     parser.add_argument("--h3_shift_video", type=float, default=12.0, help="MiniMax-H3 target-video flow shift")

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -1463,9 +1463,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         # are relative to the target-block cursor, which moves with the text length. The
         # condition roles are recovered from the segments so a one-frame FL2VA layout with a
         # single condition rebuilds identically (roles are required for K=1).
-        uncond_condition_roles = tuple(
-            segment.role for segment in runtime.layout.segments if segment.kind == "visual_condition"
-        )
+        uncond_condition_roles = tuple(segment.role for segment in runtime.layout.segments if segment.kind == "visual_condition")
         uncond_layout = build_h3_layout(
             task=runtime.layout.task,
             text_length=uncond_hidden.shape[0],

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -34,6 +34,7 @@ from musubi_tuner.minimax_h3_cache_latents import (
 from musubi_tuner.dataset.bucket import BucketBatchManager
 from musubi_tuner.dataset.cache_io import (
     AUDIO_PRESENT_KEY,
+    ONE_FRAME_CONTROL_INDICES_KEY,
     ONE_FRAME_TARGET_INDEX_KEY,
     save_latent_cache_minimax_h3,
     save_text_encoder_output_cache_minimax_h3,
@@ -1038,3 +1039,132 @@ def test_h3_latent_writer_rejects_invalid_one_frame_target_indices(tmp_path: Pat
     for index in invalid:
         with pytest.raises(ValueError, match=ONE_FRAME_TARGET_INDEX_KEY):
             save_latent_cache_minimax_h3(item, {**base, ONE_FRAME_TARGET_INDEX_KEY: index}, {"task": "t2va"})
+
+
+@pytest.mark.parametrize("control_indices", [[0], [0, 48]])
+def test_build_one_frame_latents_pack_controls_and_their_indices(tmp_path: Path, control_indices: list[int]):
+    image_path = _touch(tmp_path / "target.png")
+    video_vae = _FakeH3VideoVAE()
+    controls = [torch.full((64, 64, 3), 32 * (index + 1), dtype=torch.uint8) for index in range(len(control_indices))]
+
+    payload = build_one_frame_latent_tensors(
+        image_frames=torch.zeros(64, 64, 3, dtype=torch.uint8),
+        target_index=24,
+        video_vae=video_vae,
+        silence_audio_latent=torch.zeros(32, 2, 2),
+        cache_seed=123,
+        item_key=str(image_path),
+        video_vae_fingerprint="video-fingerprint",
+        audio_vae_fingerprint="audio-fingerprint",
+        media_fingerprints={image_path: "target-image"},
+        control_frames=controls,
+        control_indices=control_indices,
+    )
+
+    expected_roles = ("first", "last")[: len(control_indices)]
+    assert set(payload.tensors) == {
+        "latents_1x4x4_float32",
+        "latents_audio_32x2x2_float32",
+        AUDIO_PRESENT_KEY,
+        ONE_FRAME_TARGET_INDEX_KEY,
+        ONE_FRAME_CONTROL_INDICES_KEY,
+        *(f"latents_{role}_1x4x4_float32" for role in expected_roles),
+    }
+    indices = payload.tensors[ONE_FRAME_CONTROL_INDICES_KEY]
+    assert indices.dtype == torch.int64 and indices.tolist() == control_indices
+    # target encode + one condition encode per control
+    assert [call.shape for call in video_vae.calls] == [(1, 3, 1, 64, 64)] * (1 + len(control_indices))
+    assert payload.metadata["task"] == "fl2va"
+    assert payload.metadata["one_frame"] == "1"
+    assert payload.metadata["one_frame_control_indices"] == ";".join(str(index) for index in control_indices)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)]}, "together"),
+        ({"control_indices": [0]}, "together"),
+        (
+            {"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)] * 3, "control_indices": [0, 1, 2]},
+            "1 or 2 control images",
+        ),
+        (
+            {"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)], "control_indices": [0, 48]},
+            "does not match",
+        ),
+        (
+            {"control_frames": [torch.zeros(32, 32, 3, dtype=torch.uint8)], "control_indices": [0]},
+            "does not match the target",
+        ),
+        (
+            {"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)], "control_indices": [-1]},
+            "nonnegative",
+        ),
+    ],
+)
+def test_build_one_frame_latents_reject_invalid_controls(tmp_path: Path, overrides: dict, message: str):
+    image_path = _touch(tmp_path / "target.png")
+    inputs = dict(
+        image_frames=torch.zeros(64, 64, 3, dtype=torch.uint8),
+        target_index=24,
+        video_vae=_FakeH3VideoVAE(),
+        silence_audio_latent=torch.zeros(32, 2, 2),
+        cache_seed=0,
+        item_key=str(image_path),
+        video_vae_fingerprint="video-fingerprint",
+        audio_vae_fingerprint="audio-fingerprint",
+        media_fingerprints={image_path: "target-image"},
+    )
+    inputs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        build_one_frame_latent_tensors(**inputs)
+
+
+def test_one_frame_control_cache_keys_round_trip_through_the_bucket_collator(tmp_path: Path):
+    item = ItemInfo("edit", "an editing caption", (64, 64), (64, 64, 1))
+    item.latent_cache_path = str(tmp_path / "edit_0064x0064_mmh3.safetensors")
+    item.text_encoder_output_cache_path = str(tmp_path / "edit_mmh3_te.safetensors")
+    latent_tensors = {
+        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
+        "latents_first_1x4x4_float32": torch.ones(24, 1, 4, 4),
+        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
+        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
+        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
+        ONE_FRAME_CONTROL_INDICES_KEY: torch.tensor([0], dtype=torch.int64),
+    }
+    text_tensors = {
+        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
+        "varlen_mmh3_token_tags_int64": torch.tensor([1, 1, 1], dtype=torch.int64),
+    }
+    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "fl2va", "one_frame": "1"})
+    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "fl2va"})
+
+    manager = BucketBatchManager({(64, 64, 1): [item]}, batch_size=1)
+    batch = manager[0]
+
+    assert batch["latents"].shape == (1, 24, 1, 4, 4)
+    assert batch["latents_first"].shape == (1, 24, 1, 4, 4)
+    torch.testing.assert_close(batch["one_frame_target_index"], torch.tensor([24], dtype=torch.int64))
+    torch.testing.assert_close(batch["one_frame_control_indices"], torch.tensor([[0]], dtype=torch.int64))
+
+
+def test_h3_latent_writer_rejects_invalid_one_frame_control_indices(tmp_path: Path):
+    item = _h3_item(tmp_path)
+    base = {
+        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
+        "latents_first_1x4x4_float32": torch.zeros(24, 1, 4, 4),
+        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
+        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
+        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
+    }
+    invalid = (
+        torch.tensor(0, dtype=torch.int64),
+        torch.tensor([0], dtype=torch.int32),
+        torch.tensor([-1], dtype=torch.int64),
+        torch.tensor([0, 1, 2], dtype=torch.int64),
+        torch.zeros(1, 1, dtype=torch.int64),
+    )
+    for indices in invalid:
+        with pytest.raises(ValueError, match=ONE_FRAME_CONTROL_INDICES_KEY):
+            save_latent_cache_minimax_h3(item, {**base, ONE_FRAME_CONTROL_INDICES_KEY: indices}, {"task": "fl2va"})

--- a/tests/test_minimax_h3_dataset.py
+++ b/tests/test_minimax_h3_dataset.py
@@ -162,15 +162,102 @@ def _h3_image_dataset(tmp_path: Path, **overrides):
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
-        ({"control_directory": "controls"}, "control images"),
         ({"multiple_target": True}, "multiple targets"),
-        ({"fp_1f_clean_indices": [0]}, "fp_1f_clean_indices"),
+        ({"no_resize_control": True}, "no_resize_control"),
+        ({"control_resolution": (512, 512)}, "control_resolution"),
         ({"fp_1f_target_index": -1}, "nonnegative"),
+        # time-annotated control validation: indices and controls must arrive together, with an
+        # explicit target index and 1..2 nonnegative entries
+        ({"control_directory": "controls"}, "require fp_1f_clean_indices"),
+        ({"fp_1f_clean_indices": [0]}, "explicit fp_1f_target_index"),
+        ({"fp_1f_clean_indices": [0], "fp_1f_target_index": 24}, "requires control images"),
+        ({"fp_1f_clean_indices": [0, 1, 2], "fp_1f_target_index": 24}, "1 or 2 entries"),
+        ({"fp_1f_clean_indices": [-1], "fp_1f_target_index": 24}, "nonnegative"),
     ],
 )
 def test_h3_image_dataset_rejects_unsupported_one_frame_features(tmp_path: Path, overrides: dict, message: str):
     with pytest.raises(ValueError, match=message):
         _h3_image_dataset(tmp_path, **overrides)
+
+
+def test_h3_image_dataset_jsonl_control_paths_require_indices(tmp_path: Path):
+    jsonl = tmp_path / "items.jsonl"
+    jsonl.write_text('{"image_path": "target.png", "caption": "c", "control_path": "source.png"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="require fp_1f_clean_indices"):
+        _h3_image_dataset(tmp_path, image_directory=None, image_jsonl_file=str(jsonl))
+
+
+def test_h3_jsonl_datasource_exposes_control_paths_for_fingerprinting(tmp_path: Path):
+    jsonl = tmp_path / "items.jsonl"
+    jsonl.write_text(
+        '{"image_path": "a.png", "caption": "c", "control_path": "s0.png", "control_path_1": "s1.png"}\n',
+        encoding="utf-8",
+    )
+    dataset = _h3_image_dataset(
+        tmp_path,
+        image_directory=None,
+        image_jsonl_file=str(jsonl),
+        fp_1f_clean_indices=[0, 48],
+        fp_1f_target_index=24,
+    )
+
+    assert dataset.datasource.get_control_paths() == {"a.png": ["s0.png", "s1.png"]}
+
+
+def test_h3_image_dataset_with_controls_splits_buckets_and_forwards_indices(tmp_path: Path):
+    dataset = _h3_image_dataset(
+        tmp_path,
+        control_directory=str(tmp_path / "ctrl"),
+        fp_1f_clean_indices=[0],
+        fp_1f_target_index=24,
+    )
+    assert dataset.has_control
+
+    class FakeImageDatasource:
+        has_control = True
+
+        def __iter__(self):
+            from PIL import Image
+
+            image = Image.new("RGB", (64, 64))
+            control = Image.new("RGB", (128, 128))  # resized to the bucket resolution
+            yield lambda: (str(tmp_path / "target.png"), [image], "caption", [control])
+
+    dataset.datasource = FakeImageDatasource()
+
+    batches = list(dataset.retrieve_latent_cache_batches(num_workers=1))
+
+    assert len(batches) == 1
+    bucket, items = batches[0]
+    # (W, H) + control count + per-control bucket-resized shape
+    assert bucket == (64, 64, 1, 64, 64)
+    assert items[0].fp_1f_clean_indices == [0]
+    assert items[0].fp_1f_target_index == 24
+    assert len(items[0].control_content) == 1
+    assert items[0].control_content[0].shape == (64, 64, 3)
+
+
+def test_h3_image_prepare_for_training_splits_buckets_by_control_count(tmp_path: Path):
+    from safetensors.torch import save_file
+
+    for stem in ("edit", "plain"):
+        # the control-key scan reads real safetensors headers, so the caches must be well-formed
+        save_file({"latents": torch.zeros(1)}, str(tmp_path / f"{stem}_0064x0064_mmh3.safetensors"))
+        save_file({"rows": torch.zeros(1)}, str(tmp_path / f"{stem}_mmh3_te.safetensors"))
+    with_controls = _h3_image_dataset(
+        tmp_path,
+        control_directory=str(tmp_path / "ctrl"),
+        fp_1f_clean_indices=[0, 48],
+        fp_1f_target_index=24,
+    )
+    without_controls = _h3_image_dataset(tmp_path)
+
+    with_controls.prepare_for_training()
+    without_controls.prepare_for_training()
+
+    assert set(with_controls.batch_manager.buckets) == {(64, 64, 2)}
+    assert set(without_controls.batch_manager.buckets) == {(64, 64)}
 
 
 def test_h3_image_dataset_forwards_the_target_index_to_items(tmp_path: Path):

--- a/tests/test_minimax_h3_generation_modes.py
+++ b/tests/test_minimax_h3_generation_modes.py
@@ -158,6 +158,38 @@ def test_prompt_validation_checks_output_name_suffixes_in_directory_modes(tmp_pa
         validate_prompt_args(image_args, directory_output=True)
 
 
+def test_one_frame_fl2va_control_index_error_reports_the_counts(tmp_path):
+    first = tmp_path / "first.png"
+    first.touch()
+    args = _session_args(
+        tmp_path,
+        task="fl2va",
+        frame_count=1,
+        first_frame=str(first),
+        one_frame="target_index=6,control_index=0;123",
+        output=str(tmp_path / "out.png"),
+    )
+
+    with pytest.raises(ValueError, match=r"got 2 control_index entries for 1 condition frames \(first_frame\)"):
+        validate_prompt_args(args)
+
+
+def test_from_file_reports_the_failing_line_number(tmp_path):
+    prompts = tmp_path / "prompts.txt"
+    prompts.write_text("# comment\n\na cat sings --d 11\na dog barks --w 0\n", encoding="utf-8")
+    args = _session_args(
+        tmp_path,
+        frame_count=5,
+        allow_experimental_duration=True,
+        output=str(tmp_path / "outputs"),
+        from_file=str(prompts),
+    )
+
+    # the bad width line is file line 4; validation fails before any model loads
+    with pytest.raises(ValueError, match="--from_file line 4 is invalid.*divisible by 32"):
+        generate.process_from_file(args, torch.device("cpu"))
+
+
 def test_latent_file_roundtrip_preserves_tensors_and_rejects_missing_audio(tmp_path):
     args = _session_args(tmp_path, frame_count=39, allow_experimental_duration=True)
     video = torch.randn(1, 24, 3, 4, 4)

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -1060,9 +1060,7 @@ def test_one_frame_fl2va_batch_builds_condition_time_overrides(monkeypatch, role
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     transformer = _RecordingTransformer()
 
-    _one_frame_process_batch(
-        trainer, args, _one_frame_fl_batch(control_indices=control_indices, roles=roles), transformer
-    )
+    _one_frame_process_batch(trainer, args, _one_frame_fl_batch(control_indices=control_indices, roles=roles), transformer)
 
     layout = transformer.calls[0]["layout"]
     assert layout.task == "fl2va"

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from contextlib import nullcontext
 from pathlib import Path
@@ -1038,27 +1039,133 @@ def test_one_frame_batch_requires_a_valid_index_tensor(index):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
 
 
-def test_one_frame_batch_rejects_condition_latents():
+def _one_frame_fl_batch(target_index: int = 24, control_indices: list[int] | None = None, roles=("first",)):
+    batch = _one_frame_batch(target_index=target_index)
+    for role in roles:
+        batch[f"latents_{role}"] = torch.zeros(1, 24, 1, 4, 4)
+    if control_indices is not None:
+        batch["one_frame_control_indices"] = torch.tensor([control_indices], dtype=torch.int64)
+    return batch
+
+
+@pytest.mark.parametrize(
+    ("roles", "control_indices"),
+    [(("first",), [0]), (("first", "last"), [0, 48]), (("first",), [120])],
+)
+def test_one_frame_fl2va_batch_builds_condition_time_overrides(monkeypatch, roles, control_indices):
+    # the last case places the lone control AFTER the target (l2va-style) — ordering is free
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="fl2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    transformer = _RecordingTransformer()
+
+    _one_frame_process_batch(
+        trainer, args, _one_frame_fl_batch(control_indices=control_indices, roles=roles), transformer
+    )
+
+    layout = transformer.calls[0]["layout"]
+    assert layout.task == "fl2va"
+    assert layout.target_video.frames == 1
+    assert tuple(segment.role for segment in layout.segments if segment.kind == "visual_condition") == roles
+    assert layout.time_overrides.condition_times == tuple(FRAME_RESCALE * index for index in control_indices)
+    assert layout.time_overrides.target_time == FRAME_RESCALE * 24
+
+
+def test_one_frame_fl2va_batch_requires_the_control_indices_tensor():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="fl2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_fl_batch(control_indices=None)
+
+    with pytest.raises(ValueError, match=r"one_frame_control_indices tensor.*--task fl2va"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+@pytest.mark.parametrize(
+    "indices",
+    [
+        torch.tensor([0], dtype=torch.int64),  # missing batch axis
+        torch.tensor([[0]], dtype=torch.int32),
+        torch.tensor([[-1]], dtype=torch.int64),
+    ],
+)
+def test_one_frame_fl2va_batch_requires_a_valid_control_indices_tensor(indices):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="fl2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_fl_batch(control_indices=None)
+    batch["one_frame_control_indices"] = indices
+
+    with pytest.raises(ValueError, match="one_frame_control_indices|nonnegative"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+def test_one_frame_fl2va_batch_rejects_a_lone_last_condition():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="fl2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_fl_batch(control_indices=[0], roles=("last",))
+
+    with pytest.raises(ValueError, match="latents_first"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+def test_one_frame_fl2va_batch_requires_matching_condition_and_index_counts():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="fl2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_fl_batch(control_indices=[0, 48], roles=("first",))
+
+    with pytest.raises(ValueError, match="re-run latent caching"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+def test_one_frame_t2va_batch_rejects_stray_control_indices():
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(one_frame=True)
     trainer.handle_model_specific_args(args)
     batch = _one_frame_batch()
-    batch["latents_first"] = torch.zeros(1, 24, 1, 4, 4)
-    batch["latents_last"] = torch.zeros(1, 24, 1, 4, 4)
+    batch["one_frame_control_indices"] = torch.tensor([[0]], dtype=torch.int64)
 
-    with pytest.raises(ValueError, match="plain T2VA"):
+    with pytest.raises(ValueError, match="T2VA batch cannot carry one_frame_control_indices"):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
 
 
-def test_video_batch_rejects_a_stray_one_frame_index():
+def test_one_frame_coinciding_control_and_target_indices_warn_once(monkeypatch, caplog):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="fl2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    import musubi_tuner.minimax_h3_train_network as train_module
+
+    monkeypatch.setattr(train_module, "_coinciding_one_frame_indices_warned", False)
+    with caplog.at_level(logging.WARNING):
+        for _ in range(2):
+            _one_frame_process_batch(
+                trainer, args, _one_frame_fl_batch(control_indices=[24], roles=("first",)), _RecordingTransformer()
+            )
+
+    warnings = [record for record in caplog.records if "verbatim anchor copying" in record.getMessage()]
+    assert len(warnings) == 1
+
+
+@pytest.mark.parametrize(
+    ("extra_key", "message"),
+    [
+        ("one_frame_target_index", "one-frame index tensors"),
+        ("one_frame_control_indices", "one-frame index tensors"),
+    ],
+)
+def test_video_batch_rejects_stray_one_frame_index_tensors(extra_key, message):
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(one_frame=True)
     trainer.handle_model_specific_args(args)
     video_latents = torch.zeros(1, 24, 2, 4, 4)
     batch = _training_batch()
-    batch["one_frame_target_index"] = torch.tensor([0], dtype=torch.int64)
+    batch[extra_key] = torch.tensor([0], dtype=torch.int64)
 
-    with pytest.raises(ValueError, match="video batch cannot carry one_frame_target_index"):
+    with pytest.raises(ValueError, match=message):
         trainer.process_batch(
             args,
             _Accelerator(),
@@ -1078,14 +1185,17 @@ def test_video_batch_rejects_a_stray_one_frame_index():
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
-        ({"one_frame": True, "task": "fl2va"}, "requires --task t2va"),
-        ({"one_frame": True, "task": "ref2va"}, "requires --task t2va"),
+        ({"one_frame": True, "task": "ref2va"}, "requires --task t2va or fl2va"),
         ({"one_frame": True, "h3_teacher_matching": True}, "does not support --one_frame"),
     ],
 )
 def test_one_frame_training_flag_validations(overrides, message):
     with pytest.raises(ValueError, match=message):
         MiniMaxH3NetworkTrainer().handle_model_specific_args(_trainer_args(**overrides))
+
+
+def test_one_frame_training_accepts_the_fl2va_task():
+    MiniMaxH3NetworkTrainer().handle_model_specific_args(_trainer_args(one_frame=True, task="fl2va"))
 
 
 def test_one_frame_training_records_provenance_metadata():
@@ -1111,9 +1221,21 @@ def test_one_frame_sample_normalization_parses_the_of_option():
 @pytest.mark.parametrize(
     ("args_overrides", "sample", "message"),
     [
-        ({"task": "fl2va"}, {"prompt": "x", "frame_count": 1, "first_frame": "a.png", "last_frame": "b.png"}, "t2va only"),
+        ({"task": "ref2va"}, {"prompt": "x", "frame_count": 1}, "t2va and fl2va only"),
         ({}, {"prompt": "x", "frame_count": 1, "one_frame": "target_index=0,control_index=0"}, "control_index"),
         ({}, {"prompt": "x", "frame_count": 124, "one_frame": "target_index=24"}, r"require --f 1"),
+        # fl2va one-frame: control_index is mandatory, one entry per provided frame
+        (
+            {"task": "fl2va"},
+            {"prompt": "x", "frame_count": 1, "first_frame": "a.png", "last_frame": "b.png"},
+            "one entry per provided frame",
+        ),
+        (
+            {"task": "fl2va"},
+            {"prompt": "x", "frame_count": 1, "first_frame": "a.png", "one_frame": "control_index=0;48"},
+            "one entry per provided frame",
+        ),
+        ({"task": "fl2va"}, {"prompt": "x", "frame_count": 1, "one_frame": "control_index=0"}, "first_frame and/or last_frame"),
     ],
 )
 def test_one_frame_sample_normalization_rejects_invalid_requests(args_overrides, sample, message):
@@ -1121,6 +1243,28 @@ def test_one_frame_sample_normalization_rejects_invalid_requests(args_overrides,
 
     with pytest.raises(ValueError, match=message):
         _normalize_h3_sample_parameter(args, sample)
+
+
+def test_one_frame_fl2va_sample_normalization_parses_control_indices(tmp_path):
+    first = tmp_path / "first.png"
+    first.touch()
+    args = _trainer_args(task="fl2va", one_frame=True)
+
+    sample = _normalize_h3_sample_parameter(
+        args,
+        {
+            "prompt": "an edit",
+            "frame_count": 1,
+            "first_frame": str(first),
+            "one_frame": "target_index=24,control_index=0",
+            "width": 64,
+            "height": 64,
+        },
+    )
+
+    assert sample["frame_count"] == 1
+    assert sample["one_frame_target_index"] == 24
+    assert sample["one_frame_control_indices"] == (0,)
 
 
 def test_t2va_draws_no_condition_noise(monkeypatch):
@@ -1550,6 +1694,34 @@ def test_guidance_loss_uncond_layout_carries_the_one_frame_overrides(tmp_path, m
     assert uncond_call["layout"].target_audio_frames == 2
     assert uncond_call["layout"].time_overrides == cond_call["layout"].time_overrides
     assert uncond_call["layout"].time_overrides.target_time == FRAME_RESCALE * 24
+    assert metrics["guidance/applied"] == 1.0
+
+
+def test_guidance_loss_uncond_layout_carries_one_frame_fl_condition_roles(tmp_path, monkeypatch):
+    # a K=1 one-frame FL2VA layout cannot be rebuilt without explicit condition roles, so the
+    # uncond probe must recover them from the segments (the PR-A layout-rebuild lesson)
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(
+        task="fl2va",
+        one_frame=True,
+        h3_guidance_loss_scale=3.0,
+        h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
+    )
+    trainer.handle_model_specific_args(args)
+    transformer = _RecordingTransformer()
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
+
+    batch = _one_frame_fl_batch(control_indices=[0], roles=("first",))
+    _, metrics = _one_frame_process_batch(trainer, args, batch, transformer)
+
+    assert len(transformer.calls) == 2
+    uncond_call, cond_call = transformer.calls
+    for call in (uncond_call, cond_call):
+        assert call["layout"].task == "fl2va"
+        assert tuple(segment.role for segment in call["layout"].segments if segment.kind == "visual_condition") == ("first",)
+    assert uncond_call["layout"].time_overrides == cond_call["layout"].time_overrides
+    assert uncond_call["layout"].time_overrides.condition_times == (0.0,)
     assert metrics["guidance/applied"] == 1.0
 
 


### PR DESCRIPTION
## Summary

Experimental one-frame **editing/inbetween LoRA training** for MiniMax-H3 (fl2va, K=1/2), building on the K=0 image LoRA training from #1057. An image dataset now pairs each target image with 1-2 **time-annotated control images**: the controls become FL2VA condition latents (and `<Picture i>` visuals in the text presentation), and their positions on the rotary time axis come from `fp_1f_clean_indices` / `fp_1f_target_index` (0-based 24 fps pixel-frame indices, explicit values required — no defaults).

Time ordering is unconstrained, so L2VA-style datasets (anchor after the target: generate the image that precedes an end state) work with the same config.

## Changes

- **Dataset layer**: MiniMax-H3 joins the FramePack/WAN time-annotated-control branches (control count derived from the indices, bucket split by K at both caching and training prep). Control/index agreement is validated after datasource construction (covers JSONL `control_path`); `multiple_target` / `no_resize_control` / `control_resolution` are rejected for mmh3.
- **Latent caching**: `--one_frame` now pairs with `--task t2va` or `fl2va`. Controls are encoded as `latents_first` (+ `latents_last` for K=2) in packed order; the indices ride as an int64 `one_frame_control_indices` tensor (the collator only carries tensors) with a metadata copy for `--skip_existing` staleness; control files join the media fingerprints.
- **Text-encoder caching**: fl2va one-frame presentations embed the bucket-resized control pixels from the shared `requires_content` path — the TE and the VAE see identical control pixels by construction. Presentation identity fingerprints the control files.
- **Trainer**: `_collect_fl_conditions` generalized to first-only for one-frame batches (a lone control is always `latents_first`; its temporal position is carried by the index, not the role name). Condition times become `H3TimeOverrides.condition_times`. The guidance-loss uncond layout rebuild recovers `condition_roles` from the segments — required for K=1 (the #1057 layout-rebuild lesson, regression-tested). Training samples accept `--f 1` fl2va lines (`--i`/`--ei` + `--of target_index=..,control_index=..`). A one-time warning fires when a control index coincides with the target index (the base model's verbatim anchor-copy prior).
- **Batch generation diagnostics** (found during smoke): the one-frame FL2VA control_index mismatch error now reports entry/frame counts, and `--from_file` upfront validation reports the failing file line number.
- **Docs**: `docs/minimax_h3_1f.md` gains the editing-training section (dataset config, index-selection guidance incl. the anchor-copy warning, L2VA-style variant, inbetween triplet recipe, official-format caption requirement).

## Testing

- 564 tests pass (`tests/`), ruff clean. New coverage: cache tensor/metadata contract for controls+indices, collator round trip, writer validation, dataset-layer gates and bucket splits, trainer condition-time layouts and error paths, guidance-loss role recovery, sample-line parsing, batch-validation diagnostics.
- Real-machine smoke (all passed):
  - **K=1 editing**: channel-permutation LoRA (a deterministic mapping the prompt cannot express — verified prompt-impossible on the base first). Objective grading on a held-out control: LoRA `RMS vs GT 0.099 / vs source 0.227`; base with the same prompt copies the anchor instead (`0.194 / 0.047`). Learned by ~200 of 300 steps with the guidance loss.
  - **K=2 inbetween** (orbit triplets): pipeline gate passed; the interpolation-calibration quality question remains open at smoke scale, as expected.
  - **Regression**: #1057 t2va image training, video fl2va, and mixed image+video TOML runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)