### PR TITLE
Fix rank_dropout mask shape for Linear layers with non-3D inputs

### DIFF
--- a/src/musubi_tuner/networks/lora.py
+++ b/src/musubi_tuner/networks/lora.py
@@ -100,6 +100,9 @@ class LoRAModule(torch.nn.Module):
         self.dropout = dropout
         self.rank_dropout = rank_dropout
         self.module_dropout = module_dropout
+        # Used by _rank_dropout_mask to locate the rank dim in lx; saved now since
+        # org_module is deleted in apply_to() before forward() ever runs.
+        self._rank_dropout_is_conv = org_module.__class__.__name__ in ("Conv2d", "Conv3d")
 
     def _autocast_enabled_for(self, x):
         if not x.is_floating_point():
@@ -108,6 +111,23 @@ class LoRAModule(torch.nn.Module):
             return torch.is_autocast_enabled(x.device.type)
         except TypeError:
             return torch.is_autocast_enabled()
+
+    def _rank_dropout_mask(self, lx: torch.Tensor) -> torch.Tensor:
+        """Build a per-rank keep/drop mask shaped to broadcast against lx.
+
+        Where the rank dim sits in lx depends on the wrapped module: Conv puts it at
+        dim=1 (channels), Linear always puts it last, no matter how many leading
+        dims lx has (e.g. a 4D (b, l, d, rank) input, as in krea2's text-fusion
+        projector).
+        """
+        mask = torch.rand((lx.size(0), self.lora_dim), device=lx.device) > self.rank_dropout
+        extra_dims = lx.dim() - 2
+        if extra_dims <= 0:
+            return mask
+        if self._rank_dropout_is_conv:
+            return mask.view(mask.shape[0], mask.shape[1], *([1] * extra_dims))
+        else:
+            return mask.view(mask.shape[0], *([1] * extra_dims), mask.shape[1])
 
     def _lora_input(self, x):
         if self.split_dims is None:
@@ -153,14 +173,7 @@ class LoRAModule(torch.nn.Module):
 
             # rank dropout
             if self.rank_dropout is not None and self.training:
-                mask = torch.rand((lx.size(0), self.lora_dim), device=lx.device) > self.rank_dropout
-                if len(lx.size()) == 3:
-                    mask = mask.unsqueeze(1)  # for Text Encoder
-                elif len(lx.size()) == 4:
-                    mask = mask.unsqueeze(-1).unsqueeze(-1)  # for Conv2d
-                elif len(lx.size()) == 5:
-                    mask = mask.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)  # for Conv3d
-                lx = lx * mask
+                lx = lx * self._rank_dropout_mask(lx)
 
                 # scaling for rank dropout: treat as if the rank is changed
                 scale = self.scale * (1.0 / (1.0 - self.rank_dropout))  # redundant for readability
@@ -180,13 +193,7 @@ class LoRAModule(torch.nn.Module):
 
             # rank dropout
             if self.rank_dropout is not None and self.training:
-                masks = [torch.rand((lx.size(0), self.lora_dim), device=lx.device) > self.rank_dropout for lx in lxs]
-                for i in range(len(lxs)):
-                    if len(lx.size()) == 3:
-                        masks[i] = masks[i].unsqueeze(1)
-                    elif len(lx.size()) == 4:
-                        masks[i] = masks[i].unsqueeze(-1).unsqueeze(-1)
-                    lxs[i] = lxs[i] * masks[i]
+                lxs = [lx * self._rank_dropout_mask(lx) for lx in lxs]
 
                 # scaling for rank dropout: treat as if the rank is changed
                 scale = self.scale * (1.0 / (1.0 - self.rank_dropout))  # redundant for readability


### PR DESCRIPTION
## Summary
- `LoRAModule`'s rank_dropout mask placement was inferred from `len(lx.size())` (3 → Linear, 4 → Conv2d, 5 → Conv3d), assuming a Linear-wrapped layer always sees 3D input.
- krea2's `TextFusionTransformer.projector` is a `Linear` applied to a 4D `(b, l, d, n)` tensor (see `krea2/krea2_mmdit.py`), so the mask was misidentified as Conv2d-shaped and broadcast against the wrong dim, crashing rank_dropout during sampling with:
  ```
  RuntimeError: The size of tensor a (18) must match the size of tensor b (16) at non-singleton dimension 1
  ```
- Fix: record whether `org_module` is Conv vs Linear at `__init__` time (it's deleted by `apply_to()` before `forward()` runs), and use that to place the rank dim correctly — dim=1 for Conv, always-last for Linear regardless of input rank.
- Also fixes an unreachable `NameError` in the `split_dims` rank_dropout branch, which referenced a comprehension-scoped `lx` variable that doesn't leak in Python 3.

## Test plan
- [x] Verified via standalone script covering 4 cases: krea2-style 4D Linear input, standard 3D Linear input, Conv2d, and `split_dims` Linear — all produce correctly shaped output with rank_dropout enabled.
- [x] Re-run a krea2 LoRA training with `rank_dropout` enabled through a full sampling step to confirm no regression end-to-end.

AI Assisted