### PR TITLE
fix(hv_1_5): i2v latent caching fails on image datasets

### DIFF
--- a/src/musubi_tuner/hv_1_5_cache_latents.py
+++ b/src/musubi_tuner/hv_1_5_cache_latents.py
@@ -76,7 +76,12 @@ def encode_and_save_batch(
                 cond_latents_list.append(cond_latents[0])  # remove batch dim
 
             # extract vision feature from first frame
-            first_frame_np = batch[i].content[0]  # H, W, C, uint8
+            # An image dataset sets content to a bare (H, W, C) frame, so an
+            # unconditional [0] slices a single row and fails the ndim check in
+            # hf_clip_vision_encode. Only video (F, H, W, C) and multiple_target
+            # (list) need indexing. Same guard as ideogram4_cache_latents.py.
+            content = batch[i].content
+            first_frame_np = content[0] if isinstance(content, list) or content.ndim == 4 else content  # H, W, C, uint8
             feature_extractor, image_encoder = image_encoder_assets
             with torch.no_grad():
                 vision_feature = hf_clip_vision_encode(first_frame_np, feature_extractor, image_encoder)


### PR DESCRIPTION
## Problem

HunyuanVideo 1.5 i2v latent caching crashes on **image datasets**, with `--i2v` and `--image_encoder` both correctly supplied:

```
File "musubi_tuner/hv_1_5_cache_latents.py", line 79, in encode_and_save_batch
    vision_feature = hf_clip_vision_encode(first_frame_np, feature_extractor, image_encoder)
File "musubi_tuner/frame_pack/clip_vision.py", line 6, in hf_clip_vision_encode
    assert image.ndim == 3 and image.shape[2] == 3
AssertionError
```

This is distinct from #753, where the flags were missing — here they are present and the run still dies on the first item.

## Cause

`encode_and_save_batch` takes the conditioning frame with an unconditional index:

```python
first_frame_np = batch[i].content[0]  # H, W, C, uint8
```

That is correct for video, where `content` is `(F, H, W, C)`. But an image dataset stores a bare `(H, W, C)` frame:

```python
# dataset/image_video_dataset.py:387
content=image if len(images) == 1 else images
```

so `content[0]` slices a single **row**, producing `(W, C)` with `ndim == 2`. The assertion fails on its first clause and `shape[2]` is never evaluated.

It affects **every** image in the set — not RGBA, not grayscale, not anything unusual. The `0it [00:00, ?it/s]` before the traceback is the tell: nothing was cached at all.

## Why the fix looks like this

The same function already guards this exact case for the VAE path, 54 lines earlier:

```python
contents = torch.stack([torch.from_numpy(item.content) for item in batch])
if len(contents.shape) == 4:
    contents = contents.unsqueeze(1)  # B, H, W, C -> B, F, H, W, C
```

so the file already knows image items carry 3-dim content — only the CLIP vision path forgot. The `isinstance` form matches the idiom already used in `ideogram4_cache_latents.py:21`:

```python
content = item.content[0] if isinstance(item.content, list) else item.content
```

extended with the `ndim == 4` case so genuine video still indexes correctly. The `multiple_target` list case is covered by the `isinstance` check, which short-circuits before `.ndim` is touched.

## Verification

Replayed the real load path against a 23-image dataset — `BucketSelector`, `resize_image_to_bucket`, and the `datasources.py` mode logic — then evaluated the expression that reaches `hf_clip_vision_encode`:

| | items satisfying `ndim == 3 and shape[2] == 3` |
|---|---|
| before | **0 / 23** |
| after | **23 / 23** |

Examples of the failure: `001.jpg` content `(672, 384, 3)` → `content[0]` `(384, 3)`; `018.jpg` `(512, 512, 3)` → `(512, 3)`.

After the change, an i2v LoRA trains through to completion on a stills dataset.

## Note

Video datasets are unaffected — `image_video_dataset.py:789` sets `content=cropped_video`, which is 4-dim and still takes the `[0]` branch.
