### PR TITLE
MiniMax-H3 generation: --output_type, I2VA/L2VA support, safer --output handling

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -380,6 +380,18 @@ python minimax_h3_generate_video.py \
 
 `--seed` is optional: when omitted, each generation draws a fresh random seed and logs it (auto-named outputs embed it in the filename).
 
+`--output` accepts either a file name or a directory: an existing directory, a trailing path separator, or an extension-free path selects auto-naming (`<timestamp>_<seed>` plus the output type's extension) inside that directory, while any other unrecognized extension stays an error (a directory name containing a dot needs the trailing-separator spelling, e.g. `some.dir/`). An existing output is never overwritten — the new file is renamed with a `-1`, `-2`, ... suffix and a warning is logged — so re-running an edited command line without changing `--output` cannot destroy earlier results.
+
+`--output_type {video,latent,both,images,latent_images}` (default `video`) selects what is saved:
+
+- `video` — the muxed video (or the one-frame PNG), as above.
+- `latent` — only the sampled video+audio latents, as a safetensors file (a `.safetensors` output name, or auto-named `<timestamp>_<seed>_latent.safetensors`); VAE decoding is skipped and `--latent_path` turns the file into a video later. `--trajectory_dir` requires decoding and is rejected.
+- `both` — the video plus the latents as `<name>_latent.safetensors` next to it.
+- `images` — the decoded frames as `00000.png`-numbered files plus the decoded audio as `audio.wav`, written into an auto-named `<timestamp>_<seed>/` directory under `--output` (which always names a directory for the image types, so two runs never mix their frames).
+- `latent_images` — `images` plus `latent.safetensors` inside the same directory.
+
+In `--from_file` mode the latent-bearing types simply keep the intermediate latent files (with their `<timestamp>_<index>_<seed>_latent.safetensors` names) instead of removing them, and `--output_type latent` skips the decode phase entirely; `--latent_path` decoding accepts `video` and `images`.
+
 Add a trained LoRA with:
 
 ```text
@@ -396,7 +408,7 @@ For FL2VA, keep the FL2VA base and replace the task inputs:
 --task fl2va --prompt "..." --first_frame first.png --last_frame last.png
 ```
 
-For Ref2VA, use a Ref2VA base (BF16 or ConvRot INT8) and an ordered JSONL record:
+The official prompt guide treats I2VA (first frame only) and L2VA (last frame only) as FL2VA variants, and the released FL2VA base supports both: pass only `--first_frame` to develop forward from the image, or only `--last_frame` to converge onto it. The lone picture is `<Picture 1>` in either case — the released prompt builder numbers the pictures that are present — and the first/last distinction is carried by the rotary anchor times (a lone last frame keeps its end-of-video anchor), so the prompt should use the matching official instruction line: the I2VA "at 0.00 seconds ... fully referenced" form, or the L2VA alignment form anchoring `<Picture 1>` at the final second mark. (BF16 or ConvRot INT8) and an ordered JSONL record:
 
 ```text
 --task ref2va --dit /models/minimax_h3_ref2va_bf16.safetensors --reference_jsonl /data/h3/ref2va.jsonl --reference_index 0
@@ -456,9 +468,9 @@ A singer performs under stage lights. --w 768 --h 1344 --f 124 --d 42 --s 30
 | `--of` | `--one_frame` |
 | `--o` | output filename inside the output directory |
 
-Unspecified options inherit the command-line values, so a fixed `--ref` set with varying prompts works. A line starting with `--` carries only options and keeps the command-line `--prompt` in effect — with a session prompt, `--d 43` alone re-runs it with a new seed. The literal string `\n` in prompt text (line prompts and `--prompt` alike) becomes a newline, so the multi-line official prompt format fits on one line. `--task`, the model artifacts, and the LoRA configuration are fixed for the session, and `--text_cache` and `--trajectory_dir` are not accepted. In both modes `--output` names a directory (created if missing); files are auto-named `<timestamp>_<seed>.png/.mp4` unless a line overrides the name with `--o`, and omitting `--d` draws a fresh random seed per line.
+Unspecified options inherit the command-line values, so a fixed `--ref` set with varying prompts works. A line starting with `--` carries only options and keeps the command-line `--prompt` in effect — with a session prompt, `--d 43` alone re-runs it with a new seed. The literal string `\n` in prompt text (line prompts and `--prompt` alike) becomes a newline, so the multi-line official prompt format fits on one line. `--task`, the model artifacts, and the LoRA configuration are fixed for the session, and `--text_cache` and `--trajectory_dir` are not accepted. In both modes `--output` names a directory (created if missing); files are auto-named `<timestamp>_<seed>` with the output type's extension (a per-generation directory for the image types) unless a line overrides the name with `--o`, and omitting `--d` draws a fresh random seed per line.
 
-**`--from_file prompts.txt`** runs the prompts in four phases, loading each model family exactly once: condition VAE encoding for every line (lines starting with `#` and empty lines are skipped), then all text encodings, then all samplings, then all decodes. Peak VRAM therefore matches single-shot generation — the same `--blocks_to_swap`/`--text_encoder_blocks_to_swap` settings apply unchanged. Each sampled result is written to `<output>/<timestamp>_<index>_<seed>_latent.safetensors` before any decoding, so a crash never loses finished sampling work; the file is removed once its output is written and kept (with a log message) when decoding fails. A failing line is reported and skipped without aborting the rest of the batch.
+**`--from_file prompts.txt`** runs the prompts in four phases, loading each model family exactly once: condition VAE encoding for every line (lines starting with `#` and empty lines are skipped), then all text encodings, then all samplings, then all decodes. Peak VRAM therefore matches single-shot generation — the same `--blocks_to_swap`/`--text_encoder_blocks_to_swap` settings apply unchanged. Each sampled result is written to `<output>/<timestamp>_<index>_<seed>_latent.safetensors` before any decoding, so a crash never loses finished sampling work; the file is removed once its output is written (unless `--output_type` keeps latents) and kept (with a log message) when decoding fails. A failing line is reported and skipped without aborting the rest of the batch.
 
 **`--latent_path FILE...`** decodes those intermediate latent files without loading the transformer or text encoder — only the VAEs (`--audio_vae` may be omitted when every file is a one-frame latent). Outputs go to the `--output` directory.
 

--- a/src/musubi_tuner/minimax_h3/packing.py
+++ b/src/musubi_tuner/minimax_h3/packing.py
@@ -314,8 +314,8 @@ def build_h3_layout(
                 raise ValueError("MiniMax-H3 one-frame FL2VA layout requires one or two visual conditions")
             if time_overrides is None or len(time_overrides.condition_times) != len(visual_conditions):
                 raise ValueError("MiniMax-H3 one-frame FL2VA layout requires one condition time override per condition")
-        elif len(visual_conditions) != 2:
-            raise ValueError("MiniMax-H3 FL2VA layout requires exactly first and last visual conditions")
+        elif not 1 <= len(visual_conditions) <= 2:
+            raise ValueError("MiniMax-H3 FL2VA layout requires one or two visual conditions (first and/or last)")
         roles = _fl_condition_roles(condition_roles, len(visual_conditions))
         for role, condition in zip(roles, visual_conditions):
             if condition != H3VideoGeometry(1, target_video.height, target_video.width):

--- a/src/musubi_tuner/minimax_h3/sampling.py
+++ b/src/musubi_tuner/minimax_h3/sampling.py
@@ -298,6 +298,38 @@ def write_image(frame: torch.Tensor, output_path: str | Path) -> None:
     Image.fromarray(frame.cpu().numpy()).save(output_path)
 
 
+def write_image_sequence(video: torch.Tensor, output_dir: str | Path) -> None:
+    """Write uint8 [F,H,W,3] frames as zero-padded numbered PNGs into a directory."""
+    if video.ndim != 4 or video.shape[-1] != 3 or video.dtype != torch.uint8:
+        raise ValueError(f"MiniMax-H3 image-sequence write needs uint8 [F,H,W,3], got {tuple(video.shape)} {video.dtype}")
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for index, frame in enumerate(video):
+        Image.fromarray(frame.cpu().numpy()).save(output_dir / f"{index:05d}.png")
+
+
+def write_audio_wav(audio: torch.Tensor, output_path: str | Path, *, sample_rate: int) -> None:
+    """Write stereo [-1,1] float [2,L] audio as a 16-bit PCM WAV; the audio track of image-sequence outputs."""
+    if audio.ndim != 2 or audio.shape[0] != 2:
+        raise ValueError(f"MiniMax-H3 WAV write needs stereo [2,L], got {tuple(audio.shape)}")
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    interleaved = (audio.detach().cpu().float().clamp(-1.0, 1.0) * 32767.0).round().to(torch.int16).t().contiguous()
+    with av.open(str(output_path), mode="w") as container:
+        audio_stream = container.add_stream("pcm_s16le", rate=sample_rate)
+        audio_stream.layout = "stereo"
+        for start in range(0, interleaved.shape[0], 1024):
+            chunk = interleaved[start : start + 1024]
+            frame = av.AudioFrame.from_ndarray(chunk.reshape(1, -1).numpy(), format="s16", layout="stereo")
+            frame.sample_rate = sample_rate
+            frame.pts = start
+            frame.time_base = Fraction(1, sample_rate)
+            for packet in audio_stream.encode(frame):
+                container.mux(packet)
+        for packet in audio_stream.encode():
+            container.mux(packet)
+
+
 # Without an explicit rate control, PyAV encodes libx264 at its ~1 Mbps ABR default — far too
 # low for 1 MP/24 fps outputs and enough to masquerade as generation artifacts (mushy lines).
 # CRF keeps quality resolution- and content-independent; 16 is evaluation-grade.

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import copy
 import gc
+import itertools
 import logging
 import random
 from collections import OrderedDict
@@ -51,7 +52,9 @@ from musubi_tuner.minimax_h3.sampling import (
     initialize_target_latents,
     sample_joint_av,
     synchronize_decoded_av,
+    write_audio_wav,
     write_image,
+    write_image_sequence,
     write_joint_av,
     write_video_only,
 )
@@ -104,6 +107,29 @@ def _require_path(value: str | None, label: str) -> Path:
     return path
 
 
+def _output_is_directory(raw_output: str) -> bool:
+    """Directory interpretation of a single-generation --output: an existing directory, a
+    trailing path separator, or an extension-free path selects auto-naming inside that
+    directory; a recognized extension names an explicit file, and any other extension
+    stays an error (typo guard). Directory names containing a dot need the trailing
+    separator spelling (e.g. "some.dir/")."""
+    path = Path(raw_output).expanduser()
+    return raw_output.endswith(("/", "\\")) or path.is_dir() or path.suffix == ""
+
+
+def _explicit_output_name(args: argparse.Namespace, *, directory_output: bool) -> Path | None:
+    """The user-chosen output file name whose extension must be validated, or None when
+    the output is auto-named or is itself a directory (image-sequence outputs)."""
+    if args.output_type in ("images", "latent_images"):
+        return None
+    if directory_output:
+        output_name = getattr(args, "output_name", None)
+        return Path(output_name) if output_name else None
+    if _output_is_directory(args.output):
+        return None
+    return Path(args.output)
+
+
 def validate_session_args(args: argparse.Namespace) -> None:
     """Validate arguments that hold for the whole invocation (model paths, mode selection)."""
     mode_flags = [
@@ -115,6 +141,8 @@ def validate_session_args(args: argparse.Namespace) -> None:
         raise ValueError("MiniMax-H3 --interactive, --from_file, and --latent_path are mutually exclusive")
 
     if getattr(args, "latent_path", None):
+        if args.output_type not in ("video", "images"):
+            raise ValueError("MiniMax-H3 --latent_path decoding supports --output_type video or images only")
         for path in args.latent_path:
             _require_path(path, "latent_path")
         _require_path(getattr(args, "video_vae", None), "video_vae")
@@ -208,16 +236,30 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
         value = float(getattr(args, label))
         if not 0.0 <= value <= 1.0:
             raise ValueError(f"MiniMax-H3 --{label} must be in [0.0,1.0], got {value}")
-    output_name = Path(getattr(args, "output_name", None)) if directory_output and getattr(args, "output_name", None) else None
-    checked_output = output_name if directory_output else Path(args.output)
+    if args.output_type in ("images", "latent_images"):
+        # --output is a directory holding an auto-named per-generation subdirectory; a
+        # media extension signals a video command line reused without adjusting --output
+        if Path(args.output).suffix.lower() in (*VIDEO_OUTPUT_SUFFIXES, ".png", ".safetensors"):
+            raise ValueError(
+                f"MiniMax-H3 --output_type {args.output_type} writes into a directory; --output must not name a media file"
+            )
+    checked_output = _explicit_output_name(args, directory_output=directory_output)
     if checked_output is not None:
-        if one_frame:
+        if args.output_type == "latent":
+            if checked_output.suffix.lower() != ".safetensors":
+                raise ValueError("MiniMax-H3 --output_type latent writes a safetensors file; the output name must use .safetensors")
+        elif one_frame:
             if checked_output.suffix.lower() != ".png":
                 raise ValueError("MiniMax-H3 one-frame generation writes an image; the output name must use .png")
         elif checked_output.suffix.lower() not in VIDEO_OUTPUT_SUFFIXES:
-            raise ValueError("MiniMax-H3 output names must use .mp4, .mkv, or .mov")
+            raise ValueError(
+                "MiniMax-H3 output names must use .mp4, .mkv, or .mov (pass an existing directory,"
+                " a trailing path separator, or an extension-free path for auto-naming)"
+            )
     if args.trajectory_stride < 1:
         raise ValueError(f"MiniMax-H3 --trajectory_stride must be at least 1, got {args.trajectory_stride}")
+    if args.trajectory_dir and args.output_type == "latent":
+        raise ValueError("MiniMax-H3 --trajectory_dir decodes per-step estimates and cannot combine with --output_type latent")
 
     if args.task == "t2va":
         if not args.prompt:
@@ -231,15 +273,14 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
             raise ValueError("MiniMax-H3 FL2VA requires --prompt")
         if args.reference_jsonl or args.ref:
             raise ValueError("MiniMax-H3 FL2VA does not accept --reference_jsonl or --ref")
-        if one_frame:
-            if not args.first_frame and not args.last_frame:
-                raise ValueError("MiniMax-H3 one-frame FL2VA requires --first_frame and/or --last_frame")
-            for label in ("first_frame", "last_frame"):
-                if getattr(args, label):
-                    _require_path(getattr(args, label), label)
-        else:
-            _require_path(args.first_frame, "first_frame")
-            _require_path(args.last_frame, "last_frame")
+        if not args.first_frame and not args.last_frame:
+            raise ValueError(
+                "MiniMax-H3 FL2VA requires --first_frame and/or --last_frame"
+                " (first only = I2VA, last only = L2VA; use --task t2va to condition on neither)"
+            )
+        for label in ("first_frame", "last_frame"):
+            if getattr(args, label):
+                _require_path(getattr(args, label), label)
     else:
         if bool(args.reference_jsonl) == bool(args.ref):
             raise ValueError("MiniMax-H3 Ref2VA requires exactly one of --reference_jsonl or --ref")
@@ -844,8 +885,10 @@ def _decode_and_save(
     gc.collect()
     clean_memory_on_device(device)
 
+    image_sequence = args.output_type in ("images", "latent_images")
     if one_frame:
-        write_image(decoded_video_to_uint8(decoded_video, frame_limit=1)[0], output_path)
+        frame_path = Path(output_path) / "00000.png" if image_sequence else Path(output_path)
+        write_image(decoded_video_to_uint8(decoded_video, frame_limit=1)[0], frame_path)
         logger.info("Saved MiniMax-H3 output: %s", output_path)
         return Path(output_path)
 
@@ -865,7 +908,12 @@ def _decode_and_save(
         frame_count=args.frame_count,
         fps=args.output_fps,
     )
-    write_joint_av(decoded, output_path)
+    if image_sequence:
+        output_path = Path(output_path)
+        write_image_sequence(decoded.video, output_path)
+        write_audio_wav(decoded.audio, output_path / "audio.wav", sample_rate=decoded.sample_rate)
+    else:
+        write_joint_av(decoded, output_path)
     logger.info("Saved MiniMax-H3 output: %s", output_path)
     return Path(output_path)
 
@@ -878,16 +926,52 @@ def _resolve_seed(args: argparse.Namespace) -> int:
     return seed
 
 
+def _auto_output_name(args: argparse.Namespace, seed: int) -> str:
+    base = f"{_time_flag()}_{seed}"
+    if args.output_type == "latent":
+        return f"{base}_latent.safetensors"
+    if args.output_type in ("images", "latent_images"):
+        return base
+    return base + (".png" if args.frame_count == 1 else ".mp4")
+
+
+def _dedupe_output_path(path: Path) -> Path:
+    """No-clobber: an existing file or directory is never overwritten; the new output is
+    renamed with a numeric suffix instead (the reused-command-line safeguard)."""
+    if not path.exists():
+        return path
+    for index in itertools.count(1):
+        candidate = path.with_name(f"{path.stem}-{index}{path.suffix}")
+        if not candidate.exists():
+            logger.warning("MiniMax-H3 output %s already exists; writing %s instead", path, candidate)
+            return candidate
+
+
 def _resolve_output_path(args: argparse.Namespace, seed: int, *, directory_mode: bool) -> Path:
-    if not directory_mode:
-        return Path(args.output)
-    output_dir = Path(args.output).expanduser()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_name = getattr(args, "output_name", None)
-    if output_name:
-        return output_dir / output_name
-    suffix = ".png" if args.frame_count == 1 else ".mp4"
-    return output_dir / f"{_time_flag()}_{seed}{suffix}"
+    """Resolve the primary output target: the media file for video/both, the latent file
+    for latent, or the image-sequence directory for images/latent_images. A single
+    generation writes to --output itself when it names a file and auto-names inside it
+    when it selects a directory (see _output_is_directory); the multi-prompt modes and
+    the image-sequence types always auto-name inside the --output directory."""
+    images = args.output_type in ("images", "latent_images")
+    if directory_mode or images or _output_is_directory(args.output):
+        output_dir = Path(args.output).expanduser()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_name = getattr(args, "output_name", None) if directory_mode else None
+        return _dedupe_output_path(output_dir / (output_name or _auto_output_name(args, seed)))
+    return _dedupe_output_path(Path(args.output).expanduser())
+
+
+def _resolve_latent_path(args: argparse.Namespace, output_path: Path) -> Path | None:
+    """The latent safetensors target for the output types that save one."""
+    if args.output_type == "latent":
+        return output_path
+    if args.output_type == "both":
+        return _dedupe_output_path(output_path.with_name(output_path.stem + "_latent.safetensors"))
+    if args.output_type == "latent_images":
+        # the freshly deduped sequence directory cannot hold a colliding file yet
+        return output_path / "latent.safetensors"
+    return None
 
 
 def _save_latent_file(
@@ -911,7 +995,7 @@ def _save_latent_file(
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     save_file(tensors, str(path), metadata=metadata)
-    logger.info("Saved MiniMax-H3 intermediate latents: %s", path)
+    logger.info("Saved MiniMax-H3 latents: %s", path)
     return path
 
 
@@ -1043,6 +1127,11 @@ def run_generation(
         # the 2-frame audio target is a byproduct of the joint layout, not an output
         audio_latents = None
     output_path = _resolve_output_path(args, seed, directory_mode=directory_output)
+    latent_path = _resolve_latent_path(args, output_path)
+    if latent_path is not None:
+        _save_latent_file(latent_path, video_latents, audio_latents, args, seed)
+    if args.output_type == "latent":
+        return output_path
     return _decode_and_save(
         args,
         video_latents,
@@ -1175,22 +1264,27 @@ def process_from_file(args: argparse.Namespace, device: torch.device) -> None:
             _mark_failed(item, "sampling", error)
     shared.release_transformer()
 
-    logger.info("MiniMax-H3 batch phase 4/4: decoding")
-    for item in items:
-        if item.error:
-            continue
-        try:
-            output_path = _resolve_output_path(item.args, item.seed, directory_mode=True)
-            _decode_and_save(item.args, item.video_latents, item.audio_latents, output_path, device, shared)
-            item.video_latents = None
-            item.audio_latents = None
-            if item.latent_file is not None:
-                item.latent_file.unlink(missing_ok=True)
-                item.latent_file = None
-        except Exception as error:
-            _mark_failed(item, "decoding", error)
-            if item.latent_file is not None:
-                logger.info("MiniMax-H3 intermediate latents kept for --latent_path decoding: %s", item.latent_file)
+    # the latent-bearing output types keep the phase-3 files (their names) as outputs
+    keep_latents = args.output_type in ("latent", "both", "latent_images")
+    if args.output_type == "latent":
+        logger.info("MiniMax-H3 batch phase 4/4: skipped (the sampled latents are the outputs)")
+    else:
+        logger.info("MiniMax-H3 batch phase 4/4: decoding")
+        for item in items:
+            if item.error:
+                continue
+            try:
+                output_path = _resolve_output_path(item.args, item.seed, directory_mode=True)
+                _decode_and_save(item.args, item.video_latents, item.audio_latents, output_path, device, shared)
+                item.video_latents = None
+                item.audio_latents = None
+                if item.latent_file is not None and not keep_latents:
+                    item.latent_file.unlink(missing_ok=True)
+                    item.latent_file = None
+            except Exception as error:
+                _mark_failed(item, "decoding", error)
+                if item.latent_file is not None:
+                    logger.info("MiniMax-H3 intermediate latents kept for --latent_path decoding: %s", item.latent_file)
 
     failed = [item for item in items if item.error]
     logger.info("MiniMax-H3 batch finished: %d/%d prompts succeeded", len(items) - len(failed), len(items))
@@ -1285,8 +1379,11 @@ def process_latent_decode(args: argparse.Namespace, device: torch.device) -> Non
             item_args.frame_count = frame_count
             item_args.output_fps = _parse_output_fps_metadata(source, metadata, args.output_fps)
             seed = metadata.get("seeds", "0")
-            suffix = ".png" if frame_count == 1 else ".mp4"
-            output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}{suffix}"
+            if args.output_type == "images":
+                output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}"
+            else:
+                suffix = ".png" if frame_count == 1 else ".mp4"
+                output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}{suffix}"
             _decode_and_save(item_args, video_latents, audio_latents, output_path, device, shared)
         except Exception as error:
             logger.error("MiniMax-H3 latent decode failed for %s: %s", source, error, exc_info=True)
@@ -1416,8 +1513,19 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output",
         required=True,
-        help="output file for a single generation (.png for one-frame, .mp4/.mkv/.mov otherwise);"
-        " output directory with --interactive, --from_file, and --latent_path (auto-named files)",
+        help="output target. For a single generation: a file path (.png for one-frame, .mp4/.mkv/.mov otherwise,"
+        " .safetensors with --output_type latent), or a directory for auto-named files (an existing directory,"
+        " a trailing path separator, or an extension-free path). Always a directory with --output_type"
+        " images/latent_images, --interactive, --from_file, and --latent_path. An existing output is never"
+        " overwritten; the new file gets a numeric suffix instead",
+    )
+    parser.add_argument(
+        "--output_type",
+        choices=("video", "latent", "both", "images", "latent_images"),
+        default="video",
+        help="what to save: the muxed video (or one-frame PNG; default), the sampled latents as a safetensors"
+        " file decodable later with --latent_path, both (latent saved next to the video), a numbered PNG"
+        " sequence plus audio.wav in an auto-named directory under --output, or that sequence plus the latents",
     )
     parser.add_argument(
         "--from_file",
@@ -1425,7 +1533,7 @@ def setup_parser() -> argparse.ArgumentParser:
         help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--ofps/--skb/--i/--ei/--ref/--of/--o"
         " options) from a file and run them in phases, loading each model family once. Sampled latents are saved"
         " to the --output directory before decoding so a crash loses nothing; the files are removed after their"
-        " output is written. See docs/minimax_h3.md",
+        " output is written unless --output_type keeps latents. See docs/minimax_h3.md",
     )
     parser.add_argument(
         "--interactive",
@@ -1437,8 +1545,8 @@ def setup_parser() -> argparse.ArgumentParser:
         "--latent_path",
         nargs="*",
         default=None,
-        help="decode-only mode: decode intermediate latents safetensors saved by --from_file into the --output"
-        " directory (only the VAEs are loaded)",
+        help="decode-only mode: decode latents safetensors saved by --from_file or --output_type into the"
+        " --output directory (only the VAEs are loaded; supports --output_type video or images)",
     )
     parser.add_argument(
         "--bell",

--- a/tests/test_minimax_h3_generation_modes.py
+++ b/tests/test_minimax_h3_generation_modes.py
@@ -46,6 +46,7 @@ def _session_args(tmp_path, *, task="t2va", **overrides):
         "steps": 2,
         "seed": 1,
         "output": str(tmp_path / "output.mp4"),
+        "output_type": "video",
         "output_name": None,
         "blocks_to_swap": 0,
         "h3_shift_video": 12.0,
@@ -134,10 +135,12 @@ def test_session_validation_enforces_mode_exclusivity_and_multi_prompt_restricti
     validate_session_args(_session_args(tmp_path, interactive=True))
     validate_session_args(_session_args(tmp_path, from_file=str(prompts)))
 
-    # decode-only mode needs just the latents and the video VAE
+    # decode-only mode needs just the latents and the video VAE, and only decoding output types
     validate_session_args(_session_args(tmp_path, latent_path=[str(latents)], task=None, dit=None, text_encoder=None))
     with pytest.raises(ValueError, match="requires --video_vae"):
         validate_session_args(_session_args(tmp_path, latent_path=[str(latents)], video_vae=None))
+    with pytest.raises(ValueError, match="video or images only"):
+        validate_session_args(_session_args(tmp_path, latent_path=[str(latents)], output_type="latent"))
 
     with pytest.raises(ValueError, match="requires --task"):
         validate_session_args(_session_args(tmp_path, task=None))
@@ -159,6 +162,67 @@ def test_prompt_validation_checks_output_name_suffixes_in_directory_modes(tmp_pa
     image_args.output_name = "image.mp4"
     with pytest.raises(ValueError, match="must use .png"):
         validate_prompt_args(image_args, directory_output=True)
+
+
+def test_fl2va_accepts_single_anchor_frames(tmp_path):
+    first = tmp_path / "first.png"
+    first.touch()
+    last = tmp_path / "last.png"
+    last.touch()
+    base = {"task": "fl2va", "output": str(tmp_path / "out.mp4")}
+    validate_prompt_args(_session_args(tmp_path, **base, first_frame=str(first)))
+    validate_prompt_args(_session_args(tmp_path, **base, last_frame=str(last)))
+    validate_prompt_args(_session_args(tmp_path, **base, first_frame=str(first), last_frame=str(last)))
+    with pytest.raises(ValueError, match="first only = I2VA"):
+        validate_prompt_args(_session_args(tmp_path, **base))
+
+
+def test_output_validation_covers_output_types_and_directory_interpretation(tmp_path):
+    # latent-only output names must be .safetensors
+    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.safetensors"), output_type="latent"))
+    with pytest.raises(ValueError, match=r"must use \.safetensors"):
+        validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.mp4"), output_type="latent"))
+
+    # image-sequence outputs are directories, so a media-file --output is rejected
+    with pytest.raises(ValueError, match="must not name a media file"):
+        validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.mp4"), output_type="images"))
+    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "frames"), output_type="images"))
+
+    # an existing directory, a trailing separator, or an extension-free path selects auto-naming
+    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path)))
+    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "newdir") + "/"))
+    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "newdir")))
+    with pytest.raises(ValueError, match=r"must use \.mp4"):
+        validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.mp3")))
+
+    # the per-step trajectory diagnostic requires decoding
+    with pytest.raises(ValueError, match="cannot combine with --output_type latent"):
+        validate_prompt_args(
+            _session_args(tmp_path, output=str(tmp_path / "out.safetensors"), output_type="latent", trajectory_dir=str(tmp_path))
+        )
+
+
+def test_resolve_output_path_auto_names_directories_and_never_overwrites(tmp_path):
+    existing = tmp_path / "clip.mp4"
+    existing.touch()
+    resolved = generate._resolve_output_path(_session_args(tmp_path, output=str(existing)), 7, directory_mode=False)
+    assert resolved == tmp_path / "clip-1.mp4"
+
+    resolved = generate._resolve_output_path(_session_args(tmp_path, output=str(tmp_path / "outdir")), 7, directory_mode=False)
+    assert resolved.parent == tmp_path / "outdir" and resolved.parent.is_dir()
+    assert resolved.name.endswith("_7.mp4")
+
+    latent_args = _session_args(tmp_path, output=str(tmp_path / "outdir"), output_type="latent")
+    resolved = generate._resolve_output_path(latent_args, 7, directory_mode=False)
+    assert resolved.name.endswith("_7_latent.safetensors")
+
+    image_args = _session_args(tmp_path, output=str(tmp_path / "frames"), output_type="images")
+    resolved = generate._resolve_output_path(image_args, 7, directory_mode=False)
+    assert resolved.parent == tmp_path / "frames" and resolved.suffix == ""
+
+    both_args = _session_args(tmp_path, output=str(tmp_path / "clip2.mp4"), output_type="both")
+    output_path = generate._resolve_output_path(both_args, 7, directory_mode=False)
+    assert generate._resolve_latent_path(both_args, output_path) == tmp_path / "clip2_latent.safetensors"
 
 
 def test_one_frame_fl2va_control_index_error_reports_the_counts(tmp_path):
@@ -339,6 +403,75 @@ def test_from_file_batch_keeps_the_latents_of_a_failed_decode(tmp_path, monkeypa
     assert audio_latents is not None
     assert frame_count == 5
     assert metadata["seeds"] == "11"
+
+
+def test_from_file_batch_with_latent_output_type_keeps_latents_and_skips_decoding(tmp_path, monkeypatch):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+
+    args = _batch_args(tmp_path, ["a cat sings --d 11"])
+    args.output_type = "latent"
+    generate.process_from_file(args, torch.device("cpu"))
+
+    # the decode phase is skipped entirely, so no VAE is ever loaded for a T2VA batch
+    assert counters["video_vae"] == 0 and counters["audio_vae"] == 0
+    kept = list((tmp_path / "outputs").glob("*_latent.safetensors"))
+    assert len(kept) == 1
+    _, audio_latents, frame_count, metadata = generate._load_latent_file(kept[0])
+    assert audio_latents is not None and frame_count == 5 and metadata["seeds"] == "11"
+
+
+def test_run_generation_latent_only_saves_a_decodable_file_without_vaes(tmp_path, monkeypatch):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+
+    args = _session_args(
+        tmp_path,
+        frame_count=5,
+        allow_experimental_duration=True,
+        output=str(tmp_path / "out.safetensors"),
+        output_type="latent",
+        device="cpu",
+        attn_mode="torch",
+        split_attn=False,
+        use_pinned_memory_for_block_swap=False,
+        include_patterns=None,
+        exclude_patterns=None,
+        disable_numpy_memmap=False,
+    )
+    result = generate.run_generation(args, torch.device("cpu"))
+
+    assert result == tmp_path / "out.safetensors"
+    _, audio_latents, frame_count, _ = generate._load_latent_file(result)
+    assert audio_latents is not None and frame_count == 5
+    assert counters["video_vae"] == 0 and counters["audio_vae"] == 0
+
+
+def test_run_generation_writes_an_image_sequence_with_audio_and_latents(tmp_path, monkeypatch):
+    counters = {"text": 0, "transformer": 0, "video_vae": 0, "audio_vae": 0}
+    _stub_generation_models(monkeypatch, counters)
+
+    args = _session_args(
+        tmp_path,
+        frame_count=5,
+        allow_experimental_duration=True,
+        output=str(tmp_path / "frames"),
+        output_type="latent_images",
+        device="cpu",
+        attn_mode="torch",
+        split_attn=False,
+        use_pinned_memory_for_block_swap=False,
+        include_patterns=None,
+        exclude_patterns=None,
+        disable_numpy_memmap=False,
+    )
+    result = generate.run_generation(args, torch.device("cpu"))
+
+    assert result.parent == tmp_path / "frames"
+    assert sorted(path.name for path in result.glob("*.png")) == [f"{index:05d}.png" for index in range(5)]
+    assert (result / "audio.wav").stat().st_size > 0
+    _, audio_latents, frame_count, _ = generate._load_latent_file(result / "latent.safetensors")
+    assert audio_latents is not None and frame_count == 5
 
 
 def test_compile_wraps_the_dit_once_with_training_parity_exclusions(tmp_path, monkeypatch):

--- a/tests/test_minimax_h3_packing.py
+++ b/tests/test_minimax_h3_packing.py
@@ -230,6 +230,39 @@ def test_position_grid_matches_full_fl2va_clock_and_does_not_advance_target_curs
     torch.testing.assert_close(actual[0], expected)
 
 
+def test_full_fl2va_layout_accepts_a_single_roled_condition_and_keeps_its_anchor_time():
+    condition = H3VideoGeometry(1, 4, 4)
+    # the lone-last anchor must equal the last-frame time of the two-condition layout
+    last_time = 2.0 + (5.0 / 3.0 + 20.0 / 3.0) - 5.0 / 3.0
+    for role, expected_time in (("first", 2.0), ("last", last_time)):
+        layout = build_h3_layout(
+            task="fl2va",
+            text_length=2,
+            target_video=TARGET_VIDEO,
+            target_audio_frames=8,
+            visual_conditions=(condition,),
+            condition_roles=(role,),
+        )
+        assert [(segment.role, segment.kind) for segment in layout.segments][:2] == [("text", "text"), (role, "visual_condition")]
+        positions = build_position_grid(layout)
+        segment = layout.segment(role)
+        torch.testing.assert_close(
+            positions[0, segment.start : segment.stop, 0],
+            torch.full((segment.row_count,), expected_time, dtype=torch.float64),
+        )
+
+    with pytest.raises(ValueError, match="requires explicit condition roles"):
+        build_h3_layout(
+            task="fl2va",
+            text_length=2,
+            target_video=TARGET_VIDEO,
+            target_audio_frames=8,
+            visual_conditions=(condition,),
+        )
+    with pytest.raises(ValueError, match="one or two visual conditions"):
+        build_h3_layout(task="fl2va", text_length=2, target_video=TARGET_VIDEO, target_audio_frames=8)
+
+
 def test_position_grid_uses_the_full_five_frame_temporal_cycle():
     target = H3VideoGeometry(7, 2, 2)
     layout = build_h3_layout(

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -313,6 +313,7 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         "steps": 2,
         "seed": 1,
         "output": str(tmp_path / "output.mp4"),
+        "output_type": "video",
         "blocks_to_swap": 0,
         "h3_shift_video": 12.0,
         "h3_shift_audio": 3.0,


### PR DESCRIPTION
## Summary

Three generation-script improvements for MiniMax-H3 (`minimax_h3_generate_video.py`):

### `--output_type {video,latent,both,images,latent_images}`

Matches the option of the other architectures, adapted to H3's audio-joint outputs:

- `latent` saves the sampled video+audio latents as a safetensors file **before decoding** (decodable later with `--latent_path`); VAE decoding is skipped entirely.
- `both` writes the video plus `<name>_latent.safetensors` next to it.
- `images` writes the decoded frames as numbered PNGs **plus the decoded audio as `audio.wav`** into an auto-named per-generation directory under `--output`, so the audio track is never silently lost and two runs never mix their frames.
- `latent_images` additionally stores `latent.safetensors` inside that directory.
- `--from_file` keeps its intermediate latent files as outputs for the latent-bearing types and skips the decode phase for latent-only; `--latent_path` decoding accepts `video` and `images`.

### I2VA / L2VA (FL2VA with a single anchor frame)

The released FL2VA base accepts 0/1/2 condition pictures (per the official prompt guide), but the script required both `--first_frame` and `--last_frame`. Only the argument validation and the layout count check were blocking — the condition roles, `<Picture i>` numbering, and rotary anchor times (a lone last frame keeps its end-of-video anchor) were already generalized — so this is a two-line relaxation plus a friendlier error message pointing at the I2VA/L2VA forms.

### Safer `--output` handling

Guards against the reused-command-line accident where an unchanged `--output` overwrote an earlier result:

- A `--output` naming an existing directory, ending with a path separator, or carrying no extension is interpreted as a directory with auto-named files (`<timestamp>_<seed>` plus the type's extension) — the `--save_path` workflow, without breaking any currently valid command line (typo extensions still error, with a hint).
- An existing output is never overwritten: the new file is renamed with a `-1`, `-2`, ... numeric suffix and a warning is logged.

## Testing

- All 445 MiniMax-H3 tests pass (new coverage: single-anchor FL2VA validation and layout anchor times, per-type output-name validation, directory interpretation and no-clobber renaming, latent-only batch/single runs asserting no VAE load, a real image-sequence + `audio.wav` + latent round trip).
- `write_audio_wav` verified by a PyAV read-back round trip (pcm_s16le, error at the 16-bit quantization floor).
- Manually verified on hardware: `--output_type latent_images` (frames + `audio.wav`) and I2VA generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjrzJ8JDMFgFWrr9uzJDBm