### PR TITLE
Support MiniMax-H3 module names in convert_lora

### DIFF
--- a/src/musubi_tuner/convert_lora.py
+++ b/src/musubi_tuner/convert_lora.py
@@ -140,6 +140,11 @@ def convert_to_diffusers(prefix, diffusers_prefix, weights_sd):
                     module_name = module_name.replace("img.", "img_")  # fix img
                     module_name = module_name.replace("txt.", "txt_")  # fix txt
                     module_name = module_name.replace("attn.", "attn_")  # fix attn
+                elif ".attn.qkv.proj" in module_name or ".attn.out.proj" in module_name or ".adaln.proj" in module_name:
+                    # MiniMax-H3 lora name to module name: ugly but works
+                    module_name = module_name.replace("qkv.proj", "qkv_proj")  # fix qkv proj
+                    module_name = module_name.replace("out.proj", "out_proj")  # fix out proj
+                    module_name = module_name.replace("adaln.proj", "adaln_proj")  # fix adaln proj
 
             dim = None  # None means LoHa or LoKr, otherwise it's LoRA with alpha and dim is used for scaling
             if "lora_down" in key:


### PR DESCRIPTION
`convert_lora.py --target other` mangles MiniMax-H3 module names: the generic `"_"` → `"."` reconstruction has no H3 fixup branch, so the attention keys come out as `diffusion_model.blocks.N.attn.qkv.proj.lora_A.weight` / `...attn.out.proj...` (and `adaln_proj.linear` as `adaln.proj.linear`) instead of `attn.qkv_proj` / `attn.out_proj`. Consumers expecting the released `diffusion_model.blocks.N.<module>.lora_A/B.weight` layout then silently skip the attention modules — the bulk of the adapter.

This adds an H3 fixup branch following the existing Wan / Z-Image / HunyuanVideo pattern, keyed on the unambiguous `.attn.qkv.proj` / `.attn.out.proj` / `.adaln.proj` signatures.

Verified with a synthetic H3 LoRA covering the default targets (`attn.qkv_proj`, `attn.out_proj`, `mlp.fc1`, `mlp.fc2`) plus `adaln_proj.linear`, rank 16 / alpha 16, on 2 blocks:

- converted keys match the released `diffusion_model.blocks.{0,49}.<module>.lora_{A,B}.weight` layout exactly
- with `alpha == dim` the tensors are byte-identical after conversion (scale 1)
- converting the result back with `--target default` reproduces the original key set losslessly

