### PR TITLE
MiniMax-H3: experimental --output_fps temporal stretch (effective 12/16 fps generation)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -427,7 +427,7 @@ The native sampler builds one common base grid, derives independent shifted vide
 
 ### Temporal stretch (experimental)
 
-`--output_fps N` (default 24) samples the generated timeline at N fps instead of the trained 24. `--frame_count` still counts generated pixel frames, so the clip covers `frame_count / N` seconds: the target video's rotary time spans scale by `24/N` (the H3 time axis is real-time, 1 unit = 1/40 s), the audio track keeps its native 40 Hz latent rate over the stretched real duration, and the output container, trajectory dumps, and intermediate latent files all carry the requested rate. The released 5-15 s duration gate applies to the real (stretched) duration. References, FL2VA conditions, and one-frame mode keep native 24 fps spans (one-frame mode rejects a stretch).
+`--output_fps N` (default 24, accepted range 1-24; rates above the native 24 are rejected until the squeeze direction is validated) samples the generated timeline at N fps instead of the trained 24. `--frame_count` still counts generated pixel frames, so the clip covers `frame_count / N` seconds: the target video's rotary time spans scale by `24/N` (the H3 time axis is real-time, 1 unit = 1/40 s), the audio track keeps its native 40 Hz latent rate over the stretched real duration, and the output container, trajectory dumps, and intermediate latent files all carry the requested rate. The released 5-15 s duration gate applies to the real (stretched) duration. References, FL2VA conditions, and one-frame mode keep native 24 fps spans (one-frame mode rejects a stretch).
 
 Two ways to use it: keeping `--frame_count` fixed doubles the clip length at 12 fps for nearly the same compute (only the audio rows grow), while generating the same real duration with proportionally fewer frames cuts the packed sequence roughly in half at 12 fps (about a quarter of the video-video attention cost; 124 frames at 12 fps measured ~2.1x faster than the equal-duration 243 frames at 24 fps).
 
@@ -450,7 +450,7 @@ A singer performs under stage lights. --w 768 --h 1344 --f 124 --d 42 --s 30
 | `--d` | `--seed` |
 | `--s` | `--steps` |
 | `--fs`, `--fsa` | `--h3_shift_video`, `--h3_shift_audio` |
-| `--ofps` | `--output_fps` |
+| `--ofps`, `--skb` | `--output_fps`, `--stretch_keep_bands` |
 | `--i`, `--ei` | `--first_frame`, `--last_frame` (end image) |
 | `--ref` | `--ref` (repeatable; replaces the session-level list) |
 | `--of` | `--one_frame` |

--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -425,6 +425,16 @@ T2VA and Ref2VA generation may use `--text_cache` instead of `--text_encoder`. T
 
 The native sampler builds one common base grid, derives independent shifted video and audio sigma grids, and advances each modality with its own finite sigma interval. It does not apply CFG, negate the model heads, or apply ComfyUI's single-sampler audio slope adapter. Musubi also adds condition noise before packing, while ComfyUI adds it after packing; the distributions agree but RNG placement does not. These two intentional differences mean the same seed is not bitwise reproducible against ComfyUI. Video and audio are decoded sequentially, trimmed to a common duration, and muxed with PyAV as H.264 plus AAC.
 
+### Temporal stretch (experimental)
+
+`--output_fps N` (default 24) samples the generated timeline at N fps instead of the trained 24. `--frame_count` still counts generated pixel frames, so the clip covers `frame_count / N` seconds: the target video's rotary time spans scale by `24/N` (the H3 time axis is real-time, 1 unit = 1/40 s), the audio track keeps its native 40 Hz latent rate over the stretched real duration, and the output container, trajectory dumps, and intermediate latent files all carry the requested rate. The released 5-15 s duration gate applies to the real (stretched) duration. References, FL2VA conditions, and one-frame mode keep native 24 fps spans (one-frame mode rejects a stretch).
+
+Two ways to use it: keeping `--frame_count` fixed doubles the clip length at 12 fps for nearly the same compute (only the audio rows grow), while generating the same real duration with proportionally fewer frames cuts the packed sequence roughly in half at 12 fps (about a quarter of the video-video attention cost; 124 frames at 12 fps measured ~2.1x faster than the equal-duration 243 frames at 24 fps).
+
+The model was trained at 24 fps only, so a plain stretch produces periodic artifacts with a 17-pixel-frame period: the leading (highest-frequency) temporal RoPE bands have periods at or below the latent token spacing and carry a per-token lattice phase rather than time, and stretching re-dials that phase against the `(1,4,4,4,4)` VAE token grouping. `--stretch_keep_bands K` rotates the K leading temporal bands by the unstretched grid instead, which restores the trained lattice phase while the remaining bands carry the stretched clock. Recommended values: `3` at 12 fps (where `4` also removes the last residual glitches), `2` at 16 fps, `1` at 20 fps — the count of bands whose per-token rotation changes regime at that stretch.
+
+Temporal resolution is the real cost: 12 fps halves it. This interacts with a model habit that is unrelated to the stretch: anime-style outputs animate characters on twos (a learned production convention, bound to the token grid and present at native 24 fps), so at 12 fps character motion drops to an effective 6 fps while backgrounds and camera moves stay per-frame. 16 fps with `--stretch_keep_bands 2` is often the better compromise for animated styles; the cadence itself follows the style stated in the prompt (live-action and game-engine styles animate per frame).
+
 ### Batch and interactive modes
 
 Model loading dominates single-shot latency (and `--convrot_int8` requantizes at every start), so repeated generation should use `--from_file` or `--interactive` instead of one process per prompt. Both read prompt lines of the form:
@@ -440,6 +450,7 @@ A singer performs under stage lights. --w 768 --h 1344 --f 124 --d 42 --s 30
 | `--d` | `--seed` |
 | `--s` | `--steps` |
 | `--fs`, `--fsa` | `--h3_shift_video`, `--h3_shift_audio` |
+| `--ofps` | `--output_fps` |
 | `--i`, `--ei` | `--first_frame`, `--last_frame` (end image) |
 | `--ref` | `--ref` (repeatable; replaces the session-level list) |
 | `--of` | `--one_frame` |

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -10,6 +10,7 @@ import torch
 
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode
 from musubi_tuner.minimax_h3.media import (
+    TARGET_FPS,
     H3Record,
     audio_latent_frames,
     load_h3_jsonl_records,
@@ -25,7 +26,7 @@ from musubi_tuner.minimax_h3_cache_latents import PyAVH3MediaDecoder
 VIDEO_VAE_SPATIAL_RATIO = 16
 # with a one-frame target, reference videos keep their full released span instead of
 # being capped by the target duration
-ONE_FRAME_REFERENCE_FRAME_CAP = 15 * 24
+ONE_FRAME_REFERENCE_FRAME_CAP = 15 * TARGET_FPS
 
 
 def parse_one_frame_options(spec: str) -> tuple[int, tuple[int, ...] | None]:
@@ -120,7 +121,12 @@ def decode_generation_visuals(args, record: H3Record, decoder: PyAVH3MediaDecode
             text_visuals[role] = H3TextVisual(frames)
         return raw_visuals, text_visuals
 
-    reference_frame_cap = ONE_FRAME_REFERENCE_FRAME_CAP if args.frame_count == 1 else args.frame_count
+    if args.frame_count == 1:
+        reference_frame_cap = ONE_FRAME_REFERENCE_FRAME_CAP
+    else:
+        # cap reference videos by the real target duration in native 24 fps frames; a
+        # temporal stretch makes that duration exceed frame_count generated frames
+        reference_frame_cap = args.frame_count * TARGET_FPS // getattr(args, "output_fps", TARGET_FPS)
     for reference in record.references:
         if reference.type not in {"image", "video"}:
             continue
@@ -195,7 +201,7 @@ def encode_audio_conditions(
         else:
             # standalone audio spans the target duration (stretched when --output_fps lowers the
             # sampling rate); one-frame generation rejects it upstream
-            frames = audio_latent_frames(args.frame_count, output_fps=getattr(args, "output_fps", 24))
+            frames = audio_latent_frames(args.frame_count, output_fps=getattr(args, "output_fps", TARGET_FPS))
             require_exact = False
         waveform = decoder.decode_audio(
             reference.audio,

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -193,8 +193,9 @@ def encode_audio_conditions(
             frames = audio_latent_frames(frame_count)
             require_exact = True
         else:
-            # standalone audio spans the target duration; one-frame generation rejects it upstream
-            frames = audio_latent_frames(args.frame_count)
+            # standalone audio spans the target duration (stretched when --output_fps lowers the
+            # sampling rate); one-frame generation rejects it upstream
+            frames = audio_latent_frames(args.frame_count, output_fps=getattr(args, "output_fps", 24))
             require_exact = False
         waveform = decoder.decode_audio(
             reference.audio,

--- a/src/musubi_tuner/minimax_h3/media.py
+++ b/src/musubi_tuner/minimax_h3/media.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from fractions import Fraction
 import json
 from pathlib import Path
 from typing import Callable, Literal, Optional
@@ -53,9 +54,15 @@ def video_latent_frames(frame_count: int) -> int:
     return 5 * ((frame_count - 5) // 17) + 2
 
 
-def audio_latent_frames(frame_count: int) -> int:
+def audio_latent_frames(frame_count: int, *, output_fps: int = 24) -> int:
     _validate_frame_count(frame_count)
-    return (10 * frame_count + 3) // 6
+    if output_fps == TARGET_FPS:
+        return (10 * frame_count + 3) // 6
+    if not isinstance(output_fps, int) or output_fps <= 0:
+        raise ValueError(f"MiniMax-H3 output fps must be a positive integer, got {output_fps}")
+    # 40 Hz audio latents over the real duration frame_count/output_fps seconds;
+    # reduces to the released (10*f+3)//6 mapping at 24 fps
+    return int((Fraction(10 * frame_count * TARGET_FPS, output_fps) + 3) // 6)
 
 
 def waveform_samples(audio_frames: int) -> int:

--- a/src/musubi_tuner/minimax_h3/media.py
+++ b/src/musubi_tuner/minimax_h3/media.py
@@ -54,12 +54,12 @@ def video_latent_frames(frame_count: int) -> int:
     return 5 * ((frame_count - 5) // 17) + 2
 
 
-def audio_latent_frames(frame_count: int, *, output_fps: int = 24) -> int:
+def audio_latent_frames(frame_count: int, *, output_fps: int = TARGET_FPS) -> int:
     _validate_frame_count(frame_count)
+    if isinstance(output_fps, bool) or not isinstance(output_fps, int) or output_fps <= 0:
+        raise ValueError(f"MiniMax-H3 output fps must be a positive integer, got {output_fps!r}")
     if output_fps == TARGET_FPS:
         return (10 * frame_count + 3) // 6
-    if not isinstance(output_fps, int) or output_fps <= 0:
-        raise ValueError(f"MiniMax-H3 output fps must be a positive integer, got {output_fps}")
     # 40 Hz audio latents over the real duration frame_count/output_fps seconds;
     # reduces to the released (10*f+3)//6 mapping at 24 fps
     return int((Fraction(10 * frame_count * TARGET_FPS, output_fps) + 3) // 6)

--- a/src/musubi_tuner/minimax_h3/model.py
+++ b/src/musubi_tuner/minimax_h3/model.py
@@ -812,12 +812,32 @@ class MiniMaxH3Model(nn.Module):
             if not matches(buffer.device):
                 raise RuntimeError(f"MiniMax-H3 block {index} buffer {name} is on {buffer.device}, expected {expected} after wait")
 
-    def _rotation_table(self, position_ids: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    def _rotation_table(
+        self,
+        position_ids: torch.Tensor,
+        dtype: torch.dtype,
+        *,
+        fine_position_ids: torch.Tensor | None = None,
+        fine_bands: int = 0,
+    ) -> torch.Tensor:
         positions = position_ids.to(device=self.rope.inv_freq.device, dtype=torch.float32)
         if positions.ndim != 3 or positions.shape[-1] != 3:
             raise ValueError("MiniMax-H3 position ids must be [B,S,3]")
         per_axis = positions.unsqueeze(-1) * self.rope.inv_freq.reshape(1, 1, 1, -1)
         temporal, height, width = per_axis.unbind(dim=2)
+        if fine_position_ids is not None and fine_bands:
+            # temporal-stretch experiment: the leading (sub-lattice) bands rotate by the
+            # unstretched grid so the per-token lattice phase stays as trained, while the
+            # remaining bands carry the stretched physical timeline
+            if fine_bands > self.rope.inv_freq.shape[0]:
+                raise ValueError(
+                    f"MiniMax-H3 temporal fine bands {fine_bands} exceed the {self.rope.inv_freq.shape[0]}-band rotary spectrum"
+                )
+            fine_positions = fine_position_ids.to(device=self.rope.inv_freq.device, dtype=torch.float32)
+            if fine_positions.shape != positions.shape:
+                raise ValueError("MiniMax-H3 fine position ids must match the stretched grid shape")
+            fine_temporal = fine_positions[..., 0].unsqueeze(-1) * self.rope.inv_freq.reshape(1, 1, -1)
+            temporal = torch.cat((fine_temporal[..., :fine_bands], temporal[..., fine_bands:]), dim=-1)
         half = torch.cat((temporal, height, width), dim=-1)
         angles = torch.cat((half, half), dim=-1)
         pair_count = angles.shape[-1] // 2
@@ -849,7 +869,12 @@ class MiniMaxH3Model(nn.Module):
             self._rotary_cache.move_to_end(key)
             return cached
         position_ids = build_position_grid(layout, device=device)
-        rotation_table = self._rotation_table(position_ids, dtype)
+        fine_position_ids = None
+        if layout.temporal_fine_bands and layout.temporal_stretch != 1.0:
+            fine_position_ids = build_position_grid(replace(layout, temporal_stretch=1.0, temporal_fine_bands=0), device=device)
+        rotation_table = self._rotation_table(
+            position_ids, dtype, fine_position_ids=fine_position_ids, fine_bands=layout.temporal_fine_bands
+        )
         self._rotary_cache[key] = rotation_table
         while len(self._rotary_cache) > _ROTARY_CACHE_SIZE:
             self._rotary_cache.popitem(last=False)

--- a/src/musubi_tuner/minimax_h3/model.py
+++ b/src/musubi_tuner/minimax_h3/model.py
@@ -35,6 +35,7 @@ from musubi_tuner.minimax_h3.checkpoint import (
     load_safetensors_metadata,
     resolve_safetensors_files,
 )
+from musubi_tuner.minimax_h3.media import TARGET_FPS
 from musubi_tuner.minimax_h3.packing import (
     AUDIO_CHANNELS,
     VIDEO_CHANNELS,
@@ -829,9 +830,10 @@ class MiniMaxH3Model(nn.Module):
             # temporal-stretch experiment: the leading (sub-lattice) bands rotate by the
             # unstretched grid so the per-token lattice phase stays as trained, while the
             # remaining bands carry the stretched physical timeline
-            if fine_bands > self.rope.inv_freq.shape[0]:
+            if fine_bands >= self.rope.inv_freq.shape[0]:
                 raise ValueError(
-                    f"MiniMax-H3 temporal fine bands {fine_bands} exceed the {self.rope.inv_freq.shape[0]}-band rotary spectrum"
+                    f"MiniMax-H3 temporal fine bands {fine_bands} must leave at least one of the"
+                    f" {self.rope.inv_freq.shape[0]} rotary bands on the stretched clock"
                 )
             fine_positions = fine_position_ids.to(device=self.rope.inv_freq.device, dtype=torch.float32)
             if fine_positions.shape != positions.shape:
@@ -870,8 +872,8 @@ class MiniMaxH3Model(nn.Module):
             return cached
         position_ids = build_position_grid(layout, device=device)
         fine_position_ids = None
-        if layout.temporal_fine_bands and layout.temporal_stretch != 1.0:
-            fine_position_ids = build_position_grid(replace(layout, temporal_stretch=1.0, temporal_fine_bands=0), device=device)
+        if layout.temporal_fine_bands and layout.output_fps != TARGET_FPS:
+            fine_position_ids = build_position_grid(replace(layout, output_fps=TARGET_FPS, temporal_fine_bands=0), device=device)
         rotation_table = self._rotation_table(
             position_ids, dtype, fine_position_ids=fine_position_ids, fine_bands=layout.temporal_fine_bands
         )

--- a/src/musubi_tuner/minimax_h3/packing.py
+++ b/src/musubi_tuner/minimax_h3/packing.py
@@ -148,6 +148,13 @@ class H3PackedLayout:
     # spans; the target audio frame count must cover the stretched real duration.
     # Also frozen here so the rotary cache keys on it.
     temporal_stretch: float = 1.0
+    # with a stretch, rotate this many leading (highest-frequency) temporal RoPE bands
+    # by the UNSTRETCHED grid instead. Those bands have periods at or below the latent
+    # token spacing, so they cannot encode time between tokens -- they carry a per-token
+    # lattice phase that training bakes in against the native (1,4,4,4,4)-span grid;
+    # stretching scrambles it with the 17-pixel-frame group period (fading/stripes).
+    # ~3 is the sub-lattice band count for the released 16-band spectrum.
+    temporal_fine_bands: int = 0
 
     def segment(self, role: str) -> H3RowSegment:
         matches = [segment for segment in self.segments if segment.role == role]
@@ -260,6 +267,7 @@ def build_h3_layout(
     condition_roles: Sequence[str] | None = None,
     time_overrides: H3TimeOverrides | None = None,
     temporal_stretch: float = 1.0,
+    temporal_fine_bands: int = 0,
 ) -> H3PackedLayout:
     if task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
@@ -270,6 +278,11 @@ def build_h3_layout(
         raise ValueError(f"MiniMax-H3 temporal stretch must be finite and positive, got {temporal_stretch}")
     if one_frame and temporal_stretch != 1.0:
         raise ValueError("MiniMax-H3 one-frame layouts do not support temporal stretch")
+    temporal_fine_bands = int(temporal_fine_bands)
+    if temporal_fine_bands < 0:
+        raise ValueError(f"MiniMax-H3 temporal fine bands must be nonnegative, got {temporal_fine_bands}")
+    if temporal_fine_bands and temporal_stretch == 1.0:
+        raise ValueError("MiniMax-H3 temporal fine bands require an active temporal stretch")
     target_video = _coerce_video_geometry(target_video, "target video")
     if one_frame:
         if target_video.frames != ONE_FRAME_VIDEO_LATENT_FRAMES:
@@ -358,6 +371,7 @@ def build_h3_layout(
         row_count=row,
         time_overrides=time_overrides,
         temporal_stretch=temporal_stretch,
+        temporal_fine_bands=temporal_fine_bands,
     )
 
 

--- a/src/musubi_tuner/minimax_h3/packing.py
+++ b/src/musubi_tuner/minimax_h3/packing.py
@@ -22,12 +22,11 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
-from fractions import Fraction
 from typing import Literal
 
 import torch
 
-from musubi_tuner.minimax_h3.media import H3Task
+from musubi_tuner.minimax_h3.media import TARGET_FPS, H3Task, audio_latent_frames
 
 VIDEO_CHANNELS = 24
 AUDIO_CHANNELS = 32
@@ -142,12 +141,12 @@ class H3PackedLayout:
     # part of the frozen layout value so the transformer's layout-keyed rotary cache
     # cannot serve a grid built for different times
     time_overrides: H3TimeOverrides | None = None
-    # experimental target-timeline stretch: each generated pixel frame advances
-    # temporal_stretch / 24 s on the rotary clock (an effective 24/temporal_stretch fps
-    # sampling of the timeline). References and conditions keep their native 24 fps
-    # spans; the target audio frame count must cover the stretched real duration.
-    # Also frozen here so the rotary cache keys on it.
-    temporal_stretch: float = 1.0
+    # experimental target-timeline stretch: generated pixel frames sample the timeline at
+    # output_fps instead of the native 24 fps, so each frame spans 24/output_fps native
+    # rotary steps and the clip covers frame_count/output_fps real seconds. References and
+    # conditions keep their native 24 fps spans; the target audio frame count must cover
+    # the stretched real duration. Frozen here so the rotary cache keys on it.
+    output_fps: int = TARGET_FPS
     # with a stretch, rotate this many leading (highest-frequency) temporal RoPE bands
     # by the UNSTRETCHED grid instead. Those bands have periods at or below the latent
     # token spacing, so they cannot encode time between tokens -- they carry a per-token
@@ -161,6 +160,10 @@ class H3PackedLayout:
         if len(matches) != 1:
             raise KeyError(f"MiniMax-H3 layout expected exactly one {role!r} segment, found {len(matches)}")
         return matches[0]
+
+    @property
+    def temporal_stretch(self) -> float:
+        return TARGET_FPS / self.output_fps
 
     @property
     def target_video_segment(self) -> H3RowSegment:
@@ -196,16 +199,11 @@ def _validate_video_latent_frames(frames: int, label: str) -> None:
         raise ValueError(f"MiniMax-H3 {label} latent frames must be 5*n+2, got {frames}")
 
 
-def _expected_audio_frames(video_latent_frames: int, temporal_stretch: float = 1.0) -> int:
+def _expected_audio_frames(video_latent_frames: int, output_fps: int = TARGET_FPS) -> int:
     _validate_video_latent_frames(video_latent_frames, "target video")
     n = (video_latent_frames - 2) // 5
     pixel_frames = 17 * n + 5
-    if temporal_stretch == 1.0:
-        return (10 * pixel_frames + 3) // 6
-    # exact rational arithmetic so stretched counts agree bit-for-bit with
-    # media.audio_latent_frames for any stretch of the form 24/fps with integer fps
-    stretch = Fraction(temporal_stretch).limit_denominator(240)
-    return int((10 * pixel_frames * stretch + 3) // 6)
+    return audio_latent_frames(pixel_frames, output_fps=output_fps)
 
 
 def pack_video_rows(latents: torch.Tensor) -> torch.Tensor:
@@ -266,22 +264,21 @@ def build_h3_layout(
     one_frame: bool = False,
     condition_roles: Sequence[str] | None = None,
     time_overrides: H3TimeOverrides | None = None,
-    temporal_stretch: float = 1.0,
+    output_fps: int = TARGET_FPS,
     temporal_fine_bands: int = 0,
 ) -> H3PackedLayout:
     if task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
     if text_length <= 0:
         raise ValueError(f"MiniMax-H3 text length must be positive, got {text_length}")
-    temporal_stretch = float(temporal_stretch)
-    if not math.isfinite(temporal_stretch) or temporal_stretch <= 0.0:
-        raise ValueError(f"MiniMax-H3 temporal stretch must be finite and positive, got {temporal_stretch}")
-    if one_frame and temporal_stretch != 1.0:
+    if isinstance(output_fps, bool) or not isinstance(output_fps, int) or output_fps <= 0:
+        raise ValueError(f"MiniMax-H3 output fps must be a positive integer, got {output_fps!r}")
+    if one_frame and output_fps != TARGET_FPS:
         raise ValueError("MiniMax-H3 one-frame layouts do not support temporal stretch")
     temporal_fine_bands = int(temporal_fine_bands)
     if temporal_fine_bands < 0:
         raise ValueError(f"MiniMax-H3 temporal fine bands must be nonnegative, got {temporal_fine_bands}")
-    if temporal_fine_bands and temporal_stretch == 1.0:
+    if temporal_fine_bands and output_fps == TARGET_FPS:
         raise ValueError("MiniMax-H3 temporal fine bands require an active temporal stretch")
     target_video = _coerce_video_geometry(target_video, "target video")
     if one_frame:
@@ -296,11 +293,11 @@ def build_h3_layout(
         if time_overrides is not None:
             raise ValueError("MiniMax-H3 time overrides require a one-frame layout")
         _validate_video_latent_frames(target_video.frames, "target video")
-        expected_audio_frames = _expected_audio_frames(target_video.frames, temporal_stretch)
+        expected_audio_frames = _expected_audio_frames(target_video.frames, output_fps)
         if target_audio_frames != expected_audio_frames:
             raise ValueError(
                 f"MiniMax-H3 target audio has {target_audio_frames} frames, expected {expected_audio_frames} "
-                f"for {target_video.frames} video latent frames at temporal stretch {temporal_stretch}"
+                f"for {target_video.frames} video latent frames at {output_fps} fps"
             )
 
     visual_conditions = tuple(
@@ -370,7 +367,7 @@ def build_h3_layout(
         segments=tuple(segments),
         row_count=row,
         time_overrides=time_overrides,
-        temporal_stretch=temporal_stretch,
+        output_fps=output_fps,
         temporal_fine_bands=temporal_fine_bands,
     )
 

--- a/src/musubi_tuner/minimax_h3/packing.py
+++ b/src/musubi_tuner/minimax_h3/packing.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
+from fractions import Fraction
 from typing import Literal
 
 import torch
@@ -141,6 +142,12 @@ class H3PackedLayout:
     # part of the frozen layout value so the transformer's layout-keyed rotary cache
     # cannot serve a grid built for different times
     time_overrides: H3TimeOverrides | None = None
+    # experimental target-timeline stretch: each generated pixel frame advances
+    # temporal_stretch / 24 s on the rotary clock (an effective 24/temporal_stretch fps
+    # sampling of the timeline). References and conditions keep their native 24 fps
+    # spans; the target audio frame count must cover the stretched real duration.
+    # Also frozen here so the rotary cache keys on it.
+    temporal_stretch: float = 1.0
 
     def segment(self, role: str) -> H3RowSegment:
         matches = [segment for segment in self.segments if segment.role == role]
@@ -182,11 +189,16 @@ def _validate_video_latent_frames(frames: int, label: str) -> None:
         raise ValueError(f"MiniMax-H3 {label} latent frames must be 5*n+2, got {frames}")
 
 
-def _expected_audio_frames(video_latent_frames: int) -> int:
+def _expected_audio_frames(video_latent_frames: int, temporal_stretch: float = 1.0) -> int:
     _validate_video_latent_frames(video_latent_frames, "target video")
     n = (video_latent_frames - 2) // 5
     pixel_frames = 17 * n + 5
-    return (10 * pixel_frames + 3) // 6
+    if temporal_stretch == 1.0:
+        return (10 * pixel_frames + 3) // 6
+    # exact rational arithmetic so stretched counts agree bit-for-bit with
+    # media.audio_latent_frames for any stretch of the form 24/fps with integer fps
+    stretch = Fraction(temporal_stretch).limit_denominator(240)
+    return int((10 * pixel_frames * stretch + 3) // 6)
 
 
 def pack_video_rows(latents: torch.Tensor) -> torch.Tensor:
@@ -247,11 +259,17 @@ def build_h3_layout(
     one_frame: bool = False,
     condition_roles: Sequence[str] | None = None,
     time_overrides: H3TimeOverrides | None = None,
+    temporal_stretch: float = 1.0,
 ) -> H3PackedLayout:
     if task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
     if text_length <= 0:
         raise ValueError(f"MiniMax-H3 text length must be positive, got {text_length}")
+    temporal_stretch = float(temporal_stretch)
+    if not math.isfinite(temporal_stretch) or temporal_stretch <= 0.0:
+        raise ValueError(f"MiniMax-H3 temporal stretch must be finite and positive, got {temporal_stretch}")
+    if one_frame and temporal_stretch != 1.0:
+        raise ValueError("MiniMax-H3 one-frame layouts do not support temporal stretch")
     target_video = _coerce_video_geometry(target_video, "target video")
     if one_frame:
         if target_video.frames != ONE_FRAME_VIDEO_LATENT_FRAMES:
@@ -265,11 +283,11 @@ def build_h3_layout(
         if time_overrides is not None:
             raise ValueError("MiniMax-H3 time overrides require a one-frame layout")
         _validate_video_latent_frames(target_video.frames, "target video")
-        expected_audio_frames = _expected_audio_frames(target_video.frames)
+        expected_audio_frames = _expected_audio_frames(target_video.frames, temporal_stretch)
         if target_audio_frames != expected_audio_frames:
             raise ValueError(
                 f"MiniMax-H3 target audio has {target_audio_frames} frames, expected {expected_audio_frames} "
-                f"for {target_video.frames} video latent frames"
+                f"for {target_video.frames} video latent frames at temporal stretch {temporal_stretch}"
             )
 
     visual_conditions = tuple(
@@ -339,6 +357,7 @@ def build_h3_layout(
         segments=tuple(segments),
         row_count=row,
         time_overrides=time_overrides,
+        temporal_stretch=temporal_stretch,
     )
 
 
@@ -369,12 +388,12 @@ def _frame_grid(video: H3VideoGeometry) -> tuple[torch.Tensor, torch.Tensor]:
     return torch.stack((height.reshape(-1), width.reshape(-1)), dim=-1), width_axis
 
 
-def _video_t_spans(frames: int) -> list[float]:
-    return [FRAME_RESCALE * FRAME_PER_TOKEN[index % len(FRAME_PER_TOKEN)] for index in range(frames)]
+def _video_t_spans(frames: int, temporal_stretch: float = 1.0) -> list[float]:
+    return [temporal_stretch * FRAME_RESCALE * FRAME_PER_TOKEN[index % len(FRAME_PER_TOKEN)] for index in range(frames)]
 
 
-def _video_grid(video: H3VideoGeometry, cursor: float) -> torch.Tensor:
-    spans = torch.tensor(_video_t_spans(video.frames), dtype=torch.float64)
+def _video_grid(video: H3VideoGeometry, cursor: float, temporal_stretch: float = 1.0) -> torch.Tensor:
+    spans = torch.tensor(_video_t_spans(video.frames, temporal_stretch), dtype=torch.float64)
     times = cursor + torch.cat((torch.zeros(1, dtype=torch.float64), spans[:-1].cumsum(0)))
     frame, _ = _frame_grid(video)
     grid = torch.empty(video.frames, frame.shape[0], 3, dtype=torch.float64)
@@ -406,7 +425,10 @@ def build_position_grid(layout: H3PackedLayout, *, device: torch.device | str | 
         if layout.time_overrides is not None:
             condition_times = [cursor + time for time in layout.time_overrides.condition_times]
         else:
-            last_time = cursor + sum(_video_t_spans(layout.target_video.frames)) - FRAME_RESCALE
+            # the last-frame anchor sits on the final pixel frame of the target timeline,
+            # so both the total span and the one-frame back-off scale with the stretch
+            last_time = cursor + sum(_video_t_spans(layout.target_video.frames, layout.temporal_stretch))
+            last_time -= FRAME_RESCALE * layout.temporal_stretch
             condition_times = [cursor if segment.role == "first" else last_time for segment in condition_segments]
         for segment, time in zip(condition_segments, condition_times):
             positions[segment.row_slice, 0] = time
@@ -447,7 +469,7 @@ def build_position_grid(layout: H3PackedLayout, *, device: torch.device | str | 
         *target_width_endpoints,
     )
     target_video = layout.target_video_segment
-    positions[target_video.row_slice] = _video_grid(layout.target_video, cursor)
+    positions[target_video.row_slice] = _video_grid(layout.target_video, cursor, layout.temporal_stretch)
     positions = positions.unsqueeze(0)
     return positions.to(device=device) if device is not None else positions
 

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -160,6 +160,10 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
         raise ValueError(f"MiniMax-H3 --output_fps must be in [1,120], got {args.output_fps}")
     if one_frame and args.output_fps != 24:
         raise ValueError("MiniMax-H3 one-frame generation has no timeline to stretch; --output_fps must stay 24")
+    if not 0 <= args.stretch_keep_bands <= 16:
+        raise ValueError(f"MiniMax-H3 --stretch_keep_bands must be in [0,16], got {args.stretch_keep_bands}")
+    if args.stretch_keep_bands and args.output_fps == 24:
+        raise ValueError("MiniMax-H3 --stretch_keep_bands requires an --output_fps below or above 24")
     if one_frame:
         _, control_indices = parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
         if args.task == "fl2va":
@@ -675,15 +679,17 @@ def _build_layout(args: argparse.Namespace, text_length: int, visual_geometries,
         condition_roles=condition_roles,
         time_overrides=_one_frame_time_overrides(args),
         temporal_stretch=24.0 / args.output_fps,
+        temporal_fine_bands=args.stretch_keep_bands,
     )
     logger.info(
-        "MiniMax-H3 layout: task=%s video=%s audio_frames=%d text_rows=%d packed_rows=%d temporal_stretch=%.4f",
+        "MiniMax-H3 layout: task=%s video=%s audio_frames=%d text_rows=%d packed_rows=%d temporal_stretch=%.4f fine_bands=%d",
         args.task,
         layout.target_video,
         layout.target_audio_frames,
         layout.text_length,
         layout.row_count,
         layout.temporal_stretch,
+        layout.temporal_fine_bands,
     )
     return layout
 
@@ -1354,6 +1360,16 @@ def setup_parser() -> argparse.ArgumentParser:
         " the audio track covers the stretched duration, and the output container is written at this rate."
         " The model was trained at 24 fps only, so lower rates trade temporal resolution (and possibly"
         " quality) for compute; see docs. 24 disables the stretch",
+    )
+    parser.add_argument(
+        "--stretch_keep_bands",
+        type=int,
+        default=0,
+        help="with --output_fps below 24: rotate this many leading (highest-frequency) temporal RoPE bands"
+        " by the unstretched grid. Those bands have periods at or below the latent token spacing and carry"
+        " a per-token lattice phase rather than time; stretching them scrambles that phase with the"
+        " 17-pixel-frame VAE group period (periodic fading/stripes). 3 covers the sub-lattice bands of the"
+        " released 16-band spectrum. 0 stretches all bands (default)",
     )
     parser.add_argument("--allow_experimental_duration", action="store_true")
     parser.add_argument("--steps", type=int, default=30)

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -156,6 +156,10 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
     if args.width <= 0 or args.height <= 0 or args.width % 32 or args.height % 32:
         raise ValueError(f"MiniMax-H3 width and height must be positive and divisible by 32, got {args.width}x{args.height}")
     one_frame = args.frame_count == 1
+    if not 1 <= args.output_fps <= 120:
+        raise ValueError(f"MiniMax-H3 --output_fps must be in [1,120], got {args.output_fps}")
+    if one_frame and args.output_fps != 24:
+        raise ValueError("MiniMax-H3 one-frame generation has no timeline to stretch; --output_fps must stay 24")
     if one_frame:
         _, control_indices = parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
         if args.task == "fl2va":
@@ -175,7 +179,9 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
         if args.one_frame is not None:
             raise ValueError("MiniMax-H3 --one_frame options require --frame_count 1")
         video_latent_frames(args.frame_count)
-        duration = args.frame_count / 24.0
+        # with a temporal stretch the rotary timeline spans the real (stretched) duration,
+        # so that is the quantity to hold inside the released range
+        duration = args.frame_count / args.output_fps
         if not args.allow_experimental_duration and not 5.0 <= duration <= 15.0:
             raise ValueError(
                 f"MiniMax-H3 duration {duration:.3f}s is outside the released 5-15s range; "
@@ -660,20 +666,24 @@ def _build_layout(args: argparse.Namespace, text_length: int, visual_geometries,
             args.height // VIDEO_VAE_SPATIAL_RATIO,
             args.width // VIDEO_VAE_SPATIAL_RATIO,
         ),
-        target_audio_frames=ONE_FRAME_AUDIO_LATENT_FRAMES if one_frame else audio_latent_frames(args.frame_count),
+        target_audio_frames=(
+            ONE_FRAME_AUDIO_LATENT_FRAMES if one_frame else audio_latent_frames(args.frame_count, output_fps=args.output_fps)
+        ),
         visual_conditions=visual_geometries,
         references=reference_geometries,
         one_frame=one_frame,
         condition_roles=condition_roles,
         time_overrides=_one_frame_time_overrides(args),
+        temporal_stretch=24.0 / args.output_fps,
     )
     logger.info(
-        "MiniMax-H3 layout: task=%s video=%s audio_frames=%d text_rows=%d packed_rows=%d",
+        "MiniMax-H3 layout: task=%s video=%s audio_frames=%d text_rows=%d packed_rows=%d temporal_stretch=%.4f",
         args.task,
         layout.target_video,
         layout.target_audio_frames,
         layout.text_length,
         layout.row_count,
+        layout.temporal_stretch,
     )
     return layout
 
@@ -810,7 +820,9 @@ def _decode_and_save(
                     write_image(decoded_video_to_uint8(step_video, frame_limit=1)[0], step_path)
                 else:
                     step_path = trajectory_dir / f"{step_stem}.mp4"
-                    write_video_only(decoded_video_to_uint8(step_video, frame_limit=args.frame_count), step_path)
+                    write_video_only(
+                        decoded_video_to_uint8(step_video, frame_limit=args.frame_count), step_path, fps=args.output_fps
+                    )
                 del step_video
                 clean_memory_on_device(device)
                 logger.info("Saved MiniMax-H3 trajectory step: %s", step_path)
@@ -838,6 +850,7 @@ def _decode_and_save(
         decoded_video,
         decoded_audio,
         frame_count=args.frame_count,
+        fps=args.output_fps,
     )
     write_joint_av(decoded, output_path)
     logger.info("Saved MiniMax-H3 output: %s", output_path)
@@ -878,6 +891,7 @@ def _save_latent_file(
         "width": str(args.width),
         "height": str(args.height),
         "frame_count": str(args.frame_count),
+        "output_fps": str(args.output_fps),
         "steps": str(args.steps),
         "h3_shift_video": str(args.h3_shift_video),
         "h3_shift_audio": str(args.h3_shift_audio),
@@ -911,7 +925,7 @@ def parse_prompt_line(line: str) -> dict:
     """Parse an interactive/from-file prompt line into argument overrides.
 
     Format: "prompt text --w 768 --h 1344 --f 1 --d 42 --s 30 --fs 12.0 --fsa 3.0
-    --i first.png --ei last.png --ref face.png --of target_index=24 --o name.png".
+    --ofps 12 --i first.png --ei last.png --ref face.png --of target_index=24 --o name.png".
     --ref is repeatable and replaces any session-level --ref list. A line starting
     with "--" carries only options; without prompt text the command-line --prompt
     (when given) stays in effect. The literal string "\\n" in the prompt text becomes
@@ -935,6 +949,8 @@ def parse_prompt_line(line: str) -> dict:
             overrides["height"] = int(value)
         elif option == "f":
             overrides["frame_count"] = int(value)
+        elif option == "ofps":
+            overrides["output_fps"] = int(value)
         elif option == "d":
             overrides["seed"] = int(value)
         elif option == "s":
@@ -1226,6 +1242,7 @@ def process_latent_decode(args: argparse.Namespace, device: torch.device) -> Non
         logger.info("Decoding MiniMax-H3 latents from %s", source)
         item_args = copy.deepcopy(args)
         item_args.frame_count = frame_count
+        item_args.output_fps = int(metadata.get("output_fps", "24"))
         seed = metadata.get("seeds", "0")
         suffix = ".png" if frame_count == 1 else ".mp4"
         output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}{suffix}"
@@ -1328,6 +1345,16 @@ def setup_parser() -> argparse.ArgumentParser:
         " order and is required when conditions are present. The base model reads these as trainable time inputs;"
         " see docs/minimax_h3_1f.md",
     )
+    parser.add_argument(
+        "--output_fps",
+        type=int,
+        default=24,
+        help="experimental temporal stretch: sample the generated timeline at this rate instead of 24 fps."
+        " The --frame_count frames then cover frame_count/fps seconds -- target RoPE spans scale by 24/fps,"
+        " the audio track covers the stretched duration, and the output container is written at this rate."
+        " The model was trained at 24 fps only, so lower rates trade temporal resolution (and possibly"
+        " quality) for compute; see docs. 24 disables the stretch",
+    )
     parser.add_argument("--allow_experimental_duration", action="store_true")
     parser.add_argument("--steps", type=int, default=30)
     parser.add_argument("--seed", type=int, default=None, help="random when omitted")
@@ -1340,7 +1367,7 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--from_file",
         default=None,
-        help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--i/--ei/--ref/--of/--o"
+        help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--ofps/--i/--ei/--ref/--of/--o"
         " options) from a file and run them in phases, loading each model family once. Sampled latents are saved"
         " to the --output directory before decoding so a crash loses nothing; the files are removed after their"
         " output is written. See docs/minimax_h3.md",

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -27,13 +27,14 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     parse_one_frame_options,
 )
 from musubi_tuner.minimax_h3.media import (
+    TARGET_FPS,
     H3Record,
     audio_latent_frames,
     video_latent_frames,
 )
 from musubi_tuner.minimax_h3.checkpoint import resolve_safetensors_files
 from musubi_tuner.modules.convrot_int8_utils import has_comfy_quant_tensors
-from musubi_tuner.minimax_h3.model import load_h3_transformer
+from musubi_tuner.minimax_h3.model import MiniMaxH3Config, load_h3_transformer
 from musubi_tuner.minimax_h3.packing import (
     FRAME_RESCALE,
     ONE_FRAME_AUDIO_LATENT_FRAMES,
@@ -156,14 +157,20 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
     if args.width <= 0 or args.height <= 0 or args.width % 32 or args.height % 32:
         raise ValueError(f"MiniMax-H3 width and height must be positive and divisible by 32, got {args.width}x{args.height}")
     one_frame = args.frame_count == 1
-    if not 1 <= args.output_fps <= 120:
-        raise ValueError(f"MiniMax-H3 --output_fps must be in [1,120], got {args.output_fps}")
-    if one_frame and args.output_fps != 24:
-        raise ValueError("MiniMax-H3 one-frame generation has no timeline to stretch; --output_fps must stay 24")
-    if not 0 <= args.stretch_keep_bands <= 16:
-        raise ValueError(f"MiniMax-H3 --stretch_keep_bands must be in [0,16], got {args.stretch_keep_bands}")
-    if args.stretch_keep_bands and args.output_fps == 24:
-        raise ValueError("MiniMax-H3 --stretch_keep_bands requires an --output_fps below or above 24")
+    # fps above the native rate would let the duration gate admit packed sequences far past
+    # the released maximum (and desynchronize the floored audio count), so the squeeze
+    # direction stays closed until it is validated
+    if not 1 <= args.output_fps <= TARGET_FPS:
+        raise ValueError(f"MiniMax-H3 --output_fps must be in [1,{TARGET_FPS}], got {args.output_fps}")
+    if one_frame and args.output_fps != TARGET_FPS:
+        raise ValueError(f"MiniMax-H3 one-frame generation has no timeline to stretch; --output_fps must stay {TARGET_FPS}")
+    # at least one band must stay on the stretched clock, or the video RoPE silently reverts
+    # to the native timeline while the audio still covers the stretched duration
+    max_keep_bands = MiniMaxH3Config.rope_inv_freq_len - 1
+    if not 0 <= args.stretch_keep_bands <= max_keep_bands:
+        raise ValueError(f"MiniMax-H3 --stretch_keep_bands must be in [0,{max_keep_bands}], got {args.stretch_keep_bands}")
+    if args.stretch_keep_bands and args.output_fps == TARGET_FPS:
+        raise ValueError(f"MiniMax-H3 --stretch_keep_bands requires an --output_fps below {TARGET_FPS}")
     if one_frame:
         _, control_indices = parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
         if args.task == "fl2va":
@@ -678,7 +685,7 @@ def _build_layout(args: argparse.Namespace, text_length: int, visual_geometries,
         one_frame=one_frame,
         condition_roles=condition_roles,
         time_overrides=_one_frame_time_overrides(args),
-        temporal_stretch=24.0 / args.output_fps,
+        output_fps=args.output_fps,
         temporal_fine_bands=args.stretch_keep_bands,
     )
     logger.info(
@@ -931,7 +938,7 @@ def parse_prompt_line(line: str) -> dict:
     """Parse an interactive/from-file prompt line into argument overrides.
 
     Format: "prompt text --w 768 --h 1344 --f 1 --d 42 --s 30 --fs 12.0 --fsa 3.0
-    --ofps 12 --i first.png --ei last.png --ref face.png --of target_index=24 --o name.png".
+    --ofps 12 --skb 3 --i first.png --ei last.png --ref face.png --of target_index=24 --o name.png".
     --ref is repeatable and replaces any session-level --ref list. A line starting
     with "--" carries only options; without prompt text the command-line --prompt
     (when given) stays in effect. The literal string "\\n" in the prompt text becomes
@@ -957,6 +964,8 @@ def parse_prompt_line(line: str) -> dict:
             overrides["frame_count"] = int(value)
         elif option == "ofps":
             overrides["output_fps"] = int(value)
+        elif option == "skb":
+            overrides["stretch_keep_bands"] = int(value)
         elif option == "d":
             overrides["seed"] = int(value)
         elif option == "s":
@@ -1086,7 +1095,12 @@ def process_from_file(args: argparse.Namespace, device: torch.device) -> None:
             prompt_args = apply_overrides(args, parse_prompt_line(line))
             validate_prompt_args(prompt_args, directory_output=True)
         except ValueError as error:
-            raise ValueError(f"MiniMax-H3 --from_file line {line_number} is invalid: {error}") from error
+            # an invalid line must not abort the batch: record it as a failed item so the
+            # remaining prompts still run and the summary reports it
+            failed = _BatchItem(index=len(items), args=copy.deepcopy(args))
+            _mark_failed(failed, f"line {line_number} validation", error)
+            items.append(failed)
+            continue
         items.append(_BatchItem(index=len(items), args=prompt_args))
     if not items:
         logger.warning("MiniMax-H3 --from_file %s contains no prompts", args.from_file)
@@ -1233,6 +1247,26 @@ def process_interactive(args: argparse.Namespace, device: torch.device) -> None:
         print("\nExiting interactive mode")
 
 
+def _parse_output_fps_metadata(source: Path, metadata: dict, requested_fps: int) -> int:
+    """The stored rate is authoritative: the latents were sampled on its rotary timeline,
+    so decoding at any other rate would desynchronize audio and video."""
+    raw = metadata.get("output_fps", str(TARGET_FPS))
+    try:
+        output_fps = int(raw)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"MiniMax-H3 latent file {source} has invalid output_fps metadata {raw!r}") from error
+    if not 1 <= output_fps <= TARGET_FPS:
+        raise ValueError(f"MiniMax-H3 latent file {source} output_fps metadata {output_fps} is outside [1,{TARGET_FPS}]")
+    if requested_fps not in (TARGET_FPS, output_fps):
+        logger.warning(
+            "MiniMax-H3 latent file %s was sampled at %d fps; decoding at that rate and ignoring --output_fps %d",
+            source,
+            output_fps,
+            requested_fps,
+        )
+    return output_fps
+
+
 def process_latent_decode(args: argparse.Namespace, device: torch.device) -> None:
     """Decode-only mode for --from_file intermediate latents; only the VAEs are loaded."""
     output_dir = Path(args.output).expanduser()
@@ -1246,13 +1280,16 @@ def process_latent_decode(args: argparse.Namespace, device: torch.device) -> Non
     shared = H3SharedModels(device=device)
     for source, video_latents, audio_latents, frame_count, metadata in loaded:
         logger.info("Decoding MiniMax-H3 latents from %s", source)
-        item_args = copy.deepcopy(args)
-        item_args.frame_count = frame_count
-        item_args.output_fps = int(metadata.get("output_fps", "24"))
-        seed = metadata.get("seeds", "0")
-        suffix = ".png" if frame_count == 1 else ".mp4"
-        output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}{suffix}"
-        _decode_and_save(item_args, video_latents, audio_latents, output_path, device, shared)
+        try:
+            item_args = copy.deepcopy(args)
+            item_args.frame_count = frame_count
+            item_args.output_fps = _parse_output_fps_metadata(source, metadata, args.output_fps)
+            seed = metadata.get("seeds", "0")
+            suffix = ".png" if frame_count == 1 else ".mp4"
+            output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}{suffix}"
+            _decode_and_save(item_args, video_latents, audio_latents, output_path, device, shared)
+        except Exception as error:
+            logger.error("MiniMax-H3 latent decode failed for %s: %s", source, error, exc_info=True)
 
 
 def setup_parser() -> argparse.ArgumentParser:
@@ -1354,12 +1391,13 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output_fps",
         type=int,
-        default=24,
-        help="experimental temporal stretch: sample the generated timeline at this rate instead of 24 fps."
-        " The --frame_count frames then cover frame_count/fps seconds -- target RoPE spans scale by 24/fps,"
-        " the audio track covers the stretched duration, and the output container is written at this rate."
-        " The model was trained at 24 fps only, so lower rates trade temporal resolution (and possibly"
-        " quality) for compute; see docs. 24 disables the stretch",
+        default=TARGET_FPS,
+        help="experimental temporal stretch: sample the generated timeline at this rate (1-24) instead of"
+        " 24 fps. The --frame_count frames then cover frame_count/fps seconds -- target RoPE spans scale"
+        " by 24/fps, the audio track covers the stretched duration, and the output container is written"
+        " at this rate. The model was trained at 24 fps only, so lower rates trade temporal resolution"
+        " (and possibly quality) for compute; pair with --stretch_keep_bands, see docs. 24 disables the"
+        " stretch",
     )
     parser.add_argument(
         "--stretch_keep_bands",
@@ -1368,8 +1406,9 @@ def setup_parser() -> argparse.ArgumentParser:
         help="with --output_fps below 24: rotate this many leading (highest-frequency) temporal RoPE bands"
         " by the unstretched grid. Those bands have periods at or below the latent token spacing and carry"
         " a per-token lattice phase rather than time; stretching them scrambles that phase with the"
-        " 17-pixel-frame VAE group period (periodic fading/stripes). 3 covers the sub-lattice bands of the"
-        " released 16-band spectrum. 0 stretches all bands (default)",
+        " 17-pixel-frame VAE group period (periodic fading/stripes). Recommended: 3-4 at 12 fps, 2 at"
+        " 16 fps, 1 at 20 fps (at most 15 -- at least one band must stay on the stretched clock)."
+        " 0 stretches all bands (default)",
     )
     parser.add_argument("--allow_experimental_duration", action="store_true")
     parser.add_argument("--steps", type=int, default=30)
@@ -1383,7 +1422,7 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--from_file",
         default=None,
-        help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--ofps/--i/--ei/--ref/--of/--o"
+        help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--ofps/--skb/--i/--ei/--ref/--of/--o"
         " options) from a file and run them in phases, loading each model family once. Sampled latents are saved"
         " to the --output directory before decoding so a crash loses nothing; the files are removed after their"
         " output is written. See docs/minimax_h3.md",

--- a/tests/test_minimax_h3_generation_modes.py
+++ b/tests/test_minimax_h3_generation_modes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -39,6 +40,8 @@ def _session_args(tmp_path, *, task="t2va", **overrides):
         "width": 64,
         "height": 64,
         "frame_count": 124,
+        "output_fps": 24,
+        "stretch_keep_bands": 0,
         "allow_experimental_duration": False,
         "steps": 2,
         "seed": 1,
@@ -174,20 +177,21 @@ def test_one_frame_fl2va_control_index_error_reports_the_counts(tmp_path):
         validate_prompt_args(args)
 
 
-def test_from_file_reports_the_failing_line_number(tmp_path):
-    prompts = tmp_path / "prompts.txt"
-    prompts.write_text("# comment\n\na cat sings --d 11\na dog barks --w 0\n", encoding="utf-8")
-    args = _session_args(
-        tmp_path,
-        frame_count=5,
-        allow_experimental_duration=True,
-        output=str(tmp_path / "outputs"),
-        from_file=str(prompts),
-    )
+def test_from_file_records_invalid_lines_without_aborting_the_batch(tmp_path, monkeypatch, caplog):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+    written = []
+    monkeypatch.setattr(generate, "write_joint_av", lambda decoded, output: written.append(Path(output)))
 
-    # the bad width line is file line 4; validation fails before any model loads
-    with pytest.raises(ValueError, match="--from_file line 4 is invalid.*divisible by 32"):
+    args = _batch_args(tmp_path, ["# comment", "", "a cat sings --d 11", "a dog barks --w 0"])
+    with caplog.at_level(logging.ERROR, logger=generate.logger.name):
         generate.process_from_file(args, torch.device("cpu"))
+
+    # the bad width line is file line 4; it is recorded as a failed item while the valid prompt still runs
+    assert len(written) == 1
+    assert written[0].name.endswith("_11.mp4")
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("line 4 validation" in message and "divisible by 32" in message for message in messages)
 
 
 def test_latent_file_roundtrip_preserves_tensors_and_rejects_missing_audio(tmp_path):

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -307,6 +307,8 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         "width": 64,
         "height": 64,
         "frame_count": 124,
+        "output_fps": 24,
+        "stretch_keep_bands": 0,
         "allow_experimental_duration": False,
         "steps": 2,
         "seed": 1,

--- a/tests/test_minimax_h3_temporal_stretch.py
+++ b/tests/test_minimax_h3_temporal_stretch.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+import musubi_tuner.minimax_h3_generate_video as generate
+from musubi_tuner.minimax_h3.media import audio_latent_frames, video_latent_frames
+from musubi_tuner.minimax_h3.model import MiniMaxH3Model
+from musubi_tuner.minimax_h3.packing import (
+    FRAME_RESCALE,
+    H3VideoGeometry,
+    _expected_audio_frames,
+    build_h3_layout,
+    build_position_grid,
+)
+
+
+def _layout(output_fps=24, temporal_fine_bands=0, frame_count=124, task="t2va", **kwargs):
+    return build_h3_layout(
+        task=task,
+        text_length=10,
+        target_video=H3VideoGeometry(video_latent_frames(frame_count), 42, 24),
+        target_audio_frames=audio_latent_frames(frame_count, output_fps=output_fps),
+        output_fps=output_fps,
+        temporal_fine_bands=temporal_fine_bands,
+        **kwargs,
+    )
+
+
+def _target_video_times(layout, grid):
+    segment = layout.target_video_segment
+    times = grid[0, segment.row_slice, 0]
+    return times.view(layout.target_video.frames, layout.target_video.frame_rows)[:, 0]
+
+
+def test_expected_audio_frames_match_the_media_helper_across_rates():
+    for fps in (24, 20, 16, 12, 8, 6, 1):
+        for frame_count in (5, 22, 124, 141, 243, 345):
+            assert _expected_audio_frames(video_latent_frames(frame_count), fps) == audio_latent_frames(frame_count, output_fps=fps)
+
+
+def test_audio_latent_frames_validates_the_rate_before_the_native_fast_path():
+    for bad in (24.0, 12.0, 0, -1, True):
+        with pytest.raises(ValueError, match="positive integer"):
+            audio_latent_frames(124, output_fps=bad)
+
+
+def test_stretched_target_times_scale_exactly_and_audio_rows_keep_the_native_rate():
+    native = _layout()
+    stretched = _layout(output_fps=12)
+    native_times = _target_video_times(native, build_position_grid(native))
+    stretched_times = _target_video_times(stretched, build_position_grid(stretched))
+    assert torch.allclose(stretched_times - 10.0, (native_times - 10.0) * 2.0)
+    # the audio grid stays one rotary unit per latent frame; only the frame count grows
+    grid = build_position_grid(stretched)
+    audio_times = grid[0, stretched.target_audio_segment.row_slice, 0]
+    per_channel = audio_times.view(2, stretched.target_audio_frames)
+    assert torch.equal(per_channel[0].diff(), torch.ones(stretched.target_audio_frames - 1, dtype=torch.float64))
+    # video and audio cover the same stretched duration to within one audio frame
+    video_span = float(stretched_times[-1] - 10.0) + FRAME_RESCALE * 4 * 2
+    assert math.isclose(video_span, stretched.target_audio_frames, abs_tol=1.0)
+
+
+def test_fl2va_last_anchor_follows_the_stretched_timeline():
+    layout = _layout(
+        output_fps=12,
+        task="fl2va",
+        visual_conditions=[H3VideoGeometry(1, 42, 24)] * 2,
+    )
+    grid = build_position_grid(layout)
+    last_anchor = float(grid[0, layout.segment("last").start, 0]) - 10.0
+    assert last_anchor == pytest.approx((124 - 1) * FRAME_RESCALE * 2, abs=1e-9)
+
+
+def test_keep_bands_rotate_by_the_unstretched_grid_and_spare_the_spatial_axes():
+    inv_freq = torch.tensor([10000.0 ** (-k / 16) for k in range(16)], dtype=torch.float32)
+    dummy = SimpleNamespace(rope=SimpleNamespace(inv_freq=inv_freq))
+    stretched = _layout(output_fps=12, temporal_fine_bands=3)
+    grid = build_position_grid(stretched)
+    fine_grid = build_position_grid(replace(stretched, output_fps=24, temporal_fine_bands=0))
+
+    hybrid = MiniMaxH3Model._rotation_table(dummy, grid, torch.float64, fine_position_ids=fine_grid, fine_bands=3)
+    all_stretched = MiniMaxH3Model._rotation_table(dummy, grid, torch.float64)
+    all_fine = MiniMaxH3Model._rotation_table(dummy, fine_grid, torch.float64)
+
+    # pair layout: [temporal 16 | height 16 | width 16] truncated to the head pair budget
+    assert torch.equal(hybrid[..., :3, :, :], all_fine[..., :3, :, :])
+    assert torch.equal(hybrid[..., 3:16, :, :], all_stretched[..., 3:16, :, :])
+    assert torch.equal(hybrid[..., 16:, :, :], all_stretched[..., 16:, :, :])
+    # non-target rows (text) are identical in both grids, so the splice is a no-op there
+    assert torch.equal(hybrid[:, :10], all_stretched[:, :10])
+
+    with pytest.raises(ValueError, match="at least one"):
+        MiniMaxH3Model._rotation_table(dummy, grid, torch.float64, fine_position_ids=fine_grid, fine_bands=16)
+
+
+def test_layout_validation_rejects_inconsistent_stretch_combinations():
+    with pytest.raises(ValueError, match="one-frame"):
+        build_h3_layout(
+            task="t2va",
+            text_length=10,
+            target_video=H3VideoGeometry(1, 42, 24),
+            target_audio_frames=2,
+            one_frame=True,
+            output_fps=12,
+        )
+    with pytest.raises(ValueError, match="require an active temporal stretch"):
+        _layout(output_fps=24, temporal_fine_bands=3)
+    with pytest.raises(ValueError, match="at 12 fps"):
+        build_h3_layout(
+            task="t2va",
+            text_length=10,
+            target_video=H3VideoGeometry(video_latent_frames(124), 42, 24),
+            target_audio_frames=audio_latent_frames(124),
+            output_fps=12,
+        )
+    # stretched and native layouts must never share a rotary cache entry
+    assert hash(_layout()) != hash(_layout(output_fps=12))
+    assert hash(_layout(output_fps=12)) != hash(_layout(output_fps=12, temporal_fine_bands=3))
+
+
+def _prompt_args(**overrides):
+    args = generate.setup_parser().parse_args(["--task", "t2va", "--output", "out.mp4", "--prompt", "p", "--frame_count", "124"])
+    args.output_name = None
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_prompt_validation_bounds_the_stretch_arguments():
+    generate.validate_prompt_args(_prompt_args(output_fps=12, stretch_keep_bands=3, allow_experimental_duration=True))
+    with pytest.raises(ValueError, match=r"--output_fps must be in \[1,24\]"):
+        generate.validate_prompt_args(_prompt_args(output_fps=48))
+    with pytest.raises(ValueError, match=r"--stretch_keep_bands must be in \[0,15\]"):
+        generate.validate_prompt_args(_prompt_args(output_fps=12, stretch_keep_bands=16, allow_experimental_duration=True))
+    with pytest.raises(ValueError, match="requires an --output_fps below"):
+        generate.validate_prompt_args(_prompt_args(stretch_keep_bands=3))
+    with pytest.raises(ValueError, match="one-frame"):
+        generate.validate_prompt_args(_prompt_args(frame_count=1, output_fps=12, output="out.png"))
+    # the released 5-15 s duration gate reads the real (stretched) duration
+    generate.validate_prompt_args(_prompt_args(output_fps=12))  # 124/12 = 10.3 s
+    with pytest.raises(ValueError, match="outside the released 5-15s range"):
+        generate.validate_prompt_args(_prompt_args(frame_count=22, output_fps=12))  # 1.8 s
+
+
+def test_prompt_line_aliases_cover_the_stretch_options():
+    overrides = generate.parse_prompt_line("hello --ofps 12 --skb 3")
+    assert overrides == {"prompt": "hello", "output_fps": 12, "stretch_keep_bands": 3}
+
+
+def test_output_fps_metadata_is_authoritative_and_validated(tmp_path, caplog):
+    source = tmp_path / "latent.safetensors"
+    assert generate._parse_output_fps_metadata(source, {}, 24) == 24
+    assert generate._parse_output_fps_metadata(source, {"output_fps": "12"}, 24) == 12
+    with caplog.at_level("WARNING", logger=generate.logger.name):
+        assert generate._parse_output_fps_metadata(source, {"output_fps": "12"}, 16) == 12
+    assert any("ignoring --output_fps 16" in record.getMessage() for record in caplog.records)
+    for bad in ("", "12.0", "0", "48"):
+        with pytest.raises(ValueError):
+            generate._parse_output_fps_metadata(source, {"output_fps": bad}, 24)


### PR DESCRIPTION
## Summary

Adds an experimental temporal stretch to MiniMax-H3 generation: `--output_fps N` samples the generated timeline at N fps instead of the trained 24, by scaling the target video's rotary time spans by `24/N`. The H3 time axis is real-time (1 rotary unit = 1/40 s, 5/3 units per 24 fps pixel frame), so the audio grid stays on its native 40 Hz clock over the stretched real duration and cross-modal alignment is preserved without further changes.

Uses:
- same `--frame_count`, lower fps -> a proportionally longer clip at nearly the same compute (only the audio rows grow)
- same real duration, proportionally fewer frames -> roughly half the packed rows at 12 fps (~2.1x faster measured: 124f@12 vs the equal-duration 243f@24)

## The keep-bands correction

A plain stretch produces periodic artifacts with a 17-pixel-frame period. Cause: the leading (highest-frequency) temporal RoPE bands (measured spectrum `inv_freq[k] = 10000^(-k/16)`) rotate at or above one cycle per latent token, so they carry a per-token lattice phase rather than time; stretching re-dials that phase against the `(1,4,4,4,4)` VAE token grouping. `--stretch_keep_bands K` rotates the K leading temporal bands by the unstretched grid instead (the transformer builds both position grids and splices the temporal angles per band). K counts the bands whose per-token rotation changes regime at that stretch: 3 at 12 fps (4 also clears the last residual glitches), 2 at 16 fps, 1 at 20 fps.

## Implementation

- `packing.py`: `H3PackedLayout.temporal_stretch` / `temporal_fine_bands` as frozen fields, so the transformer's layout-keyed rotary cache distinguishes stretched grids; audio frame count generalizes with exact rational arithmetic (reduces to the released `(10f+3)//6` at 24 fps); FL2VA last anchor follows the stretched timeline; references, conditions, and one-frame mode keep native spans (one-frame rejects a stretch)
- `model.py`: `_rotation_table` splices per-band temporal angles from the stretched and unstretched grids
- `minimax_h3_generate_video.py`: `--output_fps` / `--stretch_keep_bands` with validation, duration gate on the real (stretched) duration, fps-aware output container / trajectory dumps / latent-file metadata (decode-only mode restores it), `--ofps` prompt-line option
- docs: new "Temporal stretch (experimental)" section

Defaults (`--output_fps 24`) leave every existing code path byte-identical; training is untouched.

## Validation

- Unit checks: stretched target times exactly scale, audio counts agree bit-for-bit between packing and media helpers across fps 6-24, FL2VA last-anchor position, hybrid rotation table splicing (bands < K from the unstretched grid, spatial axes untouched), layout hash distinctness, validation rejections
- Real runs (768x1344): 12 fps + keep 4 -> no visible artifacts; 16 fps + keep 2 -> clean, good motion; measured speed consistent with the packed-row reduction; SDEdit probes confirmed the model follows the stretched rotary clock (motion speed is preserved rather than re-timed)

Known limitation: temporal resolution halves at 12 fps, and anime-style outputs animate characters on twos (a learned convention bound to the token grid, present at native 24 fps too), so animated styles are usually better served by 16 fps + keep 2. Documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eof8eNXvUDDwmMKdoL7D6U