### PR TITLE
Fix alphas on CPU with numpy2 when loading network_weights

### DIFF
--- a/src/musubi_tuner/networks/loha.py
+++ b/src/musubi_tuner/networks/loha.py
@@ -89,7 +89,7 @@ class LoHaModule(torch.nn.Module):
         torch.nn.init.normal_(self.hada_w2_b, std=1.0)
 
         if type(alpha) == torch.Tensor:
-            alpha = alpha.detach().float().numpy()
+            alpha = alpha.detach().float().cpu().item()
         alpha = lora_dim if alpha is None or alpha == 0 else alpha
         self.scale = alpha / self.lora_dim
         self.register_buffer("alpha", torch.tensor(alpha))

--- a/src/musubi_tuner/networks/lokr.py
+++ b/src/musubi_tuner/networks/lokr.py
@@ -117,7 +117,7 @@ class LoKrModule(torch.nn.Module):
                 )
 
         if type(alpha) == torch.Tensor:
-            alpha = alpha.detach().float().numpy()
+            alpha = alpha.detach().float().cpu().item()
         alpha = lora_dim if alpha is None or alpha == 0 else alpha
         # if both w1 and w2 are full matrices, use scale = 1
         if self.use_w2:

--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -89,7 +89,7 @@ class LoRAModule(torch.nn.Module):
                 torch.nn.init.zeros_(lora_up.weight)
 
         if type(alpha) == torch.Tensor:
-            alpha = alpha.detach().float().numpy()  # without casting, bf16 causes error
+            alpha = alpha.detach().float().cpu().item()  # without casting, bf16 causes error
         alpha = self.lora_dim if alpha is None or alpha == 0 else alpha
         self.scale = alpha / self.lora_dim
         self.register_buffer("alpha", torch.tensor(alpha))  # for save/load


### PR DESCRIPTION
Fixes #1068

Also checked if we need numpy here but alphas are 1 item scalars so this seems the correct choice. 
