### PR TITLE
fix: raise ValueError for missing output_dir/output_name before train…

### DIFF
--- a/src/musubi_tuner/hidream_o1_train.py
+++ b/src/musubi_tuner/hidream_o1_train.py
@@ -48,6 +48,10 @@ class HiDreamO1Trainer(HiDreamO1NetworkTrainer):
             raise ValueError("dataset_config is required")
         if args.dit is None:
             raise ValueError("path to DiT model is required")
+        if args.output_dir is None:
+            raise ValueError("output_dir is required")
+        if args.output_name is None:
+            raise ValueError("output_name is required")
 
         if args.fp8_base or args.fp8_scaled:
             raise ValueError("HiDream-O1 full finetuning does not support --fp8_base / --fp8_scaled.")

--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -730,6 +730,12 @@ class FineTuningTrainer:
         return noisy_model_input, timesteps
 
     def train(self, args):
+        # check required arguments
+        if args.output_dir is None:
+            raise ValueError("output_dir is required / output_dirが必要です")
+        if args.output_name is None:
+            raise ValueError("output_name is required / output_nameが必要です")
+
         if args.seed is None:
             args.seed = random.randint(0, 2**32)
         set_seed(args.seed)

--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -156,6 +156,10 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
             raise ValueError("dataset_config is required / dataset_configが必要です")
         if args.dit is None:
             raise ValueError("path to DiT model is required / DiTモデルのパスが必要です")
+        if args.output_dir is None:
+            raise ValueError("output_dir is required / output_dirが必要です")
+        if args.output_name is None:
+            raise ValueError("output_name is required / output_nameが必要です")
         assert not args.fp8_scaled or args.fp8_base, "fp8_scaled requires fp8_base / fp8_scaledはfp8_baseが必要です"
 
         if args.sage_attn:

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -1506,6 +1506,10 @@ class NetworkTrainer:
             raise ValueError("dataset_config is required / dataset_configが必要です")
         if args.dit is None:
             raise ValueError("path to DiT model is required / DiTモデルのパスが必要です")
+        if args.output_dir is None:
+            raise ValueError("output_dir is required / output_dirが必要です")
+        if args.output_name is None:
+            raise ValueError("output_name is required / output_nameが必要です")
         assert not args.fp8_scaled or args.fp8_base, "fp8_scaled requires fp8_base / fp8_scaledはfp8_baseが必要です"
 
         if args.sage_attn:

--- a/src/musubi_tuner/zimage_train.py
+++ b/src/musubi_tuner/zimage_train.py
@@ -92,6 +92,10 @@ class ZImageTrainer(ZImageNetworkTrainer):
             raise ValueError("dataset_config is required / dataset_configが必要です")
         if args.dit is None:
             raise ValueError("path to DiT model is required / DiTモデルのパスが必要です")
+        if args.output_dir is None:
+            raise ValueError("output_dir is required / output_dirが必要です")
+        if args.output_name is None:
+            raise ValueError("output_name is required / output_nameが必要です")
         assert not args.fp8_scaled or args.fp8_base, "fp8_scaled requires fp8_base / fp8_scaledはfp8_baseが必要です"
 
         if args.sage_attn:


### PR DESCRIPTION
Fixes #940: 

when --output_dir or --output_name is omitted, training runs to completion before crashing at the save step with a confusing TypeError.

Adds early ValueError checks in all five trainer entry points before any GPU/model/dataset work begins:

- NetworkTrainer._validate_args_and_init (training/trainer_base.py)
- FineTuningTrainer.train (hv_train.py)
- HiDreamO1Trainer._validate_full_finetune_args (hidream_o1_train.py)
- QwenImageTrainer.train (qwen_image_train.py)
- ZImageTrainer.train (zimage_train.py)