### PR TITLE
Fix RGBA control images crashing MiniMax-H3 one-frame FL2VA text caching

### DIFF
--- a/docs/minimax_h3_1f.md
+++ b/docs/minimax_h3_1f.md
@@ -171,6 +171,7 @@ fp_1f_target_index = 24       # target position — REQUIRED when controls are p
 - `control_directory` matches controls to targets by filename (`image.png` ↔ `image.png` / `image_0.png`), or use `image_jsonl_file` with `control_path` (or `control_path_0`/`control_path_1`) per line.
 - `fp_1f_clean_indices` gives one index per control image, in packed (first, last) order: control 0 is the "first" slot, control 1 the "last" slot. With one control only the "first" slot is used; the slot name carries no time meaning of its own — only the indices do.
 - Both `fp_1f_clean_indices` and an explicit `fp_1f_target_index` are required when controls are present; there are no defaults. Controls are resized to the target's bucket resolution.
+- The alpha channel of RGBA control images is ignored (dropped before both VAE and text-encoder processing) — unlike FramePack one-frame training, it does not act as a mask.
 - Time-order is unconstrained: an anchor **after** the target (`fp_1f_clean_indices = [120]`, `fp_1f_target_index = 24`) trains an L2VA-style LoRA (generate the image that precedes an end state). Note the official pipeline stretches a lone last picture to the canvas at inference while training resizes to the bucket — a minor known divergence.
 
 ### Choosing indices

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -357,7 +357,9 @@ def main() -> None:
                     if not control_indices or controls is None or len(controls) != len(control_indices):
                         raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control images: {item.item_key}")
                     for role, control in zip(("first", "last"), controls):
-                        visuals[role] = H3TextVisual(torch.as_tensor(control).unsqueeze(0))
+                        # the dataset keeps RGBA controls as-is; drop alpha the same way the
+                        # latent path does (_prepare_pixels), the processor accepts only RGB
+                        visuals[role] = H3TextVisual(torch.as_tensor(control)[..., :3].unsqueeze(0))
                     control_paths = control_paths_by_dir.get(cache_dir_key, {}).get(item.item_key)
                     if control_paths is None or len(control_paths) != len(control_indices):
                         raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control paths: {item.item_key}")


### PR DESCRIPTION
## Summary

Fixes a user-reported crash in MiniMax-H3 one-frame FL2VA text encoder caching (PR #1058): RGBA control images were passed as raw `[H,W,4]` arrays to the Qwen3-VL processor, which fails with `Unable to infer channel dimension format`.

## Background

- The dataset layer intentionally keeps RGBA control images as-is (this supports the FramePack one-frame alpha-mask feature).
- The latent caching path already handles this: `_prepare_pixels` drops alpha via `frames[..., :3]` before VAE encoding.
- The text caching path had no such handling, so RGBA controls slipped through `H3TextVisual` validation (`shape[-1] >= 3`) and crashed inside transformers.

Only the one-frame FL2VA path is affected; video FL2VA / Ref2VA text visuals come from decoded video frames, which are always 3-channel.

## Changes

- `minimax_h3_cache_text_encoder_outputs.py`: drop alpha (`[..., :3]`) before wrapping controls in `H3TextVisual` — the same plain drop (no compositing) as the latent path, so condition latents and text visuals see identical pixels.
- `docs/minimax_h3_1f.md`: note that the alpha channel of RGBA controls is ignored and, unlike FramePack one-frame training, does not act as a mask.

No cache invalidation: RGBA inputs previously crashed before writing any cache, and RGB caches are untouched (the presentation fingerprint's `image_shapes` stays `[H,W,3]`).

## Testing

- Reproduced the `Unable to infer channel dimension format` error with RGBA control images on the unpatched code, then confirmed the same run succeeds with this fix.
- `py_compile` syntax check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
