### PR TITLE
Fix fp8_scaled dtype mismatch on non-scaled_mm path

### DIFF
--- a/src/musubi_tuner/modules/fp8_optimization_utils.py
+++ b/src/musubi_tuner/modules/fp8_optimization_utils.py
@@ -427,6 +427,7 @@ def fp8_linear_forward_patch(self: nn.Linear, x, use_scaled_mm=False, max_value=
             dequantized_weight = dequantized_weight.view(self.weight.shape)
 
         # Perform linear transformation
+        dequantized_weight = dequantized_weight.to(x.dtype)
         if self.bias is not None:
             output = F.linear(x, dequantized_weight, self.bias)
         else:


### PR DESCRIPTION
## Problem

`--fp8_scaled` image generation crashes on the non-`_scaled_mm` path with:

```
RuntimeError: self and mat2 must have the same dtype, but got BFloat16 and Float
```

This path is used on every backend where `torch._scaled_mm` is unavailable (ROCm, and any non-CUDA / older-SM device), so generation fails there even though fp8-storage training works fine.

## Root cause

In `fp8_linear_forward_patch`, the dequantization branch derives the dtype from the scale:

```python
original_dtype = self.scale_weight.dtype                              # fp32
dequantized_weight = self.weight.to(original_dtype) * self.scale_weight   # fp32
...
output = F.linear(x, dequantized_weight, self.bias)   # x is bf16 -> dtype mismatch
```

`scale_weight` is fp32, so `dequantized_weight` stays fp32 while activations stay bf16/fp16. The `_scaled_mm` branch is unaffected because it passes `out_dtype` explicitly.

## Fix

Cast the dequantized weight back to the activation dtype before the linear op (one line):

```python
dequantized_weight = dequantized_weight.to(x.dtype)
```

## Verification

Reproduced and verified the dtype behaviour on Ascend NPU (torch 2.14.0a0, aarch64), which — like ROCm — does not use `_scaled_mm`:

- **Before**: `F.linear(bf16_x, fp32_dequantized_weight)` raises `expected m1 and m2 to have the same dtype` (no bias) / `self and mat2 must have the same dtype` (with bias).
- **After**: output has shape `(3, 64)` in `bf16`, and the cast result is bit-identical to computing with the original bf16 weights directly (max |Δ| = 0.0).

Fixes #1076