### PR TITLE
Support the guidance loss under --task ref2va

### DIFF
--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -1461,9 +1461,16 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             )
         # the probe swaps only the text rows; the one-frame times stay valid because they
         # are relative to the target-block cursor, which moves with the text length. The
-        # condition roles are recovered from the segments so a one-frame FL2VA layout with a
-        # single condition rebuilds identically (roles are required for K=1).
-        uncond_condition_roles = tuple(segment.role for segment in runtime.layout.segments if segment.kind == "visual_condition")
+        # FL2VA condition roles are recovered from the segments so a one-frame FL2VA layout
+        # with a single condition rebuilds identically (roles are required for K=1). Ref2VA
+        # reference blocks share the "visual_condition" segment kind but their segments are
+        # regenerated from `references`, and build_h3_layout rejects condition_roles for
+        # non-FL2VA tasks — so roles are harvested for FL2VA layouts only.
+        uncond_condition_roles = (
+            tuple(segment.role for segment in runtime.layout.segments if segment.kind == "visual_condition")
+            if runtime.layout.task == "fl2va"
+            else None
+        )
         uncond_layout = build_h3_layout(
             task=runtime.layout.task,
             text_length=uncond_hidden.shape[0],

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -1723,6 +1723,53 @@ def test_guidance_loss_uncond_layout_carries_one_frame_fl_condition_roles(tmp_pa
     assert metrics["guidance/applied"] == 1.0
 
 
+def test_guidance_loss_uncond_layout_supports_ref2va_references(tmp_path, monkeypatch):
+    # ref2va reference blocks share the "visual_condition" segment kind; harvesting their
+    # roles into condition_roles made the uncond rebuild fail with "condition roles apply
+    # only to FL2VA layouts" — roles are FL2VA-only, references rebuild from the layout itself
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(
+        task="ref2va",
+        h3_guidance_loss_scale=3.0,
+        h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
+    )
+    trainer.handle_model_specific_args(args)
+    transformer = _RecordingTransformer()
+    batch = _training_batch()
+    batch["latents_ref_000_image"] = torch.zeros(1, 24, 1, 4, 4)
+    video_latents = torch.zeros(1, 24, 2, 4, 4)
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
+
+    _, metrics = trainer.process_batch(
+        args,
+        _Accelerator(),
+        transformer,
+        None,
+        batch,
+        video_latents,
+        torch.zeros_like(video_latents),
+        None,
+        torch.bfloat16,
+        torch.float32,
+        None,
+        0,
+    )
+
+    # the no-grad uncond probe first, then the conditional pass, both on ref2va layouts
+    assert len(transformer.calls) == 2
+    uncond_call, cond_call = transformer.calls
+    for call in (uncond_call, cond_call):
+        assert call["layout"].task == "ref2va"
+        assert tuple(
+            segment.role for segment in call["layout"].segments if segment.kind == "visual_condition"
+        ) == ("ref_000_image",)
+    assert uncond_call["layout"].text_length == 2
+    # the reference conditions are shared with the conditional pass, only the text is swapped
+    assert torch.equal(uncond_call["visual_condition_latents"][0], cond_call["visual_condition_latents"][0])
+    assert metrics["guidance/applied"] == 1.0
+
+
 def test_guidance_loss_audio_scale_can_differ_from_video(tmp_path, monkeypatch):
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(


### PR DESCRIPTION
Training with `--task ref2va` and `--h3_guidance_loss_scale` fails on the first step:

```
File ".../minimax_h3/packing.py", line 325, in build_h3_layout
    raise ValueError("MiniMax-H3 condition roles apply only to FL2VA layouts")
```

`_apply_guidance_loss_targets` harvests `condition_roles` from every `visual_condition` segment of the runtime layout, but Ref2VA reference blocks share that segment kind (`ref_000_image`, `ref_001_video`, ...), so the uncond rebuild passes reference roles into `build_h3_layout`, which rejects roles for non-FL2VA tasks. The roles are only needed for FL2VA (the K=1 one-frame case); ref2va reference segments are regenerated deterministically from the layout's `references` tuple.

Fix: harvest the roles for FL2VA layouts only. The uncond probe forward then works for ref2va with the references preserved and only the text rows swapped — the same "matching how the adapted model runs at inference" semantics the docstring already states for visual/audio conditions.

Verified:
- new regression test (mirroring `test_guidance_loss_uncond_layout_carries_one_frame_fl_condition_roles`) fails on current dev and passes with the fix; `tests/test_minimax_h3_training.py` passes in full (138)
- end-to-end: a ref2va LoRA training (5 video targets + image references) that previously crashed at step 0 with this error runs to completion with the guidance loss active (B200, bf16 ref2va checkpoint)

