### PR TITLE
Add caption dropout support for CFG training

### DIFF
--- a/docs/dataset_config.md
+++ b/docs/dataset_config.md
@@ -722,3 +722,27 @@ resolution = [960, 544] # required if general resolution is not set
 -->
 
 The metadata with .json file will be supported in the near future.
+
+## Caption Dropout
+
+`caption_dropout_rate` is an optional float (default `0.0`), settable in `[general]` or per-`[[datasets]]`, following the same fallback rule as `caption_extension`/`batch_size`/etc. At training time, for each item read, with probability `caption_dropout_rate` the real caption's cached text-encoder embedding is swapped for a pre-cached **empty-caption** embedding instead. This is the standard trick used to make classifier-free guidance work well and to reduce caption overfitting during LoRA training.
+
+```toml
+[general]
+caption_dropout_rate = 0.1  # 10% of reads use the empty-caption embedding instead of the real one
+```
+
+Because training reads pre-cached text-encoder outputs rather than encoding captions live, the empty-caption embedding must also be pre-cached. Simply re-run the architecture's `*_cache_text_encoder_outputs.py` script (e.g. `wan_cache_text_encoder_outputs.py`) after setting `caption_dropout_rate` in the dataset config — it will generate one additional cache file per dataset cache directory (shared across all items in that dataset, since the empty string always encodes to the same embedding) alongside the per-item cache files it already creates. If training is started with `caption_dropout_rate > 0` and this file is missing, it fails fast with a clear error telling you to re-run the cache script.
+
+`caption_dropout_rate` is **not supported** for text-encoder caching modes that condition the text embedding on image content — currently Qwen-Image's `--is_edit` mode and HiDream-O1's control-image mode. The empty-caption embedding would depend on the image too in those modes, so a single dataset-wide cache entry isn't valid; the cache script raises a clear error if you set `caption_dropout_rate > 0` on a dataset used with either of those.
+
+<details>
+<summary>日本語</summary>
+
+`caption_dropout_rate` はオプションのfloat値（デフォルトは`0.0`）で、`caption_extension`や`batch_size`などと同様に`[general]`または各`[[datasets]]`に設定できます。学習時、読み込みごとに`caption_dropout_rate`の確率で、実際のキャプションのキャッシュされたテキストエンコーダ埋め込みの代わりに、事前にキャッシュされた**空キャプション**の埋め込みが使用されます。これは、Classifier-Free Guidanceの効果を高め、LoRA学習時のキャプションへの過学習を減らすための一般的な手法です。
+
+学習時には事前にキャッシュされたテキストエンコーダの出力を読み込むだけで、キャプションをその場でエンコードしないため、空キャプションの埋め込みも事前にキャッシュしておく必要があります。データセット設定で`caption_dropout_rate`を設定した後、該当アーキテクチャの`*_cache_text_encoder_outputs.py`スクリプト（例：`wan_cache_text_encoder_outputs.py`）を再実行してください。これにより、既存の項目ごとのキャッシュファイルに加えて、データセットのキャッシュディレクトリごとに1つの追加キャッシュファイルが生成されます（空文字列は常に同じ埋め込みにエンコードされるため、そのデータセット内の全項目で共有されます）。このファイルが存在しない状態で`caption_dropout_rate > 0`のまま学習を開始すると、キャッシュスクリプトの再実行を促す明確なエラーで即座に失敗します。
+
+`caption_dropout_rate`は、テキスト埋め込みが画像コンテンツに依存するテキストエンコーダキャッシュモード（現時点ではQwen-Imageの`--is_edit`モードとHiDream-O1のcontrol画像モード）では**サポートされていません**。これらのモードでは空キャプションの埋め込みも画像に依存するため、データセット全体で共有される単一のキャッシュエントリは正しくありません。これらのいずれかを使用するデータセットで`caption_dropout_rate > 0`を設定すると、キャッシュスクリプトが明確なエラーを発生させます。
+
+</details>

--- a/src/musubi_tuner/cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/cache_text_encoder_outputs.py
@@ -85,19 +85,25 @@ def process_text_encoder_batches(
     """
 
     num_workers = num_workers if num_workers is not None else max(1, os.cpu_count() - 1)
-    for i, dataset in enumerate(datasets):
-        logger.info(f"Encoding dataset [{i}]")
-        all_cache_files = all_cache_files_for_dataset[i]
-        all_cache_paths = all_cache_paths_for_dataset[i]
+
+    # Fail fast: validate all datasets before any encoding happens, so an invalid dataset later in the list
+    # doesn't let earlier datasets get fully (and expensively) encoded before the error is raised.
+    if requires_content:
+        for dataset_index, dataset in enumerate(datasets):
+            if getattr(dataset, "caption_dropout_rate", 0.0) > 0:
+                raise ValueError(
+                    "caption_dropout_rate is not supported for datasets whose text-encoder caching requires image "
+                    "content (e.g. Qwen-Image --is_edit, HiDream-O1 control mode): the empty-caption embedding would "
+                    "need to depend on the image, so it can't be cached once per dataset. Disable caption_dropout_rate "
+                    "for this dataset."
+                )
+
+    for dataset_index, dataset in enumerate(datasets):
+        logger.info(f"Encoding dataset [{dataset_index}]")
+        all_cache_files = all_cache_files_for_dataset[dataset_index]
+        all_cache_paths = all_cache_paths_for_dataset[dataset_index]
 
         caption_dropout_rate = getattr(dataset, "caption_dropout_rate", 0.0)
-        if caption_dropout_rate > 0 and requires_content:
-            raise ValueError(
-                "caption_dropout_rate is not supported for datasets whose text-encoder caching requires image "
-                "content (e.g. Qwen-Image --is_edit, HiDream-O1 control mode): the empty-caption embedding would "
-                "need to depend on the image, so it can't be cached once per dataset. Disable caption_dropout_rate "
-                "for this dataset."
-            )
 
         if not requires_content:
             batches = dataset.retrieve_text_encoder_output_cache_batches(num_workers)  # return captions only
@@ -129,7 +135,9 @@ def process_text_encoder_batches(
             empty_cache_path = os.path.normpath(empty_item.text_encoder_output_cache_path)
             all_cache_paths.add(empty_cache_path)
             if not (skip_existing and empty_cache_path in all_cache_files):
-                logger.info(f"Encoding empty caption for dataset [{i}] (caption_dropout_rate={caption_dropout_rate})")
+                logger.info(
+                    f"Encoding empty caption for dataset [{dataset_index}] (caption_dropout_rate={caption_dropout_rate})"
+                )
                 encode([empty_item])
 
 

--- a/src/musubi_tuner/cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/cache_text_encoder_outputs.py
@@ -90,6 +90,15 @@ def process_text_encoder_batches(
         all_cache_files = all_cache_files_for_dataset[i]
         all_cache_paths = all_cache_paths_for_dataset[i]
 
+        caption_dropout_rate = getattr(dataset, "caption_dropout_rate", 0.0)
+        if caption_dropout_rate > 0 and requires_content:
+            raise ValueError(
+                "caption_dropout_rate is not supported for datasets whose text-encoder caching requires image "
+                "content (e.g. Qwen-Image --is_edit, HiDream-O1 control mode): the empty-caption embedding would "
+                "need to depend on the image, so it can't be cached once per dataset. Disable caption_dropout_rate "
+                "for this dataset."
+            )
+
         if not requires_content:
             batches = dataset.retrieve_text_encoder_output_cache_batches(num_workers)  # return captions only
         else:
@@ -114,6 +123,14 @@ def process_text_encoder_batches(
             bs = batch_size if batch_size is not None else len(batch)
             for i in range(0, len(batch), bs):
                 encode(batch[i : i + bs])
+
+        if caption_dropout_rate > 0:
+            empty_item = dataset.get_empty_caption_item_info()
+            empty_cache_path = os.path.normpath(empty_item.text_encoder_output_cache_path)
+            all_cache_paths.add(empty_cache_path)
+            if not (skip_existing and empty_cache_path in all_cache_files):
+                logger.info(f"Encoding empty caption for dataset [{i}] (caption_dropout_rate={caption_dropout_rate})")
+                encode([empty_item])
 
 
 def post_process_cache_files(

--- a/src/musubi_tuner/cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/cache_text_encoder_outputs.py
@@ -135,9 +135,7 @@ def process_text_encoder_batches(
             empty_cache_path = os.path.normpath(empty_item.text_encoder_output_cache_path)
             all_cache_paths.add(empty_cache_path)
             if not (skip_existing and empty_cache_path in all_cache_files):
-                logger.info(
-                    f"Encoding empty caption for dataset [{dataset_index}] (caption_dropout_rate={caption_dropout_rate})"
-                )
+                logger.info(f"Encoding empty caption for dataset [{dataset_index}] (caption_dropout_rate={caption_dropout_rate})")
                 encode([empty_item])
 
 

--- a/src/musubi_tuner/dataset/bucket.py
+++ b/src/musubi_tuner/dataset/bucket.py
@@ -246,7 +246,10 @@ class BucketBatchManager:
         varlen_keys = set()
         for item_info in bucket[start:end]:
             sd_latent = load_file(item_info.latent_cache_path)
-            sd_te = load_file(item_info.text_encoder_output_cache_path)
+            te_cache_path = item_info.text_encoder_output_cache_path
+            if item_info.caption_dropout_rate > 0 and random.random() < item_info.caption_dropout_rate:
+                te_cache_path = item_info.empty_text_encoder_output_cache_path
+            sd_te = load_file(te_cache_path)
             sd = {**sd_latent, **sd_te}
 
             # TODO refactor this

--- a/src/musubi_tuner/dataset/config_utils.py
+++ b/src/musubi_tuner/dataset/config_utils.py
@@ -40,6 +40,7 @@ class BaseDatasetParams:
     cache_directory: Optional[str] = None
     debug_dataset: bool = False
     architecture: str = "no_default"  # short style like "hv" or "wan"
+    caption_dropout_rate: float = 0.0
 
 
 @dataclass
@@ -116,6 +117,7 @@ class ConfigSanitizer:
         "resolution": functools.partial(__validate_and_convert_scalar_or_twodim.__func__, int),
         "enable_bucket": bool,
         "bucket_no_upscale": bool,
+        "caption_dropout_rate": float,
     }
     IMAGE_DATASET_DISTINCT_SCHEMA = {
         "image_directory": str,

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -23,6 +23,8 @@ import logging
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+EMPTY_CAPTION_CACHE_KEY = "___empty_caption_dropout___"
+
 from musubi_tuner.dataset.architectures import *  # noqa: F401,F403
 from musubi_tuner.dataset.architectures import (  # explicit imports for local use
     ARCHITECTURE_FLUX_2_DEV,
@@ -60,6 +62,8 @@ class ItemInfo:
         self.content = content
         self.latent_cache_path = latent_cache_path
         self.text_encoder_output_cache_path: Optional[str] = None
+        self.caption_dropout_rate: float = 0.0
+        self.empty_text_encoder_output_cache_path: Optional[str] = None
 
         # np.ndarray for video, list[np.ndarray] for image with multiple controls
         self.control_content: Optional[Union[np.ndarray, list[np.ndarray]]] = None
@@ -115,6 +119,7 @@ class BaseDataset(torch.utils.data.Dataset):
         cache_directory: Optional[str] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        caption_dropout_rate: float = 0.0,
     ):
         self.resolution = resolution
         self.caption_extension = caption_extension
@@ -125,6 +130,7 @@ class BaseDataset(torch.utils.data.Dataset):
         self.cache_directory = cache_directory
         self.debug_dataset = debug_dataset
         self.architecture = architecture
+        self.caption_dropout_rate = caption_dropout_rate
         self.seed = None
         self.current_epoch = 0
         self.shared_epoch = None
@@ -169,6 +175,15 @@ class BaseDataset(torch.utils.data.Dataset):
         basename = os.path.splitext(os.path.basename(item_info.item_key))[0]
         assert self.cache_directory is not None, "cache_directory is required / cache_directoryは必須です"
         return os.path.join(self.cache_directory, f"{basename}_{self.architecture}_te.safetensors")
+
+    def get_empty_text_encoder_output_cache_path(self) -> str:
+        assert self.cache_directory is not None, "cache_directory is required / cache_directoryは必須です"
+        return os.path.join(self.cache_directory, f"{EMPTY_CAPTION_CACHE_KEY}_{self.architecture}_te.safetensors")
+
+    def get_empty_caption_item_info(self) -> ItemInfo:
+        item_info = ItemInfo(EMPTY_CAPTION_CACHE_KEY, "", (0, 0), (0, 0))
+        item_info.text_encoder_output_cache_path = self.get_empty_text_encoder_output_cache_path()
+        return item_info
 
     def retrieve_latent_cache_batches(self, num_workers: int):
         raise NotImplementedError
@@ -287,6 +302,7 @@ class ImageDataset(BaseDataset):
         control_resolution: Optional[Tuple[int, int]] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        caption_dropout_rate: float = 0.0,
     ):
         super(ImageDataset, self).__init__(
             resolution,
@@ -298,6 +314,7 @@ class ImageDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            caption_dropout_rate,
         )
         self.image_directory = image_directory
         self.image_jsonl_file = image_jsonl_file
@@ -603,6 +620,7 @@ class VideoDataset(BaseDataset):
         fp_latent_window_size: Optional[int] = 9,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        caption_dropout_rate: float = 0.0,
     ):
         super(VideoDataset, self).__init__(
             resolution,
@@ -614,6 +632,7 @@ class VideoDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            caption_dropout_rate,
         )
         self.video_directory = video_directory
         self.video_jsonl_file = video_jsonl_file

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -707,6 +707,14 @@ class VideoDataset(BaseDataset):
 
         self.batch_manager = None
         self.num_train_items = 0
+
+    def get_empty_caption_item_info(self) -> ItemInfo:
+        # Override base implementation to mark this as a video item (frame_count > 1), so that
+        # architecture-specific consumers (e.g. Kandinsky5's content-type template selection) treat
+        # the empty-caption embedding as belonging to a video dataset, not an image dataset.
+        item_info = super().get_empty_caption_item_info()
+        item_info.frame_count = 2
+        return item_info
         self.has_control = self.datasource.has_control
 
     def get_metadata(self):

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -23,7 +23,7 @@ import logging
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-EMPTY_CAPTION_CACHE_KEY = "___empty_caption_dropout___"
+EMPTY_CAPTION_CACHE_KEY = "___empty_caption___"
 
 from musubi_tuner.dataset.architectures import *  # noqa: F401,F403
 from musubi_tuner.dataset.architectures import (  # explicit imports for local use

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -707,6 +707,7 @@ class VideoDataset(BaseDataset):
 
         self.batch_manager = None
         self.num_train_items = 0
+        self.has_control = self.datasource.has_control
 
     def get_empty_caption_item_info(self) -> ItemInfo:
         # Override base implementation to mark this as a video item (frame_count > 1), so that
@@ -715,7 +716,6 @@ class VideoDataset(BaseDataset):
         item_info = super().get_empty_caption_item_info()
         item_info.frame_count = 2
         return item_info
-        self.has_control = self.datasource.has_control
 
     def get_metadata(self):
         metadata = super().get_metadata()

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -521,6 +521,16 @@ class ImageDataset(BaseDataset):
     def prepare_for_training(self, num_timestep_buckets: Optional[int] = None):
         bucket_selector = BucketSelector(self.resolution, self.enable_bucket, self.bucket_no_upscale, self.architecture)
 
+        empty_te_cache_path = None
+        if self.caption_dropout_rate > 0:
+            empty_te_cache_path = self.get_empty_text_encoder_output_cache_path()
+            if not os.path.exists(empty_te_cache_path):
+                raise FileNotFoundError(
+                    f"caption_dropout_rate is set to {self.caption_dropout_rate} but the empty-caption cache file "
+                    f"was not found: {empty_te_cache_path}. Re-run the *_cache_text_encoder_outputs.py script for "
+                    f"this dataset with caption_dropout_rate set in the dataset config to generate it."
+                )
+
         # glob cache files
         latent_cache_files = glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
 
@@ -565,6 +575,9 @@ class ImageDataset(BaseDataset):
 
             item_info = ItemInfo(item_key, "", image_size, bucket_reso, latent_cache_path=cache_file)
             item_info.text_encoder_output_cache_path = text_encoder_output_cache_file
+            if empty_te_cache_path is not None:
+                item_info.caption_dropout_rate = self.caption_dropout_rate
+                item_info.empty_text_encoder_output_cache_path = empty_te_cache_path
 
             bucket = bucketed_item_info.get(bucket_reso, [])
             for _ in range(self.num_repeats):
@@ -876,6 +889,16 @@ class VideoDataset(BaseDataset):
     def prepare_for_training(self, num_timestep_buckets: Optional[int] = None):
         bucket_selector = BucketSelector(self.resolution, self.enable_bucket, self.bucket_no_upscale, self.architecture)
 
+        empty_te_cache_path = None
+        if self.caption_dropout_rate > 0:
+            empty_te_cache_path = self.get_empty_text_encoder_output_cache_path()
+            if not os.path.exists(empty_te_cache_path):
+                raise FileNotFoundError(
+                    f"caption_dropout_rate is set to {self.caption_dropout_rate} but the empty-caption cache file "
+                    f"was not found: {empty_te_cache_path}. Re-run the *_cache_text_encoder_outputs.py script for "
+                    f"this dataset with caption_dropout_rate set in the dataset config to generate it."
+                )
+
         # glob cache files
         latent_cache_files = glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
 
@@ -901,6 +924,9 @@ class VideoDataset(BaseDataset):
             bucket_reso = (*bucket_reso, frame_count)
             item_info = ItemInfo(item_key, "", image_size, bucket_reso, frame_count=frame_count, latent_cache_path=cache_file)
             item_info.text_encoder_output_cache_path = text_encoder_output_cache_file
+            if empty_te_cache_path is not None:
+                item_info.caption_dropout_rate = self.caption_dropout_rate
+                item_info.empty_text_encoder_output_cache_path = empty_te_cache_path
 
             bucket = bucketed_item_info.get(bucket_reso, [])
             for _ in range(self.num_repeats):

--- a/src/musubi_tuner/ideogram4_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/ideogram4_cache_text_encoder_outputs.py
@@ -7,7 +7,12 @@ import torch
 import musubi_tuner.cache_text_encoder_outputs as cache_text_encoder_outputs
 from musubi_tuner.dataset import config_utils
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
-from musubi_tuner.dataset.image_video_dataset import ARCHITECTURE_IDEOGRAM4, ItemInfo, save_text_encoder_output_cache_ideogram4
+from musubi_tuner.dataset.image_video_dataset import (
+    ARCHITECTURE_IDEOGRAM4,
+    EMPTY_CAPTION_CACHE_KEY,
+    ItemInfo,
+    save_text_encoder_output_cache_ideogram4,
+)
 from musubi_tuner.ideogram4 import ideogram4_utils
 
 logger = logging.getLogger(__name__)
@@ -35,7 +40,9 @@ def encode_and_save_batch(
 ):
     cache_dtype = _resolve_cache_dtype(cache_dtype_name)
     for item in batch:
-        if validate_caption_structure:
+        if validate_caption_structure and item.item_key != EMPTY_CAPTION_CACHE_KEY:
+            # The synthetic empty-caption item (used for caption_dropout_rate) has caption="" by design,
+            # which is not valid structured JSON; skip structural validation for it.
             ideogram4_utils.validate_prompt(item.caption, warn_only=warn_only)
         with torch.no_grad():
             features = ideogram4_utils.encode_prompt_to_features(tokenizer, text_encoder, item.caption, device)

--- a/tests/test_caption_dropout.py
+++ b/tests/test_caption_dropout.py
@@ -96,3 +96,48 @@ def test_prepare_for_training_leaves_dropout_fields_default_when_rate_zero(tmp_p
     bucket = next(iter(dataset.batch_manager.buckets.values()))
     assert bucket[0].caption_dropout_rate == 0.0
     assert bucket[0].empty_text_encoder_output_cache_path is None
+
+
+from unittest.mock import patch
+
+from musubi_tuner.dataset.bucket import BucketBatchManager
+
+
+def _item_with_dropout(tmp_path, rate, real_value, empty_value):
+    real_path = tmp_path / "real_wan_te.safetensors"
+    empty_path = tmp_path / "empty_wan_te.safetensors"
+    save_file({"varlen_t5_float32": torch.full((1, 4), real_value)}, str(real_path))
+    save_file({"varlen_t5_float32": torch.full((1, 4), empty_value)}, str(empty_path))
+
+    latent_path = tmp_path / "real_0064x0064_wan.safetensors"
+    save_file({"latents_1x8x8_fp32": torch.zeros(16, 1, 8, 8)}, str(latent_path))
+
+    item = ItemInfo("real", "a caption", (64, 64), (64, 64), latent_cache_path=str(latent_path))
+    item.text_encoder_output_cache_path = str(real_path)
+    item.caption_dropout_rate = rate
+    item.empty_text_encoder_output_cache_path = str(empty_path)
+    return item
+
+
+def test_bucket_batch_manager_uses_empty_cache_when_dropout_fires(tmp_path):
+    item = _item_with_dropout(tmp_path, rate=0.5, real_value=1.0, empty_value=0.0)
+    manager = BucketBatchManager({(64, 64): [item]}, batch_size=1)
+    with patch("musubi_tuner.dataset.bucket.random.random", return_value=0.1):  # < 0.5 -> dropout fires
+        batch = manager[0]
+    assert torch.all(batch["t5"][0] == 0.0)
+
+
+def test_bucket_batch_manager_uses_real_cache_when_dropout_does_not_fire(tmp_path):
+    item = _item_with_dropout(tmp_path, rate=0.5, real_value=1.0, empty_value=0.0)
+    manager = BucketBatchManager({(64, 64): [item]}, batch_size=1)
+    with patch("musubi_tuner.dataset.bucket.random.random", return_value=0.9):  # >= 0.5 -> no dropout
+        batch = manager[0]
+    assert torch.all(batch["t5"][0] == 1.0)
+
+
+def test_bucket_batch_manager_no_dropout_when_rate_zero(tmp_path):
+    item = _item_with_dropout(tmp_path, rate=0.0, real_value=1.0, empty_value=0.0)
+    manager = BucketBatchManager({(64, 64): [item]}, batch_size=1)
+    with patch("musubi_tuner.dataset.bucket.random.random", return_value=0.0):  # would fire if rate were > 0
+        batch = manager[0]
+    assert torch.all(batch["t5"][0] == 1.0)

--- a/tests/test_caption_dropout.py
+++ b/tests/test_caption_dropout.py
@@ -18,7 +18,7 @@ def test_base_dataset_params_accepts_caption_dropout_rate():
     assert params.caption_dropout_rate == 0.1
 
 
-from musubi_tuner.dataset.image_video_dataset import EMPTY_CAPTION_CACHE_KEY, ImageDataset, ItemInfo
+from musubi_tuner.dataset.image_video_dataset import EMPTY_CAPTION_CACHE_KEY, ImageDataset, ItemInfo, VideoDataset
 
 
 def _make_image_dataset(tmp_path, caption_dropout_rate=0.0):
@@ -33,6 +33,23 @@ def _make_image_dataset(tmp_path, caption_dropout_rate=0.0):
         debug_dataset=False,
         architecture="wan",
         image_directory=str(tmp_path),
+        caption_dropout_rate=caption_dropout_rate,
+    )
+
+
+def _make_video_dataset(tmp_path, caption_dropout_rate=0.0):
+    return VideoDataset(
+        resolution=(64, 64),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=False,
+        bucket_no_upscale=False,
+        target_frames=[1],
+        video_directory=str(tmp_path),
+        cache_directory=str(tmp_path),
+        debug_dataset=False,
+        architecture="wan",
         caption_dropout_rate=caption_dropout_rate,
     )
 
@@ -60,6 +77,20 @@ def test_get_empty_caption_item_info(tmp_path):
     assert item.item_key == EMPTY_CAPTION_CACHE_KEY
     assert item.caption == ""
     assert item.text_encoder_output_cache_path == dataset.get_empty_text_encoder_output_cache_path()
+    # ImageDataset should not mark the empty-caption item as video content.
+    assert item.frame_count is None
+
+
+def test_video_dataset_get_empty_caption_item_info_sets_frame_count(tmp_path):
+    dataset = _make_video_dataset(tmp_path)
+    item = dataset.get_empty_caption_item_info()
+    assert item.item_key == EMPTY_CAPTION_CACHE_KEY
+    assert item.caption == ""
+    assert item.text_encoder_output_cache_path == dataset.get_empty_text_encoder_output_cache_path()
+    # VideoDataset must mark the empty-caption item as video content (frame_count > 1) so that
+    # architecture-specific consumers (e.g. Kandinsky5) pick the correct content-type template.
+    assert item.frame_count is not None
+    assert item.frame_count > 1
 
 
 import torch
@@ -237,3 +268,29 @@ def test_process_text_encoder_batches_raises_when_dropout_and_requires_content(t
             encode=lambda batch: None,
             requires_content=True,
         )
+
+
+def test_process_text_encoder_batches_validates_all_datasets_before_encoding(tmp_path):
+    """Fail-fast guard: with [valid_dataset, invalid_dataset] the ValueError must be raised before any
+    dataset's encode() is called, not just before the invalid dataset's own encode() call."""
+
+    valid_dataset = _FakeDataset(tmp_path, caption_dropout_rate=0.0, items=[_make_real_item(tmp_path)])
+    invalid_dataset = _FakeDataset(tmp_path, caption_dropout_rate=0.1, items=[_make_real_item(tmp_path)])
+    all_cache_files, all_cache_paths = cte.prepare_cache_files_and_paths([valid_dataset, invalid_dataset])
+
+    encoded_batches = []
+
+    with pytest.raises(ValueError):
+        cte.process_text_encoder_batches(
+            num_workers=1,
+            skip_existing=False,
+            batch_size=8,
+            datasets=[valid_dataset, invalid_dataset],
+            all_cache_files_for_dataset=all_cache_files,
+            all_cache_paths_for_dataset=all_cache_paths,
+            encode=lambda batch: encoded_batches.append(batch),
+            requires_content=True,
+        )
+
+    # The valid dataset must not have been encoded: validation happens up-front for all datasets.
+    assert encoded_batches == []

--- a/tests/test_caption_dropout.py
+++ b/tests/test_caption_dropout.py
@@ -81,6 +81,14 @@ def test_get_empty_caption_item_info(tmp_path):
     assert item.frame_count is None
 
 
+def test_video_dataset_sets_has_control_attribute(tmp_path):
+    # Regression test: VideoDataset.__init__ must still set self.has_control (used by
+    # get_metadata()) after the get_empty_caption_item_info() override was added.
+    dataset = _make_video_dataset(tmp_path)
+    assert dataset.has_control is False
+    assert dataset.get_metadata()["has_control"] is False
+
+
 def test_video_dataset_get_empty_caption_item_info_sets_frame_count(tmp_path):
     dataset = _make_video_dataset(tmp_path)
     item = dataset.get_empty_caption_item_info()

--- a/tests/test_caption_dropout.py
+++ b/tests/test_caption_dropout.py
@@ -15,7 +15,7 @@ def test_base_dataset_params_accepts_caption_dropout_rate():
     assert params.caption_dropout_rate == 0.1
 
 
-from musubi_tuner.dataset.image_video_dataset import EMPTY_CAPTION_CACHE_KEY, ImageDataset
+from musubi_tuner.dataset.image_video_dataset import EMPTY_CAPTION_CACHE_KEY, ImageDataset, ItemInfo
 
 
 def _make_image_dataset(tmp_path, caption_dropout_rate=0.0):
@@ -35,8 +35,6 @@ def _make_image_dataset(tmp_path, caption_dropout_rate=0.0):
 
 
 def test_item_info_defaults_caption_dropout_fields():
-    from musubi_tuner.dataset.image_video_dataset import ItemInfo
-
     item = ItemInfo("key", "a caption", (64, 64))
     assert item.caption_dropout_rate == 0.0
     assert item.empty_text_encoder_output_cache_path is None
@@ -59,3 +57,42 @@ def test_get_empty_caption_item_info(tmp_path):
     assert item.item_key == EMPTY_CAPTION_CACHE_KEY
     assert item.caption == ""
     assert item.text_encoder_output_cache_path == dataset.get_empty_text_encoder_output_cache_path()
+
+
+import torch
+from safetensors.torch import save_file
+
+
+def _write_minimal_wan_caches(tmp_path, item_key="item0", write_empty=True):
+    # latent cache: filename encodes item_key + WxH + architecture
+    latent = torch.zeros(16, 1, 8, 8)
+    save_file({"latents_1x8x8_fp32": latent}, str(tmp_path / f"{item_key}_0064x0064_wan.safetensors"))
+    # text-encoder cache for the real caption
+    save_file({"varlen_t5_fp32": torch.zeros(4, 16)}, str(tmp_path / f"{item_key}_wan_te.safetensors"))
+    if write_empty:
+        save_file({"varlen_t5_fp32": torch.zeros(4, 16)}, str(tmp_path / f"{EMPTY_CAPTION_CACHE_KEY}_wan_te.safetensors"))
+
+
+def test_prepare_for_training_sets_dropout_fields_on_items(tmp_path):
+    _write_minimal_wan_caches(tmp_path)
+    dataset = _make_image_dataset(tmp_path, caption_dropout_rate=0.2)
+    dataset.prepare_for_training()
+    bucket = next(iter(dataset.batch_manager.buckets.values()))
+    assert bucket[0].caption_dropout_rate == 0.2
+    assert bucket[0].empty_text_encoder_output_cache_path == dataset.get_empty_text_encoder_output_cache_path()
+
+
+def test_prepare_for_training_raises_if_empty_cache_missing(tmp_path):
+    _write_minimal_wan_caches(tmp_path, write_empty=False)
+    dataset = _make_image_dataset(tmp_path, caption_dropout_rate=0.2)
+    with pytest.raises(FileNotFoundError):
+        dataset.prepare_for_training()
+
+
+def test_prepare_for_training_leaves_dropout_fields_default_when_rate_zero(tmp_path):
+    _write_minimal_wan_caches(tmp_path, write_empty=False)
+    dataset = _make_image_dataset(tmp_path, caption_dropout_rate=0.0)
+    dataset.prepare_for_training()  # must not raise even though empty cache is absent
+    bucket = next(iter(dataset.batch_manager.buckets.values()))
+    assert bucket[0].caption_dropout_rate == 0.0
+    assert bucket[0].empty_text_encoder_output_cache_path is None

--- a/tests/test_caption_dropout.py
+++ b/tests/test_caption_dropout.py
@@ -1,0 +1,15 @@
+"""Tests for caption dropout: config parsing, cache-path helpers, dropout selection at load time."""
+
+import pytest
+
+from musubi_tuner.dataset.config_utils import BaseDatasetParams
+
+
+def test_base_dataset_params_default_caption_dropout_rate_is_zero():
+    params = BaseDatasetParams()
+    assert params.caption_dropout_rate == 0.0
+
+
+def test_base_dataset_params_accepts_caption_dropout_rate():
+    params = BaseDatasetParams(caption_dropout_rate=0.1)
+    assert params.caption_dropout_rate == 0.1

--- a/tests/test_caption_dropout.py
+++ b/tests/test_caption_dropout.py
@@ -1,5 +1,8 @@
 """Tests for caption dropout: config parsing, cache-path helpers, dropout selection at load time."""
 
+import glob
+import os
+
 import pytest
 
 from musubi_tuner.dataset.config_utils import BaseDatasetParams
@@ -141,3 +144,96 @@ def test_bucket_batch_manager_no_dropout_when_rate_zero(tmp_path):
     with patch("musubi_tuner.dataset.bucket.random.random", return_value=0.0):  # would fire if rate were > 0
         batch = manager[0]
     assert torch.all(batch["t5"][0] == 1.0)
+
+
+from musubi_tuner import cache_text_encoder_outputs as cte
+
+
+class _FakeDataset:
+    """Minimal stand-in for BaseDataset, just enough for process_text_encoder_batches
+    and prepare_cache_files_and_paths (which calls get_all_text_encoder_output_cache_files)."""
+
+    def __init__(self, tmp_path, caption_dropout_rate, items):
+        self.cache_directory = str(tmp_path)
+        self.architecture = "wan"
+        self.caption_dropout_rate = caption_dropout_rate
+        self._items = items
+
+    def get_all_text_encoder_output_cache_files(self):
+        return glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}_te.safetensors"))
+
+    def retrieve_text_encoder_output_cache_batches(self, num_workers):
+        yield self._items
+
+    def get_empty_caption_item_info(self):
+        item = ItemInfo(EMPTY_CAPTION_CACHE_KEY, "", (0, 0), (0, 0))
+        item.text_encoder_output_cache_path = os.path.join(self.cache_directory, f"{EMPTY_CAPTION_CACHE_KEY}_wan_te.safetensors")
+        return item
+
+
+def _make_real_item(tmp_path):
+    item = ItemInfo("real", "a caption", (64, 64))
+    item.text_encoder_output_cache_path = str(tmp_path / "real_wan_te.safetensors")
+    return item
+
+
+def test_process_text_encoder_batches_encodes_empty_caption_when_dropout_enabled(tmp_path):
+    dataset = _FakeDataset(tmp_path, caption_dropout_rate=0.1, items=[_make_real_item(tmp_path)])
+    all_cache_files, all_cache_paths = cte.prepare_cache_files_and_paths([dataset])
+    encoded_captions = []
+
+    def fake_encode(batch):
+        encoded_captions.extend(item.caption for item in batch)
+
+    cte.process_text_encoder_batches(
+        num_workers=1,
+        skip_existing=False,
+        batch_size=8,
+        datasets=[dataset],
+        all_cache_files_for_dataset=all_cache_files,
+        all_cache_paths_for_dataset=all_cache_paths,
+        encode=fake_encode,
+    )
+
+    assert "a caption" in encoded_captions
+    assert "" in encoded_captions  # empty-caption item was encoded
+    empty_path = os.path.normpath(dataset.get_empty_caption_item_info().text_encoder_output_cache_path)
+    assert empty_path in all_cache_paths[0]
+
+
+def test_process_text_encoder_batches_no_empty_caption_when_dropout_disabled(tmp_path):
+    dataset = _FakeDataset(tmp_path, caption_dropout_rate=0.0, items=[_make_real_item(tmp_path)])
+    all_cache_files, all_cache_paths = cte.prepare_cache_files_and_paths([dataset])
+    encoded_captions = []
+
+    def fake_encode(batch):
+        encoded_captions.extend(item.caption for item in batch)
+
+    cte.process_text_encoder_batches(
+        num_workers=1,
+        skip_existing=False,
+        batch_size=8,
+        datasets=[dataset],
+        all_cache_files_for_dataset=all_cache_files,
+        all_cache_paths_for_dataset=all_cache_paths,
+        encode=fake_encode,
+    )
+
+    assert encoded_captions == ["a caption"]
+
+
+def test_process_text_encoder_batches_raises_when_dropout_and_requires_content(tmp_path):
+    dataset = _FakeDataset(tmp_path, caption_dropout_rate=0.1, items=[_make_real_item(tmp_path)])
+    all_cache_files, all_cache_paths = cte.prepare_cache_files_and_paths([dataset])
+
+    with pytest.raises(ValueError):
+        cte.process_text_encoder_batches(
+            num_workers=1,
+            skip_existing=False,
+            batch_size=8,
+            datasets=[dataset],
+            all_cache_files_for_dataset=all_cache_files,
+            all_cache_paths_for_dataset=all_cache_paths,
+            encode=lambda batch: None,
+            requires_content=True,
+        )

--- a/tests/test_caption_dropout.py
+++ b/tests/test_caption_dropout.py
@@ -13,3 +13,49 @@ def test_base_dataset_params_default_caption_dropout_rate_is_zero():
 def test_base_dataset_params_accepts_caption_dropout_rate():
     params = BaseDatasetParams(caption_dropout_rate=0.1)
     assert params.caption_dropout_rate == 0.1
+
+
+from musubi_tuner.dataset.image_video_dataset import EMPTY_CAPTION_CACHE_KEY, ImageDataset
+
+
+def _make_image_dataset(tmp_path, caption_dropout_rate=0.0):
+    return ImageDataset(
+        resolution=(64, 64),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=False,
+        bucket_no_upscale=False,
+        cache_directory=str(tmp_path),
+        debug_dataset=False,
+        architecture="wan",
+        image_directory=str(tmp_path),
+        caption_dropout_rate=caption_dropout_rate,
+    )
+
+
+def test_item_info_defaults_caption_dropout_fields():
+    from musubi_tuner.dataset.image_video_dataset import ItemInfo
+
+    item = ItemInfo("key", "a caption", (64, 64))
+    assert item.caption_dropout_rate == 0.0
+    assert item.empty_text_encoder_output_cache_path is None
+
+
+def test_base_dataset_stores_caption_dropout_rate(tmp_path):
+    dataset = _make_image_dataset(tmp_path, caption_dropout_rate=0.15)
+    assert dataset.caption_dropout_rate == 0.15
+
+
+def test_get_empty_text_encoder_output_cache_path(tmp_path):
+    dataset = _make_image_dataset(tmp_path)
+    path = dataset.get_empty_text_encoder_output_cache_path()
+    assert path == str(tmp_path / f"{EMPTY_CAPTION_CACHE_KEY}_wan_te.safetensors")
+
+
+def test_get_empty_caption_item_info(tmp_path):
+    dataset = _make_image_dataset(tmp_path)
+    item = dataset.get_empty_caption_item_info()
+    assert item.item_key == EMPTY_CAPTION_CACHE_KEY
+    assert item.caption == ""
+    assert item.text_encoder_output_cache_path == dataset.get_empty_text_encoder_output_cache_path()


### PR DESCRIPTION
Adds `caption_dropout_rate`, a dataset-config option that randomly substitutes a pre-cached **empty-caption** text-encoder embedding in place of an item's real caption during training. This is the standard trick for improving unconditional (CFG) generation quality and reducing caption overfitting in LoRA training — without it, the model never sees an empty/unconditional caption during training, so guidance can behave poorly at inference.

## Usage

```toml
[general]
caption_dropout_rate = 0.1  # 10% of reads use the empty-caption embedding instead of the real one
```

Then re-run the architecture's cache script (e.g. `wan_cache_text_encoder_outputs.py`) as usual — it now also emits one additional empty-caption cache file per dataset cache directory (shared across all items, since `""` always encodes to the same embedding). If training starts with `caption_dropout_rate > 0` and that file is missing, it fails fast with a message telling you to re-run the cache script.

See `docs/dataset_config.md` for the full writeup (English + Japanese).

## Summary

- `caption_dropout_rate: float` dataset config option (default `0.0`), validated/propagated through `ConfigSanitizer`/`BaseDatasetParams` the same way as `caption_extension`/`batch_size` (`config_utils.py`).
- `BaseDataset.get_empty_caption_item_info()` / `get_empty_text_encoder_output_cache_path()` build a synthetic empty-caption `ItemInfo` keyed by a reserved `EMPTY_CAPTION_CACHE_KEY`, cached once per dataset directory (`image_video_dataset.py`). `VideoDataset` overrides this to mark the synthetic item as a video (`frame_count=2`) so architecture-specific consumers that branch on content type handle it correctly.
- `ImageDataset`/`VideoDataset.prepare_for_training` fail fast with a clear `FileNotFoundError` if `caption_dropout_rate > 0` but the empty-caption cache file doesn't exist yet.
- `cache_text_encoder_outputs.py` generates the extra empty-caption cache entry per dataset after normal encoding, and rejects (before doing any expensive encoding work) datasets that combine `caption_dropout_rate > 0` with image-conditioned text-encoder caching modes (Qwen-Image `--is_edit`, HiDream-O1 control mode) — the empty-caption embedding would need to vary per-image in those modes, so a single shared cache entry isn't valid.
- `BucketBatchManager` (`bucket.py`) swaps in the empty-caption cache file per-item at batch-load time with probability `caption_dropout_rate`.
- Test coverage in `tests/test_caption_dropout.py` (18 tests): config parsing/validation, empty-cache-path generation, fail-fast behavior, dropout probability application in bucket loading, and the image-conditioned-mode rejection path.

## Test plan

- [x] `uv run --no-sync --with pytest pytest tests/test_caption_dropout.py` — 18 passed
- [ ] Manual smoke test: cache a small dataset with `caption_dropout_rate` set, confirm the empty-caption `.safetensors` file is created, run a few training steps, confirm loss stays finite and no exceptions occur.
- [ ] Confirm the fail-fast `FileNotFoundError` fires when training starts with `caption_dropout_rate > 0` before the cache script has been (re-)run.
- [ ] Confirm `cache_text_encoder_outputs.py` rejects `caption_dropout_rate > 0` on a Qwen-Image `--is_edit` (or HiDream-O1 control) dataset with a clear error.