### PR TITLE
Add static watermark masking for the training loss

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -164,6 +164,7 @@ Musubi Tunerの解説記事執筆や、関連ツールの開発に取り組ん�
 - [データセット設定](./docs/dataset_config.md)
 - [高度な設定](./docs/advanced_config.md)
 - [学習中のサンプル生成](./docs/sampling_during_training.md)
+- [静的ウォーターマークのマスク](./docs/watermark_mask.md)
 - [ブロックスワップ（省メモリのためのCPUオフロード）](./docs/block_swap.md)
 - [ツールとユーティリティ](./docs/tools.md)
 - [torch.compileの使用方法](./docs/torch_compile.md)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ For detailed information on specific architectures, configurations, and advanced
 - [Dataset Configuration](./docs/dataset_config.md)
 - [Advanced Configuration](./docs/advanced_config.md)
 - [Sampling during Training](./docs/sampling_during_training.md)
+- [Static Watermark Masking](./docs/watermark_mask.md)
 - [Block Swap (CPU Offloading for Memory Saving)](./docs/block_swap.md)
 - [Tools and Utilities](./docs/tools.md)
 - [Using torch.compile](./docs/torch_compile.md)

--- a/detect_watermark_mask.py
+++ b/detect_watermark_mask.py
@@ -1,0 +1,4 @@
+from musubi_tuner.detect_watermark_mask import main
+
+if __name__ == "__main__":
+    main()

--- a/docs/dataset_config.md
+++ b/docs/dataset_config.md
@@ -658,6 +658,7 @@ batch_size = 1 # optional, default is 1. This is the default batch size for all 
 num_repeats = 1 # optional, default is 1. Number of times to repeat the dataset. Useful to balance the multiple datasets with different sizes.
 enable_bucket = true # optional, default is false. Enable bucketing for datasets
 bucket_no_upscale = false # optional, default is false. Disable upscaling for bucketing. Ignored if enable_bucket is false
+watermark_mask_suffix = "_wmask.png" # optional, default is "_wmask.png". Suffix of the static watermark loss mask placed next to each image/video. See docs/watermark_mask.md
 
 ### Image Dataset
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -8,6 +8,7 @@ This document provides documentation for utility tools available in this project
 
 - [LoRA Post-Hoc EMA merging / LoRAのPost-Hoc EMAマージ](#lora-post-hoc-ema-merging--loraのpost-hoc-emaマージ)
 - [Image Captioning with Qwen2.5-VL / Qwen2.5-VLによる画像キャプション生成](#image-captioning-with-qwen25-vl--qwen25-vlによる画像キャプション生成)
+- [Static Watermark Mask Detection / 静的ウォーターマークのマスク検出](#static-watermark-mask-detection--静的ウォーターマークのマスク検出)
 
 ## LoRA Post-Hoc EMA merging / LoRAのPost-Hoc EMAマージ
 
@@ -404,3 +405,31 @@ python src/musubi_tuner/caption_images_by_qwen_vl.py \
   --max_size 1024 \
   --prompt "A detailed and descriptive caption for this image is:\n"
 ```
+
+## Static Watermark Mask Detection / 静的ウォーターマークのマスク検出
+
+`detect_watermark_mask.py` scans a directory of videos for a burned-in static watermark and writes a per-video loss mask next to each file. During training the masked region is excluded from the loss, so the model does not learn the watermark while the frame is still trained at full size.
+
+Detection compares frames sampled evenly across the video: a static watermark has a near-zero temporal standard deviation, while the content underneath it changes. Semi-transparent watermarks keep varying with the content and are invisible to that test, so a second pass looks at the temporal median of the image gradient, where the content cancels out and the watermark does not. Only `opencv-python` and `numpy` are required.
+
+### Usage
+
+```bash
+python src/musubi_tuner/detect_watermark_mask.py --video_dir /path/to/video_dir --corner_only
+```
+
+This writes `{video_stem}_wmask.png` (white = train, black = ignore) next to each video, which the dataset picks up automatically. The watermark does not have to be on screen the whole time — up to `--frame_tolerance` of the sampled frames (10% by default) may be without it. Only *moving* watermarks are unsupported, since a single mask cannot describe them; those clips should be dropped from the dataset.
+
+See the [static watermark masking documentation](./watermark_mask.md) for the full option list, the dataset configuration, and how the mask is applied to the loss.
+
+<details>
+<summary>日本語</summary>
+
+`detect_watermark_mask.py` は、ディレクトリ内の動画から焼き込まれた静的なウォーターマークを検出し、各動画の隣に損失用のマスクを書き出します。学習時にはマスクされた領域が損失から除外されるため、フレームはフルサイズで学習しつつ、モデルがウォーターマークを学習することを防げます。
+
+検出は、動画から均等にサンプリングしたフレームを比較して行います。静的なウォーターマークは時間方向の標準偏差がほぼゼロですが、その下のコンテンツは変化します。半透明のウォーターマークはコンテンツに応じて変化し続けるためこの方法では検出できないので、2つ目のパスとして画像の勾配の時間方向の中央値を見ます。コンテンツの勾配は相殺されますが、ウォーターマークの勾配は残ります。必要なのは `opencv-python` と `numpy` だけです。
+
+上記のコマンドで、各動画の隣に `{動画名}_wmask.png`（白＝学習する、黒＝無視する）が書き出され、データセットが自動的に読み込みます。ウォーターマークは常に画面に表示されている必要はありません。サンプリングされたフレームのうち `--frame_tolerance` の割合（デフォルトは10%）までは、表示されていなくても構いません。単一のマスクで表現できない**移動する**ウォーターマークのみが非対応です。そのようなクリップはデータセットから除外してください。
+
+オプションの一覧、データセットの設定、損失への適用方法については、[静的ウォーターマークのマスクのドキュメント](./watermark_mask.md)を参照してください。
+</details>

--- a/docs/watermark_mask.md
+++ b/docs/watermark_mask.md
@@ -1,0 +1,259 @@
+> 📝 Click on the language section to expand / 言語をクリックして展開
+
+# Static Watermark Masking / 静的ウォーターマークのマスク
+
+Training footage often carries a burned-in logo or watermark. Without a mask, the model learns the watermark along with the concept, and it shows up in generated videos. Cropping the watermark away throws the rest of the frame away with it, and changes the composition the model sees.
+
+This feature excludes the watermark region from the **loss** instead. The frame stays full size and is encoded normally; the masked pixels simply produce no gradients.
+
+Only **static** watermarks are supported: the overlay must sit at the same place whenever it is on screen. Within that, it can be opaque or semi-transparent, and it does not have to be on screen the whole time — a watermark that briefly disappears, is occluded by bright content, or fades in and out is still detected, up to a configurable fraction of frames (`--frame_tolerance`, 10% by default). What a single mask cannot describe is a watermark that *moves* across the frame; drop those clips from the dataset instead.
+
+The mask is entirely optional. Clips without a mask file are trained on in full, exactly as before.
+
+<details>
+<summary>日本語</summary>
+
+学習用の動画には、ロゴやウォーターマークが焼き込まれていることがよくあります。マスクを使用しない場合、モデルは学習したい概念と一緒にウォーターマークも学習してしまい、生成される動画にウォーターマークが現れます。ウォーターマークを切り取ると、フレームの他の部分も一緒に失われ、モデルが見る構図も変わってしまいます。
+
+この機能では、代わりにウォーターマークの領域を**損失（loss）**から除外します。フレームはフルサイズのまま通常どおりエンコードされ、マスクされたピクセルからは勾配が生じません。
+
+対応しているのは**静的な**ウォーターマークのみです。オーバーレイは、画面に表示されている間は常に同じ位置・同じピクセルである必要があります。ただし、常に表示されている必要はありません。一時的に消える、明るいコンテンツに隠れる、フェードイン・フェードアウトするウォーターマークも、設定可能な割合のフレーム数まで（`--frame_tolerance`、デフォルトは10%）検出・マスクされます。単一のマスクで表現できないのは、フレーム内を**移動する**ウォーターマークです。そのようなクリップはデータセットから除外してください。
+
+マスクは完全に任意です。マスクファイルがないクリップは、これまでと同様にフレーム全体で学習されます。
+</details>
+
+## Mask files / マスクファイル
+
+A mask is a grayscale image the same size as the source video (any resolution works — it is resized and cropped with the video, using the same transform, so it stays aligned with the latents).
+
+| Pixel value | Meaning |
+| --- | --- |
+| `255` (white) | train on this pixel |
+| `0` (black) | ignore this pixel (watermark) |
+
+The mask lives next to the video, named after it with the `watermark_mask_suffix` appended (default `_wmask.png`):
+
+```
+dataset/
+  clip_001.mp4
+  clip_001.txt         # caption
+  clip_001_wmask.png   # watermark mask
+  clip_002.mp4
+  clip_002.txt         # no mask: the whole frame is trained on
+```
+
+Image datasets use the same convention. If the mask is not found next to the source file, the cache directory is searched too.
+
+<details>
+<summary>日本語</summary>
+
+マスクは、元の動画と同じサイズのグレースケール画像です（解像度は任意です。動画と同じ変換でリサイズ・クロップされるため、latentとの位置は一致します）。
+
+| ピクセル値 | 意味 |
+| --- | --- |
+| `255`（白） | このピクセルを学習する |
+| `0`（黒） | このピクセルを無視する（ウォーターマーク） |
+
+マスクは動画と同じディレクトリに、動画のファイル名に `watermark_mask_suffix`（デフォルトは `_wmask.png`）を付けた名前で配置します（上記の例を参照）。
+
+画像データセットでも同じ規則が使えます。ソースファイルの隣にマスクが見つからない場合は、キャッシュディレクトリも検索されます。
+</details>
+
+## Detecting the mask automatically / マスクの自動検出
+
+`detect_watermark_mask.py` finds static watermarks by comparing sampled frames: a watermark pixel does not change over time, while the content underneath does. It samples frames evenly across each video, computes the per-pixel temporal standard deviation, and marks the low-variance pixels as watermark.
+
+Before measuring that deviation it discards, per pixel, the frames furthest from that pixel's temporal median — up to `--frame_tolerance` of them. That is what makes an intermittent watermark detectable: without it, a handful of frames where the watermark is off screen would dominate the deviation and hide it completely.
+
+### The second signal: semi-transparent watermarks
+
+Deviation on its own only finds near-opaque overlays. A semi-transparent watermark blends as `alpha * W + (1 - alpha) * content`, so its pixels keep varying with the content underneath and their deviation is merely scaled by `1 - alpha`. At 30% opacity the deviation is still 70% of the content's — far above any threshold that would not also swallow every calm region of the frame. Measured on synthetic footage with a content deviation of 65:
+
+| opacity | deviation at the watermark | found by deviation alone |
+| --- | --- | --- |
+| 0.3 | 45.6 | no |
+| 0.5 | 33.8 | no |
+| 0.7 | 21.8 | no |
+| 0.95 | 6.8 | yes |
+
+So a second pass looks at the **image gradient** instead. Content gradients change from frame to frame and cancel out in a temporal median, while the watermark contributes the same `alpha * grad(W)` in every one of them and survives. Whatever is left standing after that median is, by construction, what every frame has in common. (The same observation underpins Dekel et al., *On the Effectiveness of Visible Watermarks*, CVPR 2017.)
+
+`--gradient_threshold` sets how far above the frame's own median that surviving gradient must be. Ordinary content and static background sit around 1x; a watermark between 20% and 50% opacity lands between 3x and 14x, so the default of 3.0 has margin on both sides. Raising `--n_frames` widens that gap, because content gradients cancel more completely the more frames are averaged.
+
+The two signals are not ordered and there is no mode to pick: they are unioned on every clip. Neither covers the whole range alone — an opaque logo trips both, a 30% opacity logo only the gradient, a large flat opaque patch trips deviation strongly and the gradient only along its border.
+
+The temporal median tolerates a watermark missing from a minority of frames on its own, so `--frame_tolerance` does not need to be raised for the gradient signal.
+
+On footage with strongly repetitive motion the gradient signal has a false-positive floor — a few small boxes over content, around 1% of the frame in testing. `--corner_only` and `--min_area` are the mitigations, and over-masking a little content is far cheaper than leaving watermark in the loss.
+
+### Boxes, not outlines
+
+What the two signals mark — an outline from the gradient, solid pixels from the deviation — is not the region that has to be excluded. Each detected region is replaced by its **bounding box**.
+
+That is deliberate. The VAE encoder mixes a neighbourhood of pixels into every latent cell, so a watermark bleeds into latents that its own pixels do not cover; a mask traced tightly around thin glyph strokes under-masks once it is downsampled to latent resolution. A box covers that neighbourhood, needs no morphological reconstruction of a logo's interior, and errs in the safe direction. It costs very little: on a corner logo, the box masks 2.5% of the frame where the exact glyph shapes would have masked 2.3%.
+
+Boxes are per connected region, so two logos in opposite corners stay two boxes rather than one box spanning the frame.
+
+### Letterboxing and burnt-in borders
+
+A letterbox bar is static, carries no content, and would otherwise teach the model to generate black bars — so it is detected and masked, and that is the correct outcome, not a false positive. The same goes for a burnt-in border or frame.
+
+Cropping such footage is still better than masking it, because the bars keep taking up frame area that the VAE encodes either way. And there is a limit: bars eat up to a third of the frame on their own, which is why `--max_coverage` defaults to 0.4 rather than something tighter. Beyond that the clip is left alone, on the assumption that the detection has stopped meaning anything (see below).
+
+```bash
+python src/musubi_tuner/detect_watermark_mask.py --video_dir /path/to/video_dir --corner_only
+```
+
+This writes `{video_stem}_wmask.png` next to each video. Only `opencv-python` and `numpy` are needed, so it can be run separately from training.
+
+Review the generated masks before training — the detector is a heuristic, and a wrong mask silently removes real content from the loss.
+
+### Command line options
+
+```
+--video_dir VIDEO_DIR
+    Directory containing the videos (required)
+
+--recursive
+    Search --video_dir recursively
+
+--n_frames N_FRAMES
+    Number of frames sampled per video (default: 30)
+    More frames make the detection more reliable on slow-moving footage, at the cost of speed,
+    and let content gradients cancel out better, which is what makes a semi-transparent watermark
+    stand out
+
+--threshold THRESHOLD
+    Temporal standard deviation below which a pixel is considered static (0-255 scale, default: 8.0)
+    Raise it if parts of the watermark are missed, lower it if too much content is masked
+
+--frame_tolerance FRAME_TOLERANCE
+    Fraction of sampled frames allowed to not show the watermark (default: 0.1)
+    Per pixel, that many of the most deviating frames are discarded before measuring the deviation
+    Set to 0 to require the watermark in every sampled frame
+    The fraction is over the *sampled* frames, not the source frames: if the watermark is off screen
+    for 10% of a clip, an unlucky sampling stride can still land on many more of those frames than
+    that, so raise --n_frames along with it if a known watermark is missed
+    High values (above ~0.3) start letting slow-moving content pass as static, so raise it gradually
+
+--gradient_threshold GRADIENT_THRESHOLD
+    How far above the frame's own median a pixel's frame-to-frame-consistent gradient must be to
+    count as a semi-transparent watermark edge (default: 3.0, i.e. 3x that median)
+    Ordinary content and static background sit around 1x; a watermark at 20-50% opacity lands
+    between 3x and 14x depending on opacity and --n_frames
+    Lower it if a faint watermark is missed, raise it if static textured background is picked up
+
+--corner_only
+    Only look for the watermark in a band along the frame border
+    Recommended: watermarks usually sit in a corner, and this avoids masking static background in the middle of the frame
+
+--corner_margin CORNER_MARGIN
+    Width of the border band for --corner_only, as a fraction of the frame size (default: 0.25)
+
+--dilate DILATE
+    Grow each detected box by N pixels (default: 3)
+    Anti-aliased watermark edges blend into the content and still carry watermark signal
+
+--min_area MIN_AREA
+    Drop detected regions smaller than N pixels before boxing them (default: 32)
+
+--max_coverage MAX_COVERAGE
+    Skip the video if the detected region covers more than this fraction of the frame (default: 0.4)
+    This catches locked-off shots, where "temporally static" no longer means "watermark"; those measure
+    around 0.8. Letterbox bars are a legitimate detection and reach about a third of the frame on their
+    own, so the default sits between the two
+
+--suffix SUFFIX
+    Mask file suffix (default: _wmask.png). Must match watermark_mask_suffix in the dataset config
+
+--output_dir OUTPUT_DIR
+    Write masks here instead of next to the videos
+
+--overwrite
+    Regenerate masks that already exist
+```
+
+<details>
+<summary>日本語</summary>
+
+`detect_watermark_mask.py` は、サンプリングしたフレームを比較して静的なウォーターマークを検出します。ウォーターマークのピクセルは時間的に変化しませんが、その下のコンテンツは変化します。スクリプトは各動画からフレームを均等にサンプリングし、ピクセルごとの時間方向の標準偏差を計算して、分散の低いピクセルをウォーターマークとしてマークします。
+
+標準偏差を計算する前に、ピクセルごとに、そのピクセルの時間方向の中央値から最も離れたフレームを `--frame_tolerance` の割合まで除外します。これにより、断続的に表示されるウォーターマークも検出できます。この処理がないと、ウォーターマークが画面外にある数フレームが標準偏差を支配し、検出が完全に失敗してしまいます。
+
+**半透明のウォーターマーク**：標準偏差だけでは、ほぼ不透明なオーバーレイしか検出できません。半透明のウォーターマークは `alpha * W + (1 - alpha) * コンテンツ` として合成されるため、下のコンテンツに応じて変化し続け、その偏差は `1 - alpha` 倍になるだけです。不透明度30%であれば、偏差はコンテンツの70%のままであり、これを拾えるしきい値では、動きの少ない領域もすべて拾ってしまいます。
+
+そこで2つ目のパスでは、**画像の勾配**を見ます。コンテンツの勾配はフレームごとに変化するため時間方向の中央値で相殺されますが、ウォーターマークは毎フレーム同じ `alpha * grad(W)` を寄与するため残ります（Dekel et al., *On the Effectiveness of Visible Watermarks*, CVPR 2017 と同じ着想です）。
+
+`--gradient_threshold` は、残った勾配がフレーム自身の中央値の何倍以上であればウォーターマークの輪郭とみなすかを指定します。通常のコンテンツや静止した背景は約1倍、不透明度20〜50%のウォーターマークは3〜14倍になるため、デフォルトの3.0は両側に余裕があります。`--n_frames` を増やすとコンテンツの勾配がより相殺され、この差が広がります。
+
+2つの信号に順序はなく、モードの選択もありません。常に両方が適用され、和集合が取られます。どちらか一方では全範囲をカバーできないためです（不透明なロゴは両方に、不透明度30%のロゴは勾配のみに反応します）。時間方向の中央値は少数のフレームでウォーターマークが欠けていても影響を受けないため、勾配の信号のために `--frame_tolerance` を上げる必要はありません。
+
+**輪郭ではなくボックス**：2つの信号が示すのは、勾配であれば輪郭、標準偏差であればその領域のピクセルであり、いずれも損失から除外すべき領域そのものではありません。そこで、検出された各領域はその**バウンディングボックス**に置き換えられます。VAEのエンコーダは周辺のピクセルを各latentセルに混ぜ込むため、ウォーターマークは自身のピクセルが覆っていないlatentにも影響します。細い文字の形に沿った厳密なマスクは、latent解像度に縮小した時点で不足します。ボックスであればその周辺までカバーでき、ロゴ内部の復元処理も不要で、安全側に倒れます。コストもわずかです（隅のロゴの場合、厳密な形状で2.3%、ボックスで2.5%）。ボックスは連結領域ごとに作られるため、対角の隅にある2つのロゴが1つの巨大なボックスに統合されることはありません。
+
+**レターボックスと焼き込まれた枠**：レターボックスの帯は静的で、コンテンツを含まず、そのまま学習すればモデルは黒帯を生成するようになります。したがって検出・マスクされるのが正しい動作であり、誤検出ではありません。焼き込まれた枠も同様です。ただし、そのような素材はマスクするよりクロップするほうが望ましく（VAEは黒帯も含めてエンコードするため）、帯だけでフレームの3分の1に達することもあります。`--max_coverage` のデフォルトが0.4であるのはこのためです。
+
+```bash
+python src/musubi_tuner/detect_watermark_mask.py --video_dir /path/to/video_dir --corner_only
+```
+
+各動画の隣に `{動画名}_wmask.png` が書き出されます。必要なのは `opencv-python` と `numpy` だけなので、学習とは別に実行できます。
+
+検出はヒューリスティックであり、誤ったマスクは実際のコンテンツを損失から取り除いてしまいます。学習前に生成されたマスクを確認してください。
+
+コマンドラインオプションについては、上記の英語の説明を参照してください。特に `--corner_only` の使用を推奨します。ウォーターマークは通常隅にあるため、フレーム中央の静止した背景をマスクしてしまうことを防げます。
+</details>
+
+## Dataset configuration / データセットの設定
+
+The suffix is configurable per dataset (or in `[general]`) with `watermark_mask_suffix`:
+
+```toml
+[general]
+resolution = [960, 544]
+caption_extension = ".txt"
+batch_size = 1
+watermark_mask_suffix = "_wmask.png" # optional, this is the default
+
+[[datasets]]
+video_directory = "/path/to/video_dir"
+cache_directory = "/path/to/cache_directory"
+target_frames = [1, 25, 79]
+frame_extraction = "head"
+```
+
+No training argument is needed: masks are picked up automatically when the files are present. Latent caching is unaffected, so masks can be added or regenerated without re-caching the dataset.
+
+<details>
+<summary>日本語</summary>
+
+サフィックスは `watermark_mask_suffix` で、データセットごと（または `[general]`）に設定できます（上記のTOMLの例を参照）。
+
+学習時の引数は不要です。マスクファイルが存在すれば自動的に使用されます。latentのキャッシュには影響しないため、キャッシュを再作成せずにマスクを追加・再生成できます。
+</details>
+
+## How the mask is applied / マスクの適用方法
+
+The mask reaches the training batch as `watermark_mask`, a `(B, H, W)` tensor in [0, 1] at the bucket resolution. In the loss (`reduce_loss` in `src/musubi_tuner/training/trainer_base.py`) it is area-downsampled to the latent resolution and broadcast over channels and frames, so masking works with the VAE's temporal and spatial compression without any per-architecture handling:
+
+```
+loss = mse(pred, target)            # (B, C, T, H, W), reduction="none"
+loss = (loss * mask).sum() / mask.expand_as(loss).sum()
+```
+
+Dividing by the mask weight keeps the loss scale comparable to the unmasked mean, so learning rates do not need to be retuned. A fully open mask reproduces `loss.mean()` exactly.
+
+Because area downsampling is used, a latent cell that only partially overlaps the watermark is weighted by the fraction of it that is clean, rather than being dropped entirely.
+
+Losses without a spatial layout (patchified image models, where the loss is a token sequence) cannot be masked; a warning is logged once and the mask is ignored.
+
+<details>
+<summary>日本語</summary>
+
+マスクは `watermark_mask`（バケット解像度の `(B, H, W)`、値は [0, 1]）として学習バッチに渡されます。損失の計算時（`src/musubi_tuner/training/trainer_base.py` の `reduce_loss`）に、latentの解像度へarea補間で縮小され、チャンネルとフレーム方向にブロードキャストされます。そのため、VAEの時間方向・空間方向の圧縮に関係なく、アーキテクチャごとの処理なしで動作します。
+
+マスクの重みで割ることで、損失のスケールはマスクなしの平均と同程度に保たれるため、学習率を調整し直す必要はありません。マスクが全面的に開いている場合は、`loss.mean()` と完全に一致します。
+
+area補間を使用しているため、ウォーターマークと部分的にのみ重なるlatentのセルは、そのうちクリーンな部分の割合で重み付けされます（完全に除外されるわけではありません）。
+
+空間的な配置を持たない損失（トークン列となるpatchify系の画像モデル）にはマスクを適用できません。この場合、警告が一度ログに出力され、マスクは無視されます。
+</details>

--- a/src/musubi_tuner/dataset/bucket.py
+++ b/src/musubi_tuner/dataset/bucket.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import math
 import random
 from typing import Any, Optional, Tuple, TYPE_CHECKING
@@ -26,7 +27,7 @@ from musubi_tuner.dataset.architectures import (
     ARCHITECTURE_WAN,
     ARCHITECTURE_Z_IMAGE,
 )
-from musubi_tuner.dataset.media_utils import divisible_by
+from musubi_tuner.dataset.media_utils import divisible_by, load_watermark_mask
 from musubi_tuner.utils.model_utils import remove_dtype_suffix
 
 if TYPE_CHECKING:
@@ -165,6 +166,16 @@ class BucketSelector:
         return bucket_width, bucket_height
 
 
+@functools.lru_cache(maxsize=64)
+def _cached_watermark_mask(mask_path: str, bucket_width: int, bucket_height: int) -> torch.Tensor:
+    """Decode + resize a watermark mask once and reuse it across steps.
+
+    The returned tensor is shared between callers, so it must not be modified in place.
+    """
+    mask = load_watermark_mask(mask_path, (bucket_width, bucket_height))
+    return torch.from_numpy(mask)
+
+
 class BucketBatchManager:
     def __init__(
         self, bucketed_item_info: dict[tuple[Any], list[ItemInfo]], batch_size: int, num_timestep_buckets: Optional[int] = None
@@ -244,7 +255,13 @@ class BucketBatchManager:
 
         batch_tensor_data = {}
         varlen_keys = set()
+        watermark_masks: list[Optional[torch.Tensor]] = []
         for item_info in bucket[start:end]:
+            watermark_masks.append(
+                _cached_watermark_mask(item_info.watermark_mask_path, bucket_reso[0], bucket_reso[1])
+                if item_info.watermark_mask_path is not None
+                else None
+            )
             sd_latent = load_file(item_info.latent_cache_path)
             sd_te = load_file(item_info.text_encoder_output_cache_path)
             sd = {**sd_latent, **sd_te}
@@ -274,6 +291,13 @@ class BucketBatchManager:
         for key in batch_tensor_data.keys():
             if key not in varlen_keys:
                 batch_tensor_data[key] = torch.stack(batch_tensor_data[key])
+
+        if any(mask is not None for mask in watermark_masks):
+            # (B, H, W) in [0, 1]: 1 = train on this pixel, 0 = ignore it. Items without a mask
+            # are trained on in full. The key is omitted entirely when no item in the batch has a
+            # mask, so the loss stays a plain mean in that case.
+            ones = torch.ones(bucket_reso[1], bucket_reso[0], dtype=torch.float32)
+            batch_tensor_data["watermark_mask"] = torch.stack([ones if mask is None else mask for mask in watermark_masks])
 
         if self.timestep_pool is not None:
             batch_tensor_data["timesteps"] = self.timestep_pool[idx][: end - start]  # use the pre-generated timesteps

--- a/src/musubi_tuner/dataset/config_utils.py
+++ b/src/musubi_tuner/dataset/config_utils.py
@@ -40,6 +40,7 @@ class BaseDatasetParams:
     cache_directory: Optional[str] = None
     debug_dataset: bool = False
     architecture: str = "no_default"  # short style like "hv" or "wan"
+    watermark_mask_suffix: Optional[str] = "_wmask.png"  # static watermark loss mask, see docs/watermark_mask.md
 
 
 @dataclass
@@ -116,6 +117,7 @@ class ConfigSanitizer:
         "resolution": functools.partial(__validate_and_convert_scalar_or_twodim.__func__, int),
         "enable_bucket": bool,
         "bucket_no_upscale": bool,
+        "watermark_mask_suffix": str,
     }
     IMAGE_DATASET_DISTINCT_SCHEMA = {
         "image_directory": str,
@@ -307,6 +309,7 @@ def generate_dataset_group_by_blueprint(
         bucket_no_upscale: {dataset.bucket_no_upscale}
         cache_directory: "{dataset.cache_directory}"
         debug_dataset: {dataset.debug_dataset}
+        watermark_mask_suffix: "{dataset.watermark_mask_suffix}"
     """
         )
 

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -61,6 +61,9 @@ class ItemInfo:
         self.latent_cache_path = latent_cache_path
         self.text_encoder_output_cache_path: Optional[str] = None
 
+        # static watermark loss mask, next to the source image/video (see `watermark_mask_suffix`)
+        self.watermark_mask_path: Optional[str] = None
+
         # np.ndarray for video, list[np.ndarray] for image with multiple controls
         self.control_content: Optional[Union[np.ndarray, list[np.ndarray]]] = None
 
@@ -115,6 +118,7 @@ class BaseDataset(torch.utils.data.Dataset):
         cache_directory: Optional[str] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        watermark_mask_suffix: Optional[str] = "_wmask.png",
     ):
         self.resolution = resolution
         self.caption_extension = caption_extension
@@ -125,6 +129,7 @@ class BaseDataset(torch.utils.data.Dataset):
         self.cache_directory = cache_directory
         self.debug_dataset = debug_dataset
         self.architecture = architecture
+        self.watermark_mask_suffix = watermark_mask_suffix
         self.seed = None
         self.current_epoch = 0
         self.shared_epoch = None
@@ -140,8 +145,29 @@ class BaseDataset(torch.utils.data.Dataset):
             "num_repeats": self.num_repeats,
             "enable_bucket": bool(self.enable_bucket),
             "bucket_no_upscale": bool(self.bucket_no_upscale),
+            "watermark_mask_suffix": self.watermark_mask_suffix,
         }
         return metadata
+
+    def find_watermark_mask_path(self, item_key: str, source_directory: Optional[str]) -> Optional[str]:
+        """Locate the static watermark loss mask for an item, or return None if there is none.
+
+        The mask is looked up as `{item_key}{watermark_mask_suffix}` next to the source
+        image/video first, then in the cache directory (which is the source directory unless
+        `cache_directory` is set). Masks are entirely optional: a missing mask simply means the
+        whole frame is trained on.
+        """
+        if not self.watermark_mask_suffix:
+            return None
+
+        basename = os.path.splitext(os.path.basename(item_key))[0] + self.watermark_mask_suffix
+        for directory in [source_directory, self.cache_directory]:
+            if directory is None:
+                continue
+            mask_path = os.path.join(directory, basename)
+            if os.path.exists(mask_path):
+                return mask_path
+        return None
 
     def get_all_latent_cache_files(self):
         return glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
@@ -287,6 +313,7 @@ class ImageDataset(BaseDataset):
         control_resolution: Optional[Tuple[int, int]] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        watermark_mask_suffix: Optional[str] = "_wmask.png",
     ):
         super(ImageDataset, self).__init__(
             resolution,
@@ -298,6 +325,7 @@ class ImageDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            watermark_mask_suffix,
         )
         self.image_directory = image_directory
         self.image_jsonl_file = image_jsonl_file
@@ -510,6 +538,7 @@ class ImageDataset(BaseDataset):
         # assign cache files to item info
         # (width, height) -> [ItemInfo] or (width, height, other conds...) -> [ItemInfo]
         bucketed_item_info: dict[Union[tuple[int, int], Any], list[ItemInfo]] = {}
+        num_watermark_masks = 0
         for cache_file in latent_cache_files:
             tokens = os.path.basename(cache_file).split("_")
 
@@ -548,11 +577,16 @@ class ImageDataset(BaseDataset):
 
             item_info = ItemInfo(item_key, "", image_size, bucket_reso, latent_cache_path=cache_file)
             item_info.text_encoder_output_cache_path = text_encoder_output_cache_file
+            item_info.watermark_mask_path = self.find_watermark_mask_path(item_key, self.image_directory)
+            num_watermark_masks += item_info.watermark_mask_path is not None
 
             bucket = bucketed_item_info.get(bucket_reso, [])
             for _ in range(self.num_repeats):
                 bucket.append(item_info)
             bucketed_item_info[bucket_reso] = bucket
+
+        if num_watermark_masks > 0:
+            logger.info(f"found {num_watermark_masks} watermark mask(s) with suffix {self.watermark_mask_suffix}")
 
         # prepare batch manager
         self.batch_manager = BucketBatchManager(bucketed_item_info, self.batch_size, num_timestep_buckets=num_timestep_buckets)
@@ -603,6 +637,7 @@ class VideoDataset(BaseDataset):
         fp_latent_window_size: Optional[int] = 9,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        watermark_mask_suffix: Optional[str] = "_wmask.png",
     ):
         super(VideoDataset, self).__init__(
             resolution,
@@ -614,6 +649,7 @@ class VideoDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            watermark_mask_suffix,
         )
         self.video_directory = video_directory
         self.video_jsonl_file = video_jsonl_file
@@ -862,6 +898,7 @@ class VideoDataset(BaseDataset):
 
         # assign cache files to item info
         bucketed_item_info: dict[tuple[int, int, int], list[ItemInfo]] = {}  # (width, height, frame_count) -> [ItemInfo]
+        num_watermark_masks = 0
         for cache_file in latent_cache_files:
             tokens = os.path.basename(cache_file).split("_")
 
@@ -882,11 +919,16 @@ class VideoDataset(BaseDataset):
             bucket_reso = (*bucket_reso, frame_count)
             item_info = ItemInfo(item_key, "", image_size, bucket_reso, frame_count=frame_count, latent_cache_path=cache_file)
             item_info.text_encoder_output_cache_path = text_encoder_output_cache_file
+            item_info.watermark_mask_path = self.find_watermark_mask_path(item_key, self.video_directory)
+            num_watermark_masks += item_info.watermark_mask_path is not None
 
             bucket = bucketed_item_info.get(bucket_reso, [])
             for _ in range(self.num_repeats):
                 bucket.append(item_info)
             bucketed_item_info[bucket_reso] = bucket
+
+        if num_watermark_masks > 0:
+            logger.info(f"found {num_watermark_masks} watermark mask(s) with suffix {self.watermark_mask_suffix}")
 
         # prepare batch manager
         self.batch_manager = BucketBatchManager(bucketed_item_info, self.batch_size, num_timestep_buckets=num_timestep_buckets)

--- a/src/musubi_tuner/dataset/media_utils.py
+++ b/src/musubi_tuner/dataset/media_utils.py
@@ -137,6 +137,23 @@ def resize_image_to_bucket(image: Union[Image.Image, np.ndarray], bucket_reso: t
     return image
 
 
+def load_watermark_mask(mask_path: str, bucket_reso: tuple[int, int]) -> np.ndarray:
+    """
+    Load a watermark loss mask and align it with the training frames.
+
+    The mask is a grayscale image where 255 means "train on this pixel" and 0 means "ignore
+    this pixel". It goes through exactly the same resize/crop as the video frames
+    (`resize_image_to_bucket`), so the mask stays aligned with the cached latents.
+
+    bucket_reso: **(width, height)**
+
+    Returns a float32 `(height, width)` array in [0, 1].
+    """
+    image = Image.open(mask_path).convert("L")
+    mask = resize_image_to_bucket(image, bucket_reso)
+    return np.clip(mask.astype(np.float32) / 255.0, 0.0, 1.0)
+
+
 def load_video(
     video_path: str,
     start_frame: Optional[int] = None,

--- a/src/musubi_tuner/detect_watermark_mask.py
+++ b/src/musubi_tuner/detect_watermark_mask.py
@@ -1,0 +1,402 @@
+"""Detect a static watermark / logo overlay in videos and write a loss mask for it.
+
+The detector assumes only that the overlay is *static*: it sits at the same place whenever
+it is on screen. It may be opaque or semi-transparent, and it need not be on screen the
+whole time. Two complementary signals are unioned, because neither covers that whole range
+alone (see ``detect_watermark_region``):
+
+* low temporal deviation — an overlay that hides the content behind it, see
+  ``trimmed_temporal_std``. Discarding the most-deviating frames per pixel, up to
+  ``--frame_tolerance`` of them, keeps a watermark that briefly disappears detectable.
+* a frame-to-frame-consistent image gradient — an overlay that only tints the content, see
+  ``consistent_gradient``.
+
+What both signals mark is turned into a bounding box per region, because the mask has to
+cover what the watermark bleeds into once the VAE encodes the frame, not just the pixels
+it literally occupies.
+
+The written PNG follows the convention used by the training scripts:
+
+* ``255`` – train on this pixel
+* ``0``   – ignore this pixel (watermark)
+
+Only ``opencv-python`` and ``numpy`` are required.
+"""
+
+import argparse
+from collections import Counter
+import glob
+import os
+from typing import Optional
+
+import cv2
+import numpy as np
+
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+VIDEO_EXTENSIONS = [".mp4", ".webm", ".avi", ".mkv", ".mov", ".flv", ".wmv", ".m4v", ".mpg", ".mpeg"]
+
+DEFAULT_MASK_SUFFIX = "_wmask.png"
+
+
+def sample_frames(video_path: str, n_frames: int) -> Optional[np.ndarray]:
+    """Read up to ``n_frames`` grayscale frames spread evenly over the video.
+
+    Returns a ``(N, H, W)`` float32 array, or ``None`` if the video could not be read.
+    """
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        cap.release()
+        return None
+
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    frames: list[np.ndarray] = []
+
+    if total_frames > 0:
+        # evenly spaced indices, seeking to each one
+        indices = np.unique(np.linspace(0, total_frames - 1, num=min(n_frames, total_frames)).astype(int))
+        for index in indices:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, int(index))
+            ok, frame = cap.read()
+            if not ok:
+                continue
+            frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY))
+    else:
+        # frame count unknown (some containers): fall back to a sequential read
+        while len(frames) < n_frames:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY))
+
+    cap.release()
+
+    if len(frames) < 2:
+        return None
+
+    # frames can differ in size if the container lies about the resolution; keep the first size
+    height, width = frames[0].shape
+    frames = [f for f in frames if f.shape == (height, width)]
+    if len(frames) < 2:
+        return None
+
+    return np.stack(frames).astype(np.float32)
+
+
+def make_border_mask(height: int, width: int, margin: float) -> np.ndarray:
+    """Boolean mask that is True only inside a border band of ``margin`` (fraction of the frame)."""
+    band_y = max(1, int(round(height * margin)))
+    band_x = max(1, int(round(width * margin)))
+    border = np.ones((height, width), dtype=bool)
+    border[band_y : height - band_y, band_x : width - band_x] = False
+    return border
+
+
+def trimmed_temporal_std(frames: np.ndarray, frame_tolerance: float) -> np.ndarray:
+    """Temporal standard deviation per pixel, ignoring the most deviating frames.
+
+    A watermark is rarely present in literally every frame: it can be briefly occluded by
+    bright content, fade in over the first frames, or be absent from a title card. Those
+    frames alone would blow up a plain ``frames.std(axis=0)`` and hide the watermark.
+
+    So per pixel, the ``frame_tolerance`` fraction of frames furthest from that pixel's
+    temporal median is discarded, and the standard deviation is taken over what remains.
+    The median is used as the reference because it is itself unaffected by a minority of
+    watermark-free frames. With ``frame_tolerance=0`` this is exactly ``frames.std(axis=0)``.
+    """
+    n_frames = frames.shape[0]
+    n_keep = max(2, int(np.ceil(n_frames * (1.0 - frame_tolerance))))
+    if n_keep >= n_frames:
+        return frames.std(axis=0)
+
+    deviation = np.abs(frames - np.median(frames, axis=0))
+
+    # Per-pixel deviation of the n_keep-th closest frame, then keep everything within it.
+    # Ties are kept rather than broken arbitrarily, so a perfectly static pixel keeps all
+    # of its frames instead of an arbitrary subset of identical ones.
+    cutoff = np.partition(deviation, n_keep - 1, axis=0)[n_keep - 1]
+    kept = deviation <= cutoff
+    del deviation
+
+    count = kept.sum(axis=0)
+    mean = (frames * kept).sum(axis=0) / count
+    variance = ((frames - mean) ** 2 * kept).sum(axis=0) / count
+    return np.sqrt(variance)
+
+
+def _temporal_median_sobel(frames: np.ndarray, dx: int, dy: int) -> np.ndarray:
+    """Per-pixel temporal median of one Sobel derivative, computed one axis at a time."""
+    derivatives = np.empty_like(frames)
+    for index, frame in enumerate(frames):
+        derivatives[index] = cv2.Sobel(frame, cv2.CV_32F, dx, dy, ksize=3)
+    return np.median(derivatives, axis=0)
+
+
+def consistent_gradient(frames: np.ndarray, gradient_threshold: float) -> np.ndarray:
+    """Pixels whose image gradient is the same in every sampled frame.
+
+    This is what finds a *semi-transparent* watermark. Blended as
+    ``alpha * W + (1 - alpha) * content``, such a watermark keeps varying with the content
+    underneath, so its temporal deviation is merely scaled by ``1 - alpha``: at 30% opacity
+    it is still 70% of the content's, far above any usable ``--threshold``.
+
+    The gradient does separate it. Content gradients change sign and position from frame to
+    frame and cancel in a temporal median, while the watermark contributes the same
+    ``alpha * grad(W)`` in every frame and survives. The median also tolerates a watermark
+    missing from a minority of frames on its own, without any trimming.
+
+    (The same observation underpins Dekel et al., "On the Effectiveness of Visible
+    Watermarks", CVPR 2017.)
+    """
+    gx = _temporal_median_sobel(frames, 1, 0)
+    gy = _temporal_median_sobel(frames, 0, 1)
+    edges = np.hypot(gx, gy)
+
+    # The watermark covers a small part of the frame, so the median of the map is a good
+    # stand-in for "how much consistent gradient this footage has anyway" — the threshold is
+    # expressed relative to it. The floor keeps footage with almost no texture from making
+    # the threshold collapse to zero.
+    baseline = max(float(np.median(edges)), 1.0)
+    return edges > gradient_threshold * baseline
+
+
+def bounding_boxes(mask: np.ndarray, min_area: int) -> np.ndarray:
+    """Replace each connected region of ``mask`` with its bounding box.
+
+    The detectors return the watermark's *outline* (gradient) or its solid pixels
+    (deviation), neither of which is the region that has to be excluded from the loss. That
+    region is broader than the glyphs themselves: the VAE encoder mixes a neighbourhood of
+    pixels into every latent cell, so a watermark bleeds into latents that its own pixels do
+    not cover, and a mask traced tightly around thin strokes under-masks once it is
+    downsampled to latent resolution.
+
+    A bounding box covers that neighbourhood, needs no morphological reconstruction of the
+    interior, and errs in the safe direction — losing a little clean content around a logo
+    costs far less than leaving watermark in the loss.
+    """
+    num_labels, _, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    boxes = np.zeros_like(mask)
+    for label in range(1, num_labels):  # 0 is the background
+        if stats[label, cv2.CC_STAT_AREA] < min_area:
+            continue
+        x, y = stats[label, cv2.CC_STAT_LEFT], stats[label, cv2.CC_STAT_TOP]
+        width, height = stats[label, cv2.CC_STAT_WIDTH], stats[label, cv2.CC_STAT_HEIGHT]
+        boxes[y : y + height, x : x + width] = 1
+    return boxes
+
+
+def detect_watermark_region(
+    frames: np.ndarray,
+    threshold: float = 8.0,
+    corner_only: bool = False,
+    corner_margin: float = 0.25,
+    dilate: int = 3,
+    min_area: int = 32,
+    frame_tolerance: float = 0.1,
+    gradient_threshold: float = 3.0,
+) -> np.ndarray:
+    """Return a boolean ``(H, W)`` array that is True where the watermark is.
+
+    Two complementary signals are unioned, because neither covers the whole range on its
+    own: low temporal deviation finds an overlay that hides the content behind it, and a
+    frame-to-frame-consistent gradient finds one that only tints it. An opaque logo trips
+    both; a 30% opacity logo trips only the second; a large flat opaque patch trips the
+    first strongly and the second only along its border.
+    """
+    candidate = trimmed_temporal_std(frames, frame_tolerance) < threshold
+    if gradient_threshold > 0:  # non-positive disables the signal; the CLI rejects it
+        candidate |= consistent_gradient(frames, gradient_threshold)
+
+    if corner_only:
+        candidate &= make_border_mask(frames.shape[1], frames.shape[2], corner_margin)
+
+    candidate = candidate.astype(np.uint8)
+
+    # Bridge the two edges of a stroke and any single-pixel holes, so that one logo becomes
+    # one region rather than a scatter of fragments with a bounding box each.
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+    candidate = cv2.morphologyEx(candidate, cv2.MORPH_CLOSE, kernel)
+
+    candidate = bounding_boxes(candidate, min_area)
+
+    if dilate > 0:
+        # Margin around each box: anti-aliased watermark edges blend into the content and
+        # still carry watermark signal.
+        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (dilate * 2 + 1, dilate * 2 + 1))
+        candidate = cv2.dilate(candidate, kernel)
+
+    return candidate.astype(bool)
+
+
+def list_videos(video_dir: str, recursive: bool) -> list[str]:
+    pattern = os.path.join(video_dir, "**", "*") if recursive else os.path.join(video_dir, "*")
+    paths = sorted(p for p in glob.glob(pattern, recursive=recursive) if os.path.isfile(p))
+    return [p for p in paths if os.path.splitext(p)[1].lower() in VIDEO_EXTENSIONS]
+
+
+def process_video(video_path: str, args: argparse.Namespace) -> str:
+    """Detect and write the mask for one video.
+
+    Returns the outcome as one of "written", "exists", "unreadable", "not_detected" or
+    "over_max_coverage", so that `main` can summarize a whole directory at the end.
+    """
+    mask_path = os.path.splitext(video_path)[0] + args.suffix
+    if os.path.exists(mask_path) and not args.overwrite:
+        logger.info(f"Mask already exists, skipping (use --overwrite to regenerate): {mask_path}")
+        return "exists"
+
+    frames = sample_frames(video_path, args.n_frames)
+    if frames is None:
+        logger.warning(f"Could not read enough frames, skipping: {video_path}")
+        return "unreadable"
+
+    watermark = detect_watermark_region(
+        frames,
+        args.threshold,
+        args.corner_only,
+        args.corner_margin,
+        args.dilate,
+        args.min_area,
+        args.frame_tolerance,
+        args.gradient_threshold,
+    )
+
+    coverage = float(watermark.mean())
+    if coverage == 0.0:
+        logger.info(f"No static watermark detected, no mask written: {video_path}")
+        return "not_detected"
+
+    if coverage > args.max_coverage:
+        # Usually a locked-off camera: everything is temporally static, so the detection is
+        # meaningless. Extreme letterboxing can reach this too — the bars are a correct
+        # detection, there are just so many of them that cropping beats masking.
+        logger.warning(
+            f"Detected watermark covers {coverage:.1%} of the frame (> --max_coverage {args.max_coverage:.1%}),"
+            f" no mask written. The camera is probably static, or the clip is heavily letterboxed;"
+            f" try --corner_only, crop the clip, or drop it: {video_path}"
+        )
+        return "over_max_coverage"
+
+    mask = np.where(watermark, 0, 255).astype(np.uint8)
+    if args.output_dir is not None:
+        os.makedirs(args.output_dir, exist_ok=True)
+        mask_path = os.path.join(args.output_dir, os.path.basename(mask_path))
+    cv2.imwrite(mask_path, mask)
+    logger.info(f"Wrote mask covering {coverage:.2%} of the frame: {mask_path}")
+    return "written"
+
+
+def setup_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect a static watermark in videos and write a per-video loss mask (255 = train, 0 = ignore)."
+    )
+    parser.add_argument("--video_dir", type=str, required=True, help="directory containing the videos")
+    parser.add_argument("--recursive", action="store_true", help="search --video_dir recursively")
+    parser.add_argument(
+        "--n_frames",
+        type=int,
+        default=30,
+        help="number of frames sampled per video (default: 30). More frames make the detection more reliable on"
+        " slow-moving footage, and let content gradients cancel out better, which is what makes a"
+        " semi-transparent watermark stand out",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=8.0,
+        help="temporal standard deviation below which a pixel is considered static (0-255 scale, default: 8.0)",
+    )
+    parser.add_argument(
+        "--frame_tolerance",
+        type=float,
+        default=0.1,
+        help="fraction of sampled frames allowed to not show the watermark (default: 0.1)."
+        " Per pixel, that many of the most deviating frames are discarded before measuring the deviation,"
+        " so a watermark that briefly disappears, is occluded, or fades in and out is still detected."
+        " Set to 0 to require the watermark in every sampled frame",
+    )
+    parser.add_argument(
+        "--gradient_threshold",
+        type=float,
+        default=3.0,
+        help="how far above the frame's own median a pixel's frame-to-frame-consistent gradient must be"
+        " to count as a semi-transparent watermark edge (default: 3.0, i.e. 3x that median)."
+        " Ordinary content and static background sit around 1x, a watermark at 20-50%% opacity lands"
+        " between 3x and 14x depending on opacity and --n_frames."
+        " Lower it if a faint watermark is missed, raise it if unrelated static structure is picked up",
+    )
+    parser.add_argument(
+        "--corner_only",
+        action="store_true",
+        help="only look for the watermark in a band along the frame border (see --corner_margin)",
+    )
+    parser.add_argument(
+        "--corner_margin",
+        type=float,
+        default=0.25,
+        help="width of the border band for --corner_only, as a fraction of the frame size (default: 0.25)",
+    )
+    parser.add_argument("--dilate", type=int, default=3, help="dilate the detected region by N pixels (default: 3)")
+    parser.add_argument("--min_area", type=int, default=32, help="drop detected regions smaller than N pixels (default: 32)")
+    parser.add_argument(
+        "--max_coverage",
+        type=float,
+        default=0.4,
+        help="skip the video if the detected region covers more than this fraction of the frame (default: 0.4)."
+        " The bound exists for locked-off shots, where the whole frame is temporally static and the detection"
+        " stops meaning anything; those measure around 0.8. Letterbox bars are a legitimate detection and eat"
+        " up to a third of the frame on their own, which is why the default sits between the two",
+    )
+    parser.add_argument(
+        "--suffix", type=str, default=DEFAULT_MASK_SUFFIX, help=f"mask file suffix (default: {DEFAULT_MASK_SUFFIX})"
+    )
+    parser.add_argument(
+        "--output_dir", type=str, default=None, help="write masks here instead of next to the videos (default: next to the video)"
+    )
+    parser.add_argument("--overwrite", action="store_true", help="regenerate masks that already exist")
+    return parser
+
+
+def main() -> None:
+    args = setup_parser().parse_args()
+
+    if not os.path.isdir(args.video_dir):
+        raise ValueError(f"--video_dir is not a directory: {args.video_dir}")
+    if not 0.0 <= args.frame_tolerance < 1.0:
+        raise ValueError(f"--frame_tolerance must be in [0, 1): {args.frame_tolerance}")
+    if args.gradient_threshold <= 0.0:
+        raise ValueError(f"--gradient_threshold must be positive: {args.gradient_threshold}")
+
+    video_paths = list_videos(args.video_dir, args.recursive)
+    if not video_paths:
+        logger.warning(f"No videos found in {args.video_dir}")
+        return
+
+    logger.info(f"Found {len(video_paths)} videos")
+    outcomes = Counter(process_video(video_path, args) for video_path in video_paths)
+
+    logger.info(f"Done. Wrote {outcomes['written']} mask(s) for {len(video_paths)} video(s).")
+    for outcome, message in [
+        ("exists", "already had a mask (use --overwrite to regenerate)"),
+        ("not_detected", "had no detectable static watermark"),
+        ("unreadable", "could not be read"),
+    ]:
+        if outcomes[outcome]:
+            logger.info(f"  {outcomes[outcome]} video(s) {message}")
+
+    # Surfaced separately: a large batch of these means the threshold or --corner_only needs
+    # revisiting, and the individual warnings are easy to lose in a long log.
+    if outcomes["over_max_coverage"]:
+        logger.warning(
+            f"  {outcomes['over_max_coverage']} video(s) exceeded --max_coverage"
+            f" ({args.max_coverage:.1%} of the frame) and were left without a mask."
+            " Re-run with --corner_only, crop letterboxed clips, or drop those clips."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/musubi_tuner/hidream_o1_train_network.py
+++ b/src/musubi_tuner/hidream_o1_train_network.py
@@ -853,8 +853,9 @@ class HiDreamO1NetworkTrainer(NetworkTrainer):
         dit_dtype: torch.dtype,
         network_dtype: torch.dtype,
         global_step: int,
+        batch: Optional[dict[str, torch.Tensor]] = None,
     ) -> tuple[torch.Tensor, dict[str, float]]:
-        loss, metrics = super().compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
+        loss, metrics = super().compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step, batch)
         loss, dino_logs = self.apply_dino_loss(args, loss, output.pred, output.target, output.extra["pixel_grid_hw"], global_step)
         if dino_logs:
             metrics = {**metrics, **dino_logs}

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -26,6 +26,7 @@ from musubi_tuner.training.trainer_base import (
     SS_METADATA_KEY_NETWORK_ALPHA,
     SS_METADATA_KEY_NETWORK_ARGS,
     SS_METADATA_MINIMUM_KEYS,
+    reduce_loss,
 )
 from musubi_tuner.training.accelerator_setup import (
     clean_memory_on_device,
@@ -79,6 +80,7 @@ __all__ = [
     "SS_METADATA_KEY_NETWORK_ALPHA",
     "SS_METADATA_KEY_NETWORK_ARGS",
     "SS_METADATA_MINIMUM_KEYS",
+    "reduce_loss",
     # accelerator_setup
     "clean_memory_on_device",
     "collator_class",

--- a/src/musubi_tuner/ideogram4_train_network.py
+++ b/src/musubi_tuner/ideogram4_train_network.py
@@ -13,7 +13,7 @@ from musubi_tuner.ideogram4.sampling_policy import should_use_unconditional_dit_
 from musubi_tuner.ideogram4.sampler_configs import PRESETS
 from musubi_tuner.training.parser_common import read_config_from_file, setup_parser_common
 from musubi_tuner.training.sampling_prompts import load_prompts
-from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
+from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer, reduce_loss
 from musubi_tuner.utils import model_utils
 from musubi_tuner.utils.device_utils import clean_memory_on_device
 
@@ -330,6 +330,7 @@ class Ideogram4NetworkTrainer(NetworkTrainer):
         dit_dtype: torch.dtype,
         network_dtype: torch.dtype,
         global_step: int,
+        batch: Optional[dict[str, torch.Tensor]] = None,
     ) -> tuple[torch.Tensor, dict[str, float]]:
         # Plain mean MSE in flow-matching velocity space. Ideogram 4 does not use the
         # SD3 weighting_scheme, so this owns the full loss formulation rather than
@@ -337,7 +338,7 @@ class Ideogram4NetworkTrainer(NetworkTrainer):
         del noise_scheduler, dit_dtype, global_step
         pred = output.pred.to(network_dtype)
         target = output.target.to(network_dtype)
-        loss = torch.nn.functional.mse_loss(pred, target, reduction="mean")
+        loss = reduce_loss(torch.nn.functional.mse_loss(pred, target, reduction="none"), batch)
 
         loss_metrics = {}
         if getattr(args, "log_loss_stats", False):

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -99,6 +99,48 @@ class DiTOutput:
     extra: dict = field(default_factory=dict)
 
 
+_warned_watermark_mask_unsupported = False
+
+
+def reduce_loss(loss: torch.Tensor, batch: Optional[dict[str, torch.Tensor]] = None) -> torch.Tensor:
+    """Reduce a per-element loss to a scalar, honouring an optional watermark loss mask.
+
+    Without a mask (the default) this is a plain ``loss.mean()``. When the batch carries a
+    ``watermark_mask`` — a ``(H, W)`` or ``(B, H, W)`` tensor in [0, 1] where 0 marks the
+    watermark — the masked-out pixels are excluded from the loss, and therefore from the
+    gradients, while the frame itself is trained at full size. See ``docs/watermark_mask.md``.
+
+    The mask is in pixel space, so it is area-downsampled to the spatial size of the loss
+    (i.e. the latent resolution) and broadcast over channels and frames. The result is
+    normalized by the mask weight so its scale stays comparable to the unmasked mean.
+    """
+    mask = None if batch is None else batch.get("watermark_mask")
+    if mask is None:
+        return loss.mean()
+
+    if loss.ndim not in (4, 5):
+        # Patchified/sequence-shaped losses (most image DiTs) have no spatial layout to mask.
+        global _warned_watermark_mask_unsupported
+        if not _warned_watermark_mask_unsupported:
+            _warned_watermark_mask_unsupported = True
+            logger.warning(
+                f"watermark_mask is ignored: loss has shape {tuple(loss.shape)}, which is not a spatial"
+                " (B, C, H, W) or (B, C, T, H, W) layout"
+            )
+        return loss.mean()
+
+    mask = mask.to(device=loss.device, dtype=loss.dtype)
+    mask = mask.reshape(-1, 1, *mask.shape[-2:])  # (H, W) or (B, H, W) -> (B or 1, 1, H, W)
+    mask = torch.nn.functional.interpolate(mask, size=loss.shape[-2:], mode="area")
+    if loss.ndim == 5:
+        mask = mask.unsqueeze(2)  # (B, 1, H, W) -> (B, 1, 1, H, W), broadcast over frames
+
+    masked_loss = loss * mask
+    # Denominator counts the mask weight per loss element, so a fully-open mask reproduces mean().
+    denominator = mask.expand_as(loss).sum()
+    return masked_loss.sum() / denominator.clamp(min=1e-8)
+
+
 class NetworkTrainer:
     def __init__(self):
         self.blocks_to_swap = None
@@ -1172,7 +1214,7 @@ class NetworkTrainer:
         )
 
         output = self.call_dit(args, accelerator, transformer, latents, batch, noise, noisy_model_input, timesteps, network_dtype)
-        return self.compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
+        return self.compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step, batch)
 
     def compute_loss(
         self,
@@ -1183,6 +1225,7 @@ class NetworkTrainer:
         dit_dtype: torch.dtype,
         network_dtype: torch.dtype,
         global_step: int,
+        batch: Optional[dict[str, torch.Tensor]] = None,
     ) -> tuple[torch.Tensor, dict[str, float]]:
         """Reduce a ``DiTOutput`` to a scalar loss + per-step metrics dict.
 
@@ -1198,12 +1241,17 @@ class NetworkTrainer:
         auxiliary loss only every N steps). ``loss_metrics`` defaults to empty;
         populate with named scalars for loss-decomposition logging
         (e.g. ``{"loss/gen": ..., "loss/rep": ...}``).
+
+        ``batch`` is the raw dataset batch; the default implementation only reads
+        the optional ``watermark_mask`` from it (see ``reduce_loss``). Overrides
+        that reduce the loss themselves should go through ``reduce_loss`` too, so
+        the mask keeps working.
         """
         weighting = compute_loss_weighting_for_sd3(args.weighting_scheme, noise_scheduler, timesteps, timesteps.device, dit_dtype)
         loss = torch.nn.functional.mse_loss(output.pred.to(network_dtype), output.target, reduction="none")
         if weighting is not None:
             loss = loss * weighting
-        return loss.mean(), {}
+        return reduce_loss(loss, batch), {}
 
     def on_transformer_loaded(
         self,

--- a/tests/test_ideogram4_synthetic.py
+++ b/tests/test_ideogram4_synthetic.py
@@ -562,6 +562,8 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         fake_trainer.DiTOutput = DiTOutput
         fake_trainer.NetworkTrainer = NetworkTrainer
+        # mirrors trainer_base.reduce_loss for a batch without a watermark mask
+        fake_trainer.reduce_loss = lambda loss, batch=None: loss.mean()
 
         try:
             sys.modules["musubi_tuner.dataset.image_video_dataset"] = fake_image_video
@@ -700,6 +702,8 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         fake_trainer.DiTOutput = DiTOutput
         fake_trainer.NetworkTrainer = NetworkTrainer
+        # mirrors trainer_base.reduce_loss for a batch without a watermark mask
+        fake_trainer.reduce_loss = lambda loss, batch=None: loss.mean()
 
         try:
             sys.modules["musubi_tuner.dataset.image_video_dataset"] = fake_image_video
@@ -783,6 +787,8 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
 
         fake_trainer.DiTOutput = DiTOutput
         fake_trainer.NetworkTrainer = NetworkTrainer
+        # mirrors trainer_base.reduce_loss for a batch without a watermark mask
+        fake_trainer.reduce_loss = lambda loss, batch=None: loss.mean()
 
         try:
             sys.modules["musubi_tuner.dataset.image_video_dataset"] = fake_image_video

--- a/tests/test_watermark_mask.py
+++ b/tests/test_watermark_mask.py
@@ -1,0 +1,439 @@
+import numpy as np
+import pytest
+import torch
+
+from musubi_tuner.dataset.bucket import BucketBatchManager
+from musubi_tuner.dataset.image_video_dataset import ItemInfo, VideoDataset
+from musubi_tuner.detect_watermark_mask import (
+    bounding_boxes,
+    consistent_gradient,
+    detect_watermark_region,
+    make_border_mask,
+    trimmed_temporal_std,
+)
+from musubi_tuner.training.trainer_base import reduce_loss
+
+
+# region detection
+
+
+def _synthetic_frames(height=64, width=96, n_frames=16, watermark_box=(50, 60, 80, 90)):
+    """Moving content everywhere, plus a constant bright block (the "watermark")."""
+    rng = np.random.default_rng(0)
+    frames = rng.integers(0, 256, size=(n_frames, height, width)).astype(np.float32)
+    y0, y1, x0, x1 = watermark_box
+    frames[:, y0:y1, x0:x1] = 200.0
+    return frames
+
+
+def test_detect_watermark_region_finds_static_block():
+    # the deviation signal on its own: an opaque block has a temporal std of 0
+    frames = _synthetic_frames()
+    watermark = detect_watermark_region(frames, dilate=0, min_area=0, gradient_threshold=0.0)
+
+    assert watermark[50:60, 80:90].all()
+    # nothing outside the block, the moving content has a high temporal std
+    outside = watermark.copy()
+    outside[50:60, 80:90] = False
+    assert not outside.any()
+
+
+def test_detect_watermark_region_corner_only_ignores_center():
+    # a static block in the middle of the frame is not a watermark under --corner_only
+    frames = _synthetic_frames(watermark_box=(28, 36, 44, 52))
+    watermark = detect_watermark_region(frames, corner_only=True, dilate=0, min_area=0, gradient_threshold=0.0)
+    assert not watermark.any()
+
+
+def test_detect_watermark_region_tolerates_frames_without_the_watermark():
+    # the watermark is missing from 3 of 30 frames (10%): a plain temporal std would be
+    # dominated by those frames and miss it entirely
+    rng = np.random.default_rng(0)
+    frames = rng.integers(0, 256, size=(30, 64, 96)).astype(np.float32)
+    frames[:, 50:60, 80:90] = 200.0
+    frames[:3, 50:60, 80:90] = 20.0  # the watermark is not on screen in these frames
+
+    strict = detect_watermark_region(frames, dilate=0, min_area=0, frame_tolerance=0.0, gradient_threshold=0.0)
+    assert not strict[50:60, 80:90].any()
+
+    tolerant = detect_watermark_region(frames, dilate=0, min_area=0, frame_tolerance=0.1, gradient_threshold=0.0)
+    assert tolerant[50:60, 80:90].all()
+
+    outside = tolerant.copy()
+    outside[50:60, 80:90] = False
+    assert not outside.any()  # tolerating dropped frames must not start matching moving content
+
+
+def test_trimmed_temporal_std_matches_plain_std_without_tolerance():
+    rng = np.random.default_rng(1)
+    frames = rng.normal(128.0, 20.0, size=(12, 8, 8)).astype(np.float32)
+    assert np.allclose(trimmed_temporal_std(frames, 0.0), frames.std(axis=0), atol=1e-4)
+
+
+def test_trimmed_temporal_std_keeps_all_frames_of_a_constant_pixel():
+    # ties must not be broken arbitrarily: an exactly constant pixel stays at std 0
+    frames = np.full((10, 4, 4), 77.0, dtype=np.float32)
+    assert np.allclose(trimmed_temporal_std(frames, 0.3), 0.0)
+
+
+def _translucent_frames(alpha, n_frames=24, height=96, width=160):
+    """Moving textured content with an alpha-blended static logo, plus a near-static region.
+
+    The near-static patch is deliberate bait: it is what a "low temporal deviation means
+    watermark" rule would wrongly pick up, so it must stay out of the result.
+    """
+    import cv2
+
+    rng = np.random.default_rng(2)
+    logo = np.zeros((height, width), np.uint8)
+    cv2.rectangle(logo, (width - 45, height - 30), (width - 10, height - 10), 255, 2)
+    logo = logo.astype(np.float32) / 255.0
+
+    # near-static "sky", feathered into the moving content so it has no hard edge of its own
+    # (a static hard edge is a consistent gradient, and would be picked up as a watermark)
+    sky = np.zeros((height, width), np.float32)
+    sky[:28, :44] = 1.0
+    sky = cv2.GaussianBlur(sky, (0, 0), 6)
+
+    frames = np.empty((n_frames, height, width), np.float32)
+    for i in range(n_frames):
+        content = cv2.GaussianBlur(rng.random((height, width)).astype(np.float32), (0, 0), 3)
+        content = cv2.normalize(content, None, 0, 255, cv2.NORM_MINMAX)  # full-contrast texture
+        content = np.roll(content, i * 7, axis=1)
+        content = (1.0 - sky) * content + sky * (190.0 + rng.normal(0, 2, (height, width)))
+        frames[i] = alpha * logo * 255.0 + (1.0 - alpha * logo) * np.clip(content, 0, 255)
+
+    return frames, logo > 0.5
+
+
+def test_translucent_watermark_is_missed_by_deviation_but_found_by_the_gradient_pass():
+    frames, logo = _translucent_frames(alpha=0.3)
+
+    # a 30% opacity overlay only scales the temporal deviation by 1 - alpha, nowhere near
+    # the threshold, so the deviation pass alone cannot see it
+    deviation_only = detect_watermark_region(frames, dilate=0, min_area=0, gradient_threshold=0.0)
+    assert deviation_only[logo].mean() < 0.1
+
+    both_signals = detect_watermark_region(frames, dilate=0, min_area=0)
+    assert both_signals[logo].all()
+
+
+def test_gradient_signal_does_not_claim_a_near_static_background():
+    # a feathered static region has a consistent gradient too, but a far weaker one; the
+    # gradient signal is isolated here because the deviation signal legitimately flags static
+    # regions (that is what --corner_only and --max_coverage exist for)
+    frames, _ = _translucent_frames(alpha=0.3)
+    assert not consistent_gradient(frames, gradient_threshold=3.0)[:20, :36].any()
+
+
+def test_detection_covers_the_interior_of_an_outlined_shape():
+    # the gradient only marks the rectangle's edges; the bounding box has to cover the inside
+    frames, _ = _translucent_frames(alpha=0.5)
+    detected = detect_watermark_region(frames, dilate=0)
+
+    height, width = detected.shape
+    interior = np.zeros((height, width), bool)
+    interior[height - 27 : height - 13, width - 42 : width - 13] = True
+    assert detected[interior].all()
+
+
+def test_bounding_boxes_covers_a_hollow_shape():
+    import cv2
+
+    ring = np.zeros((40, 40), np.uint8)
+    cv2.circle(ring, (20, 20), 12, 1, 2)
+    boxed = bounding_boxes(ring, min_area=0)
+
+    assert boxed[20, 20] == 1  # the hole is covered
+    assert boxed[8:33, 8:33].all()  # and so is the whole box around the circle
+    assert boxed[0, 0] == 0  # but nothing outside it
+
+
+def test_bounding_boxes_keeps_separate_regions_separate():
+    # two logos in opposite corners must not merge into one box spanning the frame
+    mask = np.zeros((40, 40), np.uint8)
+    mask[2:6, 2:6] = 1
+    mask[34:38, 34:38] = 1
+    boxed = bounding_boxes(mask, min_area=0)
+
+    assert boxed[2:6, 2:6].all() and boxed[34:38, 34:38].all()
+    assert not boxed[18:22, 18:22].any()
+
+
+def test_bounding_boxes_drops_regions_below_min_area():
+    mask = np.zeros((40, 40), np.uint8)
+    mask[2:4, 2:4] = 1  # 4 px
+    mask[20:30, 20:30] = 1  # 100 px
+    boxed = bounding_boxes(mask, min_area=32)
+
+    assert not boxed[2:4, 2:4].any()
+    assert boxed[20:30, 20:30].all()
+
+
+def _detect_args(tmp_path, **overrides):
+    from types import SimpleNamespace
+
+    defaults = dict(
+        video_dir=str(tmp_path),
+        recursive=False,
+        n_frames=16,
+        threshold=8.0,
+        corner_only=False,
+        corner_margin=0.25,
+        dilate=0,
+        min_area=0,
+        frame_tolerance=0.1,
+        gradient_threshold=3.0,
+        max_coverage=0.4,
+        suffix="_wmask.png",
+        output_dir=None,
+        overwrite=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _write_synthetic_video(path, static_background: bool):
+    import cv2
+
+    rng = np.random.default_rng(0)
+    height, width, n_frames = 64, 96, 24
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), 24.0, (width, height))
+    background = rng.integers(0, 256, size=(height, width, 3), dtype=np.uint8)
+    for _ in range(n_frames):
+        frame = background.copy() if static_background else rng.integers(0, 256, (height, width, 3), dtype=np.uint8)
+        frame[50:60, 80:90] = 200  # the static "watermark"
+        writer.write(frame)
+    writer.release()
+
+
+def test_process_video_writes_a_mask(tmp_path):
+    from musubi_tuner.detect_watermark_mask import process_video
+
+    video_path = tmp_path / "clip.mp4"
+    _write_synthetic_video(video_path, static_background=False)
+
+    assert process_video(str(video_path), _detect_args(tmp_path)) == "written"
+    assert (tmp_path / "clip_wmask.png").exists()
+
+
+def test_process_video_refuses_to_mask_more_than_max_coverage(tmp_path):
+    # a locked-off shot is temporally static everywhere, so the detection is meaningless:
+    # the boundary must stop it from masking most of the frame
+    from musubi_tuner.detect_watermark_mask import process_video
+
+    video_path = tmp_path / "static.mp4"
+    _write_synthetic_video(video_path, static_background=True)
+
+    assert process_video(str(video_path), _detect_args(tmp_path)) == "over_max_coverage"
+    assert not (tmp_path / "static_wmask.png").exists()
+
+    # raising the limit lets the same detection through, so the guard is what blocked it
+    assert process_video(str(video_path), _detect_args(tmp_path, max_coverage=1.0)) == "written"
+
+
+def test_process_video_skips_an_existing_mask_unless_overwriting(tmp_path):
+    from musubi_tuner.detect_watermark_mask import process_video
+
+    video_path = tmp_path / "clip.mp4"
+    _write_synthetic_video(video_path, static_background=False)
+    (tmp_path / "clip_wmask.png").write_bytes(b"")
+
+    assert process_video(str(video_path), _detect_args(tmp_path)) == "exists"
+    assert process_video(str(video_path), _detect_args(tmp_path, overwrite=True)) == "written"
+
+
+def test_make_border_mask_keeps_only_the_perimeter():
+    border = make_border_mask(100, 100, 0.25)
+    assert border[0, 0] and border[99, 99]
+    assert not border[50, 50]
+    assert border.mean() == pytest.approx(1.0 - 0.5 * 0.5)
+
+
+# endregion detection
+
+# region loss reduction
+
+
+def test_reduce_loss_without_mask_is_plain_mean():
+    loss = torch.rand(2, 4, 3, 8, 8)
+    assert torch.allclose(reduce_loss(loss, {}), loss.mean())
+    assert torch.allclose(reduce_loss(loss, None), loss.mean())
+    assert torch.allclose(reduce_loss(loss, {"watermark_mask": None}), loss.mean())
+
+
+def test_reduce_loss_with_open_mask_matches_mean():
+    loss = torch.rand(2, 4, 3, 8, 8)
+    mask = torch.ones(2, 64, 64)
+    assert torch.allclose(reduce_loss(loss, {"watermark_mask": mask}), loss.mean(), atol=1e-6)
+
+
+def test_reduce_loss_excludes_masked_region():
+    # right half of the latent grid is masked out; put a huge loss there and check it is ignored
+    loss = torch.ones(1, 4, 3, 8, 8)
+    loss[..., 4:] = 1000.0
+
+    mask = torch.ones(1, 64, 64)
+    mask[:, :, 32:] = 0.0
+
+    assert torch.allclose(reduce_loss(loss, {"watermark_mask": mask}), torch.tensor(1.0), atol=1e-4)
+
+
+def test_reduce_loss_is_per_sample():
+    loss = torch.ones(2, 1, 1, 4, 4)
+    loss[1] = 3.0
+
+    mask = torch.ones(2, 32, 32)
+    mask[1] = 0.0  # second sample fully masked out -> only the first one contributes
+
+    assert torch.allclose(reduce_loss(loss, {"watermark_mask": mask}), torch.tensor(1.0), atol=1e-4)
+
+
+def test_reduce_loss_accepts_unbatched_mask_and_4d_loss():
+    loss = torch.ones(2, 4, 8, 8)
+    loss[..., 4:] = 5.0
+
+    mask = torch.ones(64, 64)
+    mask[:, 32:] = 0.0
+
+    assert torch.allclose(reduce_loss(loss, {"watermark_mask": mask}), torch.tensor(1.0), atol=1e-4)
+
+
+def test_reduce_loss_ignores_mask_for_non_spatial_loss():
+    # patchified / sequence-shaped losses have no spatial layout: fall back to mean()
+    loss = torch.rand(2, 256, 64)
+    mask = torch.ones(2, 64, 64)
+    assert torch.allclose(reduce_loss(loss, {"watermark_mask": mask}), loss.mean())
+
+
+# endregion loss reduction
+
+# region dataset plumbing
+
+
+def _make_dataset(tmp_path, **kwargs):
+    return VideoDataset(
+        resolution=(64, 64),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=False,
+        bucket_no_upscale=False,
+        target_frames=[1],
+        video_directory=str(tmp_path),
+        architecture="wan",
+        **kwargs,
+    )
+
+
+def test_find_watermark_mask_path(tmp_path):
+    dataset = _make_dataset(tmp_path)
+    assert dataset.find_watermark_mask_path("clip", str(tmp_path)) is None
+
+    mask_path = tmp_path / "clip_wmask.png"
+    mask_path.write_bytes(b"")
+    assert dataset.find_watermark_mask_path("clip", str(tmp_path)) == str(mask_path)
+
+
+def test_find_watermark_mask_path_honours_custom_suffix(tmp_path):
+    dataset = _make_dataset(tmp_path, watermark_mask_suffix="_logo.png")
+    (tmp_path / "clip_wmask.png").write_bytes(b"")
+    assert dataset.find_watermark_mask_path("clip", str(tmp_path)) is None
+
+    (tmp_path / "clip_logo.png").write_bytes(b"")
+    assert dataset.find_watermark_mask_path("clip", str(tmp_path)) == str(tmp_path / "clip_logo.png")
+
+
+def test_find_watermark_mask_path_disabled(tmp_path):
+    dataset = _make_dataset(tmp_path, watermark_mask_suffix=None)
+    (tmp_path / "clip_wmask.png").write_bytes(b"")
+    assert dataset.find_watermark_mask_path("clip", str(tmp_path)) is None
+
+
+def _write_item(tmp_path, name, mask: bool):
+    from safetensors.torch import save_file
+
+    latent_path = tmp_path / f"{name}.safetensors"
+    save_file({"latents_1x8x8_float32": torch.zeros(4, 1, 8, 8)}, str(latent_path))
+    te_path = tmp_path / f"{name}_te.safetensors"
+    save_file({"context": torch.zeros(4, 8)}, str(te_path))
+
+    item = ItemInfo(name, "", (64, 64), (64, 64, 1), frame_count=1, latent_cache_path=str(latent_path))
+    item.text_encoder_output_cache_path = str(te_path)
+    if mask:
+        from PIL import Image
+
+        mask_array = np.full((64, 64), 255, dtype=np.uint8)
+        mask_array[:, 32:] = 0
+        mask_path = tmp_path / f"{name}_wmask.png"
+        Image.fromarray(mask_array).save(mask_path)
+        item.watermark_mask_path = str(mask_path)
+    return item
+
+
+def test_batch_manager_omits_key_without_masks(tmp_path):
+    item = _write_item(tmp_path, "no_mask", mask=False)
+    batch = BucketBatchManager({(64, 64, 1): [item]}, batch_size=1)[0]
+    assert "watermark_mask" not in batch
+
+
+def test_batch_manager_loads_mask(tmp_path):
+    item = _write_item(tmp_path, "with_mask", mask=True)
+    batch = BucketBatchManager({(64, 64, 1): [item]}, batch_size=1)[0]
+
+    mask = batch["watermark_mask"]
+    assert mask.shape == (1, 64, 64)
+    assert mask.dtype == torch.float32
+    assert mask[0, :, :32].eq(1.0).all()
+    assert mask[0, :, 32:].eq(0.0).all()
+
+
+def test_batch_manager_fills_missing_masks_with_ones(tmp_path):
+    items = [_write_item(tmp_path, "a", mask=True), _write_item(tmp_path, "b", mask=False)]
+    batch = BucketBatchManager({(64, 64, 1): items}, batch_size=2)[0]
+
+    mask = batch["watermark_mask"]
+    assert mask.shape == (2, 64, 64)
+    assert mask[1].eq(1.0).all()  # the item without a mask is trained on in full
+
+
+# endregion dataset plumbing
+
+# region end-to-end
+
+
+def test_prepare_for_training_picks_up_the_mask_and_masks_the_loss(tmp_path):
+    from PIL import Image
+    from safetensors.torch import save_file
+
+    # cache files as written by wan_cache_latents.py: "{stem}_{frame_pos}-{frame_count}_{WxH}_{arch}.safetensors"
+    save_file({"latents_1x8x8_float32": torch.zeros(4, 1, 8, 8)}, str(tmp_path / "clip_00000-001_0064x0064_wan.safetensors"))
+    save_file({"context": torch.zeros(4, 8)}, str(tmp_path / "clip_wan_te.safetensors"))
+
+    # bottom-right quarter of the frame is the watermark
+    mask_array = np.full((64, 64), 255, dtype=np.uint8)
+    mask_array[32:, 32:] = 0
+    Image.fromarray(mask_array).save(tmp_path / "clip_wmask.png")
+
+    dataset = _make_dataset(tmp_path, cache_directory=str(tmp_path))
+    dataset.prepare_for_training()
+    batch = dataset.batch_manager[0]
+
+    assert batch["watermark_mask"].shape == (1, 64, 64)
+
+    # the masked quarter of the latent grid is ignored, so its loss does not reach the scalar
+    loss = torch.ones(1, 16, 1, 8, 8)
+    loss[..., 4:, 4:] = 1000.0
+    assert torch.allclose(reduce_loss(loss, batch), torch.tensor(1.0), atol=1e-4)
+
+
+def test_top_level_entrypoint_exists():
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[1] / "detect_watermark_mask.py"
+    assert script.read_text(encoding="utf-8") == (
+        'from musubi_tuner.detect_watermark_mask import main\n\nif __name__ == "__main__":\n    main()\n'
+    )
+
+
+# endregion end-to-end


### PR DESCRIPTION
Related to #898 (Masked Video Training) and #227 (Training without learning the background) — this covers the static-watermark case of both, not general per-subject masked training, so neither is closed by it.

## What changed and why

Training footage often carries a burned-in logo or watermark. Without a mask, the model learns the watermark along with the concept and it shows up in generated videos. Cropping the watermark away throws the rest of the frame away with it and changes the composition the model sees.

This PR excludes the watermark region from the **loss** instead. The frame stays full size and is encoded normally; the masked pixels simply produce no gradients.

Only **static** watermarks are supported — the overlay must sit at the same place whenever it is on screen. Within that it can be opaque or semi-transparent, and it does not have to be on screen the whole time: a watermark that briefly disappears, is occluded, or fades in and out is still detected, up to a configurable fraction of frames (`--frame_tolerance`, 10% by default). What a single mask genuinely cannot describe is a watermark that *moves* across the frame, so those clips should be dropped from the dataset instead. That last limit is a deliberate scope choice, not an oversight.

Masks are optional and there is no new training argument. With no mask file present the behaviour is identical to the current behaviour.

## Changes

**`src/musubi_tuner/detect_watermark_mask.py`** (+ top-level `detect_watermark_mask.py` entrypoint)

Detects static watermarks by comparing frames sampled evenly across each video: a watermark pixel has a near-zero temporal standard deviation while the content underneath changes. Writes `{video_stem}_wmask.png` next to each video (255 = train, 0 = ignore). Only `opencv-python` and `numpy` are required, so it runs independently of training.

The deviation is measured with the most-deviating frames trimmed away per pixel — `--frame_tolerance` of them, 10% by default, referenced against the temporal median so that a minority of watermark-free frames cannot skew it. A plain `std` over all frames would be dominated by the handful of frames where an intermittent watermark is off screen, and would miss it entirely. `--frame_tolerance 0` restores the strict every-frame criterion. Note the fraction is over the *sampled* frames, so an unlucky sampling stride can over-represent the watermark-free ones; raising `--n_frames` alongside it helps.

```bash
python src/musubi_tuner/detect_watermark_mask.py --video_dir /path/to/video_dir --corner_only
```

**Two signals, unioned.** Low temporal deviation finds an overlay that hides the content behind it. It cannot find a semi-transparent one: blended as `alpha * W + (1 - alpha) * content`, that keeps varying with the content and its deviation is merely scaled by `1 - alpha`. On synthetic footage with a content deviation of 65, a 30% opacity mark still measures 45.6 — no threshold catches that without also swallowing every calm region of the frame.

So a second signal looks at the image gradient. Content gradients change between frames and cancel in a temporal median; the watermark contributes the same `alpha * grad(W)` in every frame and survives. `--gradient_threshold` is expressed relative to the frame's own median surviving gradient: ordinary content and static background sit around 1x, a 20-50% opacity watermark lands between 3x and 14x, so the default of 3.0 has margin on both sides, and raising `--n_frames` widens the gap. End to end on 25 / 40 / 60% opacity clips, deviation alone finds nothing and the union finds all three.

The two are not ordered and there is no mode to choose: both run on every clip. Neither covers the whole range alone — an opaque logo trips both, a 30% opacity logo only the gradient, a large flat opaque patch trips deviation strongly and the gradient only along its border. The temporal median tolerates a watermark missing from a minority of frames on its own, so `--frame_tolerance` does not need raising for the gradient signal.

**Boxes, not outlines.** Each detected region is replaced by its bounding box, per connected region. The VAE encoder mixes a neighbourhood of pixels into every latent cell, so a watermark bleeds into latents its own pixels do not cover, and a mask traced tightly around thin glyph strokes under-masks once downsampled to latent resolution. A box covers that neighbourhood, needs no morphological reconstruction of a logo's interior, and errs in the safe direction — on a corner logo it masks 2.5% of the frame where the exact glyph shapes masked 2.3%.

**Letterboxing** is detected and masked rather than guarded against: a bar is static, carries no content, and would otherwise teach the model to generate black bars. Cropping such footage is still better, since the bars take up frame area the VAE encodes either way, and bars alone reach about a third of the frame — which is why `--max_coverage` defaults to 0.4 rather than something tighter.

`--corner_only` restricts detection to a band along the frame border, where watermarks normally sit. `--max_coverage` (default 0.4) bounds how much of the frame a detection may claim: above it the clip is left without a mask and warned about, rather than silently losing most of its pixels to the loss mask. A locked-off camera is temporally static everywhere, so without that bound the detector would happily mask the whole shot. The count of clips that hit the bound is repeated in the run summary, since individual warnings are easy to lose in a long log.

**Dataset** (`dataset/config_utils.py`, `dataset/image_video_dataset.py`, `dataset/bucket.py`, `dataset/media_utils.py`)

New `watermark_mask_suffix` option (default `"_wmask.png"`), settable in `[general]` or per dataset. When a mask file is found next to the source image/video (falling back to the cache directory), it is loaded through the same `resize_image_to_bucket` transform as the frames, so it stays aligned with the cached latents, and reaches the batch as `watermark_mask`, a `(B, H, W)` float tensor in [0, 1]. Decoded masks are memoized with a small LRU cache.

The key is omitted entirely when no item in a batch has a mask, and items without one are filled with ones, so mixed datasets work. Latent caching is untouched, so masks can be added or regenerated without re-caching.

**Loss** (`training/trainer_base.py`)

New `reduce_loss(loss, batch)` helper, used by `NetworkTrainer.compute_loss`:

```python
loss = mse(pred, target)            # (B, C, T, H, W), reduction="none"
loss = (loss * mask).sum() / mask.expand_as(loss).sum()
```

The mask is area-downsampled to the loss's spatial size and broadcast over channels and frames, so it works across architectures with different VAE temporal/spatial compression without per-architecture handling. Area downsampling also means a latent cell partially overlapping the watermark is weighted by the clean fraction of it rather than being dropped outright.

Dividing by the mask weight keeps the loss scale comparable to the unmasked mean, so learning rates do not need retuning; a fully open mask reproduces `loss.mean()` exactly. Losses without a spatial layout (patchified image models, where the loss is a token sequence) log a warning once and ignore the mask.

`compute_loss` gains a trailing optional `batch` argument; the two in-repo overrides (Ideogram 4, HiDream-O1) were updated to match and to route their reduction through `reduce_loss`.

**Docs**

New `docs/watermark_mask.md` (EN + JA), linked from both READMEs, with a section in `docs/tools.md` for the detection script and the new option documented in `docs/dataset_config.md`.

## Testing

New `tests/test_watermark_mask.py` (29 tests) covering:

- detection on synthetic frames, including `--corner_only` rejecting a static block in the frame centre;
- a 30% opacity watermark being invisible to the deviation signal and found by the gradient one, without the latter claiming a feathered near-static background;
- the bounding box covering the interior of a shape the gradient only outlines, keeping two regions in opposite corners separate rather than merging them, and dropping regions below `--min_area`;
- an intermittent watermark (absent from 3 of 30 frames) being missed at `--frame_tolerance 0` and found at `0.1`, without the trimming starting to match moving content;
- `trimmed_temporal_std` reducing to a plain `std` at tolerance 0, and leaving a constant pixel at 0 rather than breaking ties arbitrarily;
- `--max_coverage` refusing a locked-off shot, and the same clip passing once the bound is raised;
- `reduce_loss`: a fully open mask matching `mean()`, masked regions being excluded, per-sample masks, unbatched masks, 4D and 5D losses, and the non-spatial fallback;
- mask discovery for the default suffix, a custom suffix, and the disabled case;
- batch assembly with all / some / no masks present;
- an end-to-end case going from real cache filenames through `prepare_for_training` to a masked scalar loss.

`ruff check` and `ruff format` are clean, and the full suite passes (98 tests, including the pre-existing ones). Only the CPU-side data path and loss reduction were exercised — no GPU training run was performed.

`tests/test_ideogram4_synthetic.py` needed a one-line addition to its fake `trainer_base` module stubs, which now also need `reduce_loss`.

## Breaking changes

None for users. `NetworkTrainer.compute_loss` gained a trailing optional parameter, which affects out-of-tree subclasses that override it only if they also call it positionally past `global_step`.

## Overlap with existing work

I checked for duplication before opening this:

- Nothing in the tree masks the loss today. The existing masks (`control_image_mask_path`, control-image alpha channels, kisekaeichi masks) are *conditioning* masks over clean/control latents, not loss masks, so there is no overlap — and this PR keeps their polarity convention (255 referenced, 0 ignored).
- #898 asks for masked video training in general, motivated by per-subject masks from SAM-style tools; #227 asks for the same thing to avoid learning backgrounds. Both are broader than this PR, and both would be served by the same `watermark_mask` batch key and `reduce_loss` reducer — a segmentation-based mask source could be added without touching the loss path.
- The closest prior art is #861 (closed by its author as a mistake), which refactored a mask-weighted loss into `modules/mask_loss.py` with `apply_masked_loss()`, `mask_weights` batch entries and `--mask_gamma`. That work does not exist upstream, but the API overlaps with `reduce_loss`/`watermark_mask` here. If that contribution is still expected, I am happy to rename to the more general `mask_weights` / `apply_masked_loss` naming so the two do not collide, or to rebase this on top of it and keep only the detection script plus the dataset plumbing.

## Note

This was not discussed in an issue beforehand, per CONTRIBUTING's guidance for new features. #898 is open and unanswered, so if you would prefer the design settled there first, or want the scope narrowed, say the word.
