### PR TITLE
Fix int32 address overflow in ConvRot INT8 Triton kernels (long-sequence corruption)

### DIFF
--- a/src/musubi_tuner/modules/convrot_int8_kernels.py
+++ b/src/musubi_tuner/modules/convrot_int8_kernels.py
@@ -190,8 +190,10 @@ if HAS_TRITON:
         block_size: tl.constexpr,
         input_dtype_code: tl.constexpr,
     ):
-        # Row index we are processing
-        row_idx = tl.program_id(0)
+        # Row index we are processing. Promote to int64 before the stride multiply:
+        # H3 packs video+audio+text into one ~90k-row sequence, so row*cols can
+        # exceed int32 (Triton wraps silently, corrupting the tail of the tensor).
+        row_idx = tl.program_id(0).to(tl.int64)
 
         # Pointers to the start of the row
         x_row_ptr = x_ptr + row_idx * n_elements
@@ -313,7 +315,10 @@ if HAS_TRITON:
         offs_bn = (pid_n * block_n + tl.arange(0, block_n)) % n
         offs_k = tl.arange(0, block_k)
 
-        a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+        # row * stride must be int64: at H3 scale m*stride_am and m*stride_cm exceed
+        # int32 (e.g. fc1 output m~90k x n=28672), and Triton wraps i32 silently
+        offs_am_i64 = offs_am.to(tl.int64)
+        a_ptrs = a_ptr + (offs_am_i64[:, None] * stride_am + offs_k[None, :] * stride_ak)
         b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
 
         # 2. Main Loop (Accumulate in Int32)
@@ -344,7 +349,7 @@ if HAS_TRITON:
             c = c + bias[None, :]
 
         # 4. Store Result
-        c_ptrs = c_ptr + stride_cm * offs_am[:, None] + stride_cn * offs_bn[None, :]
+        c_ptrs = c_ptr + stride_cm * offs_am_i64[:, None] + stride_cn * offs_bn[None, :]
         c_mask = (offs_am[:, None] < m) & (offs_bn[None, :] < n)
         tl.store(c_ptrs, c, mask=c_mask)
 
@@ -406,7 +411,10 @@ if HAS_TRITON:
         offs_bn = (pid_n * block_n + tl.arange(0, block_n)) % n
         offs_k = tl.arange(0, block_k)
 
-        a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+        # row * stride must be int64: at H3 scale m*stride_am and m*stride_cm exceed
+        # int32 (e.g. fc1 output m~90k x n=28672), and Triton wraps i32 silently
+        offs_am_i64 = offs_am.to(tl.int64)
+        a_ptrs = a_ptr + (offs_am_i64[:, None] * stride_am + offs_k[None, :] * stride_ak)
         b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
 
         # 2. Main Loop (Accumulate in Int32)
@@ -432,7 +440,7 @@ if HAS_TRITON:
             c = c + bias[None, :]
 
         # 4. Store Result
-        c_ptrs = c_ptr + stride_cm * offs_am[:, None] + stride_cn * offs_bn[None, :]
+        c_ptrs = c_ptr + stride_cm * offs_am_i64[:, None] + stride_cn * offs_bn[None, :]
         c_mask = (offs_am[:, None] < m) & (offs_bn[None, :] < n)
         tl.store(c_ptrs, c, mask=c_mask)
 


### PR DESCRIPTION
## Problem

Generating (or training) MiniMax-H3 at large size x long duration with the ConvRot INT8 path produces corrupted video: e.g. 1280x736 / 294f breaks from ~9.5s onward, 1280x736 / 328f can break entirely (audio included), while 1024x640 / 328f is fine. The symptom is independent of the attention backend (sageattn / flash) and of `--compile`.

## Root cause

In the Triton INT8 GEMM kernels, the row-offset pointer arithmetic

```python
a_ptrs = a_ptr + (offs_am[:, None] * stride_am + ...)
c_ptrs = c_ptr + stride_cm * offs_am[:, None] + ...
```

is computed entirely in int32 (`tl.arange`/`tl.program_id` are i32, and the strides fit i32, so the product wraps silently once `row * stride` reaches 2^31).

For H3, `mlp.fc1` has N=28672 output features, so the c-side store offset overflows once the packed sequence reaches ceil(2^31 / 28672) = **74,899 rows** — about 277+ pixel frames at 1280x736. Beyond that row:

- the fc1 output rows are never written (uninitialized garbage → video breaks from that token onward), and
- the wrapped (negative) offsets store ~3 GB *before* the output buffer, silently corrupting whatever allocation lives there — which explains the non-deterministic variants (whole video + audio broken, apparent compile dependence).

A synthetic repro at fc1 geometry (M=80000, N=28672, K=5376) crashes with `CUDA error: an illegal memory access was encountered` on the old kernels.

Sequence-length thresholds per quantized H3 layer (the packed row count is the GEMM M):

| layer | N (stride_cm) | overflowing rows |
|---|---|---|
| mlp.fc1 | 28672 | >= 74,899 |
| attn.qkv_proj | 21504 | >= 99,864 |
| mlp.fc2 / attn.out_proj | 5376 | >= 399,458 |

The same overflow affects the a-side *loads* in the tensorwise kernel used by `--convrot_int8_bwd int8` (grad @ W with stride_am = 28672), so long-sequence training was affected in both forward and backward.

## Fix

Promote the row offsets to int64 before the stride multiply (`offs_am.to(tl.int64)`) for the a-pointers and c-pointers in both `_int8_matmul_dequant_kernel` and `_int8_matmul_dequant_per_row_kernel`, and promote `row_idx` in `_quantize_rowwise_kernel` (its `row * cols` threshold of ~149.8k rows for fc2 input was not yet reachable, but has little headroom). Column-side and k-side offsets stay i32; the address math cost is negligible.

## Verification

- Synthetic repro (fc1 geometry, M=80000): old kernels → illegal memory access; fixed kernels → full-batch vs row-split outputs are **bit-identical** for both the per-channel and tensorwise kernels (per-row dynamic quantization makes bit-equality the correct expectation).
- Real generation with the ConvRot INT8 checkpoint: 1280x736 294f and 328f, previously corrupted, are now clean (with and without `--compile`).
- 564 tests passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)