### PR TITLE
MiniMax-H3: one-frame Ref2VA training (image targets with references)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -50,7 +50,7 @@ The transformer, video VAE, packed-sequence logic, text presentation, and dual s
 
 ## Dataset Configuration
 
-T2VA and FL2VA accept ordinary video directories. FL2VA derives its first and last conditions from each selected target crop. Image datasets are supported by the experimental one-frame (image LoRA) training mode, including FL2VA editing/inbetween training with time-annotated control images — see `docs/minimax_h3_1f.md`.
+T2VA and FL2VA accept ordinary video directories. FL2VA derives its first and last conditions from each selected target crop. Image datasets are supported by the experimental one-frame (image LoRA) training mode, including FL2VA editing/inbetween training with time-annotated control images and Ref2VA training with per-item references — see `docs/minimax_h3_1f.md`.
 
 ```toml
 [general]

--- a/docs/minimax_h3_1f.md
+++ b/docs/minimax_h3_1f.md
@@ -14,7 +14,7 @@
 - Standalone `audio` references are rejected in one-frame mode (their window is defined by the target duration, which a single frame does not have); video references keep their embedded audio.
 - The released 5-15 s duration gate does not apply; `--allow_experimental_duration` is not needed.
 
-Training on one-frame targets is available for plain image LoRA (T2VA) and for editing/inbetween LoRA with 1-2 control images (FL2VA); see [One-frame training](#one-frame-training-t2va-image-lora) and [One-frame editing training](#one-frame-editing-training-fl2va-control-images) below. Ref2VA one-frame training (reference-driven image LoRA) is not implemented yet.
+Training on one-frame targets is available for plain image LoRA (T2VA), for editing/inbetween LoRA with 1-2 control images (FL2VA), and for reference-conditioned image LoRA (Ref2VA); see [One-frame training](#one-frame-training-t2va-image-lora), [One-frame editing training](#one-frame-editing-training-fl2va-control-images), and [One-frame reference training](#one-frame-reference-training-ref2va-image-references) below.
 
 ## Time semantics: `--one_frame`
 
@@ -191,3 +191,49 @@ Official-format caption... --w 1024 --h 1024 --f 1 --s 30 --i source.png --of ta
 ```
 
 (`--i` is the first/only condition, `--ei` the last; `control_index` takes one `;`-separated entry per provided image, and is required.)
+
+## One-frame reference training (Ref2VA, image references)
+
+> [!WARNING]
+> Experimental. This is the training counterpart of one-frame Ref2VA generation: each image target is conditioned on its own ordered references, presented exactly as at inference (numbered reference blocks before the target, `<Picture i>`/`<Video i>` visuals in the text).
+
+With `--task ref2va`, an image dataset pairs each target image with **untimed references** (the same reference schema as video Ref2VA: images, videos with or without audio). Typical uses are identity/character LoRAs trained on (reference image → target image) pairs of the same subject, where the reference is a *different* picture than the target, and view-synthesis or restyling pairs.
+
+Both released transformer families respond to the reference presentation with a one-frame target: the Ref2VA checkpoint by design, and the FL2VA checkpoint extracts a referenced subject's identity about as well (measured with the generation CLI). Training `--task ref2va` on the FL2VA base is therefore a legitimate choice when the LoRA should be deployed with the FL2VA/T2VA weights; note that the LoRA metadata records `ss_minimax_h3_base_family=ref2va` from the task in that case.
+
+### Dataset configuration
+
+References require `image_jsonl_file`; each line carries the target, its caption, and its ordered `references` (relative reference paths resolve from the JSONL directory, as in the video Ref2VA JSONL; `image_path` follows the usual image JSONL rules):
+
+```toml
+[[datasets]]
+image_jsonl_file = "/data/h3/char/items.jsonl"
+cache_directory = "/data/h3/cache-char-ref"
+# fp_1f_target_index is optional (default 0); references carry no time index
+```
+
+```json
+{"image_path": "/data/h3/char/targets/pose_01.png", "caption": "...", "references": [{"type": "image", "path": "refs/front.png"}]}
+{"image_path": "/data/h3/char/targets/pose_02.png", "caption": "...", "references": [{"type": "image", "path": "refs/front.png"}, {"type": "video", "path": "refs/turnaround.mp4"}]}
+```
+
+- Every record needs at least one image or video reference (the video Ref2VA limits apply: at most 9 images, 3 videos, 3 audio-bearing references). Standalone `audio` references are rejected, as in one-frame generation; video references keep their embedded audio (or an explicit `audio_path`, or `"audio_path": null` for visual-only).
+- Control images (`control_path`, `fp_1f_clean_indices`) cannot be combined with references; `image_directory` datasets cannot carry references.
+- Image references are canvas-capped to the target's bucket area (downscale only); video references keep their full released span (15 s cap at 24 fps, 2 fps text sampling), exactly like one-frame generation.
+- Captions should follow the official full-reference caption format (the reference-declaration lines from the prompt-writing guide), which is what makes single-image references yield novel views at inference; the same captions are used for training-time samples.
+
+### Caching and training
+
+Same commands as plain image training with `--task ref2va` on both cache scripts and the trainer. The latent cache holds the target token, the silence placeholder, the target index, and the reference condition latents under the numbered `latents_ref_{i:03d}_{image|video|audio}` keys of video Ref2VA caches; the text cache holds the Ref2VA presentation with the reference visuals embedded. Changing a reference file re-caches both.
+
+```bash
+python minimax_h3_cache_latents.py --dataset_config items.toml --task ref2va --one_frame ...
+python minimax_h3_cache_text_encoder_outputs.py --dataset_config items.toml --task ref2va --one_frame ...
+accelerate launch ... minimax_h3_train_network.py --dataset_config items.toml --task ref2va --one_frame --video_only ...
+```
+
+The guidance-loss recommendation from plain image training applies unchanged (the uncond probe keeps the reference conditions and swaps only the text rows). `--h3_teacher_matching` is not supported with `--one_frame`. Training-time samples use the inline `--ref` syntax with `--f 1`:
+
+```text
+Full-reference caption... --w 1024 --h 1024 --f 1 --s 30 --ref refs/front.png --of target_index=0
+```

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -10,6 +10,7 @@ import torch
 
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode
 from musubi_tuner.minimax_h3.media import (
+    ONE_FRAME_REFERENCE_FRAME_CAP,
     TARGET_FPS,
     H3Record,
     audio_latent_frames,
@@ -24,9 +25,6 @@ from musubi_tuner.minimax_h3_cache_latents import PyAVH3MediaDecoder
 
 
 VIDEO_VAE_SPATIAL_RATIO = 16
-# with a one-frame target, reference videos keep their full released span instead of
-# being capped by the target duration
-ONE_FRAME_REFERENCE_FRAME_CAP = 15 * TARGET_FPS
 
 
 def parse_one_frame_options(spec: str) -> tuple[int, tuple[int, ...] | None]:

--- a/src/musubi_tuner/minimax_h3/media.py
+++ b/src/musubi_tuner/minimax_h3/media.py
@@ -10,7 +10,7 @@ import av
 
 from musubi_tuner.dataset.audio_utils import AudioSource as H3AudioSource
 from musubi_tuner.dataset.audio_utils import AudioSpec
-from musubi_tuner.dataset.datasources import VideoDatasource, VideoJsonlDatasource
+from musubi_tuner.dataset.datasources import ImageDatasource, ImageJsonlDatasource, VideoDatasource, VideoJsonlDatasource
 
 
 H3Task = Literal["t2va", "fl2va", "ref2va"]
@@ -20,6 +20,9 @@ H3MediaProbe = Callable[[Path], "H3MediaInfo"]
 TARGET_FPS = 24
 AUDIO_SAMPLE_RATE = 32000
 AUDIO_TERMINAL_TOLERANCE_SAMPLES = 800
+# with a one-frame (image) target, reference videos keep their full released span instead of
+# being capped by the target duration (shared by generation and the one-frame caches)
+ONE_FRAME_REFERENCE_FRAME_CAP = 15 * TARGET_FPS
 
 
 @dataclass(frozen=True)
@@ -264,6 +267,17 @@ def parse_inline_references(
     return _parse_references(raw_references, base_directory, context, probe)
 
 
+def reject_one_frame_audio_references(record: H3Record) -> None:
+    """Standalone audio references have no window with a one-frame target (it is defined by the
+    target duration); video references keep their embedded audio. Shared by generation, the
+    one-frame caches, and training-time samples."""
+    if any(reference.type == "audio" for reference in record.references):
+        raise ValueError(
+            "MiniMax-H3 one-frame targets do not accept standalone audio references"
+            " (their window is defined by the target duration); video references keep their embedded audio"
+        )
+
+
 def _record_from_jsonl_data(
     data: object,
     base_directory: Path,
@@ -353,4 +367,54 @@ def h3_records_from_datasource(
         if not isinstance(caption, str):
             raise ValueError("MiniMax-H3 directory caption must be a string")
         records.append(H3Record(video_path=video_path, caption=caption, references=(), jsonl_line=0))
+    return records
+
+
+def h3_image_records_from_datasource(
+    datasource: ImageDatasource,
+    task: H3Task,
+    probe: H3MediaProbe = probe_h3_media,
+) -> dict[str, H3Record]:
+    """Builds one-frame (image target) Ref2VA records from an image datasource's parsed data.
+
+    Only ``image_jsonl_file`` datasets can carry ``references`` (the same schema as the
+    Ref2VA video JSONL, resolved from the JSONL directory), so Ref2VA requires one. The result
+    is keyed by the JSONL ``image_path`` string exactly as the dataset layer stores it in
+    ``ItemInfo.item_key`` (image items carry no datasource index); the record's target path
+    is that image path resolved the way the dataset layer opens it. For the other tasks the
+    JSONL is only checked for stray ``references`` and no records are built.
+    """
+    if task not in {"t2va", "fl2va", "ref2va"}:
+        raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
+    if not isinstance(datasource, ImageJsonlDatasource):
+        if task == "ref2va":
+            raise ValueError("MiniMax-H3 one-frame Ref2VA requires image_jsonl_file with per-item references")
+        return {}
+
+    base_directory = Path(datasource.image_jsonl_file).resolve().parent
+    records: dict[str, H3Record] = {}
+    for index, data in enumerate(datasource.data):
+        line_number = index + 1
+        if not isinstance(data, dict):
+            raise ValueError(f"H3 JSONL line {line_number}: each record must be an object")
+        raw_references = data.get("references", [])
+        if task != "ref2va":
+            if raw_references:
+                raise ValueError(f"H3 JSONL line {line_number}: references require task ref2va")
+            continue
+        item_key = data.get("image_path")
+        if not isinstance(item_key, str) or not item_key.strip():
+            raise ValueError(f"H3 JSONL line {line_number}: image_path must be a non-empty path")
+        target = Path(item_key).expanduser().resolve()
+        if not target.is_file():
+            raise ValueError(f"H3 JSONL line {line_number}: image_path does not exist: {target}")
+        caption = data.get("caption")
+        if not isinstance(caption, str):
+            raise ValueError(f"H3 JSONL line {line_number}: caption must be a string")
+        if item_key in records:
+            raise ValueError(f"H3 JSONL line {line_number}: duplicate image_path {item_key!r}")
+        references = _parse_references(raw_references, base_directory, line_number, probe)
+        records[item_key] = H3Record(video_path=target, caption=caption, references=references, jsonl_line=line_number)
+    if task == "ref2va" and not records:
+        raise ValueError(f"MiniMax-H3 JSONL contains no records: {datasource.image_jsonl_file}")
     return records

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -39,13 +39,16 @@ from musubi_tuner.minimax_h3.media import (
     AUDIO_SAMPLE_RATE,
     AUDIO_TERMINAL_TOLERANCE_SAMPLES,
     H3_AUDIO_SPEC,
+    ONE_FRAME_REFERENCE_FRAME_CAP,
     H3AudioSource,
     H3Record,
     H3Reference,
     H3Task,
     TARGET_FPS,
     audio_latent_frames,
+    h3_image_records_from_datasource,
     h3_records_from_datasource,
+    reject_one_frame_audio_references,
     video_latent_frames,
     waveform_samples,
 )
@@ -369,36 +372,16 @@ def build_latent_tensors(
             condition = _encode_condition_video(video_vae, _prepare_pixels(frame))[0]
             tensors[_visual_key(role, condition)] = condition
     elif task == "ref2va":
-        for index, reference in enumerate(record.references):
-            role_prefix = f"ref_{index:03d}"
-            visual_frames = None
-            if reference.type in {"image", "video"}:
-                visual_frames = media_decoder.decode_reference_visual(
-                    reference,
-                    target_frame_count=frame_count,
-                    target_size=(width, height),
-                )
-                if reference.type == "video":
-                    video_latent_frames(visual_frames.shape[0])
-                condition = _encode_condition_video(video_vae, _prepare_pixels(visual_frames))[0]
-                tensors[_visual_key(f"{role_prefix}_{reference.type}", condition)] = condition
-
-            if reference.audio is not None:
-                if reference.type == "video":
-                    reference_audio_frames = audio_latent_frames(visual_frames.shape[0])
-                    reference_samples = waveform_samples(reference_audio_frames)
-                    require_exact = True
-                else:
-                    reference_samples = target_samples
-                    require_exact = False
-                waveform = media_decoder.decode_audio(
-                    reference.audio,
-                    start_sample=0,
-                    sample_count=reference_samples,
-                    require_exact=require_exact,
-                )
-                audio_latent = _encode_audio(audio_vae, waveform)[0]
-                tensors[_audio_key(f"{role_prefix}_audio", audio_latent)] = audio_latent
+        _encode_reference_conditions(
+            tensors,
+            record=record,
+            reference_frame_cap=frame_count,
+            target_size=(width, height),
+            target_samples=target_samples,
+            video_vae=video_vae,
+            audio_vae=audio_vae,
+            media_decoder=media_decoder,
+        )
 
     metadata = build_latent_metadata(
         task=task,
@@ -409,6 +392,58 @@ def build_latent_tensors(
         media_fingerprints=media_fingerprints,
     )
     return H3LatentCachePayload(tensors=tensors, metadata=metadata)
+
+
+def _encode_reference_conditions(
+    tensors: dict[str, torch.Tensor],
+    *,
+    record: H3Record,
+    reference_frame_cap: int,
+    target_size: tuple[int, int],
+    target_samples: int | None,
+    video_vae,
+    audio_vae,
+    media_decoder: H3MediaDecoder,
+) -> None:
+    """Encodes the record's ordered references under the numbered ``ref_{i:03d}_{type}`` roles.
+
+    Reference videos are capped at ``reference_frame_cap`` pixel frames (the target duration for
+    video targets, the released 15 s span for one-frame targets) and keep their own audio
+    duration; standalone audio references take the target's window (``target_samples``), which
+    one-frame targets do not have (callers reject them first).
+    """
+    for index, reference in enumerate(record.references):
+        role_prefix = f"ref_{index:03d}"
+        visual_frames = None
+        if reference.type in {"image", "video"}:
+            visual_frames = media_decoder.decode_reference_visual(
+                reference,
+                target_frame_count=reference_frame_cap,
+                target_size=target_size,
+            )
+            if reference.type == "video":
+                video_latent_frames(visual_frames.shape[0])
+            condition = _encode_condition_video(video_vae, _prepare_pixels(visual_frames))[0]
+            tensors[_visual_key(f"{role_prefix}_{reference.type}", condition)] = condition
+
+        if reference.audio is not None:
+            if reference.type == "video":
+                reference_audio_frames = audio_latent_frames(visual_frames.shape[0])
+                reference_samples = waveform_samples(reference_audio_frames)
+                require_exact = True
+            else:
+                if target_samples is None:
+                    raise ValueError("MiniMax-H3 standalone audio references require a target audio window")
+                reference_samples = target_samples
+                require_exact = False
+            waveform = media_decoder.decode_audio(
+                reference.audio,
+                start_sample=0,
+                sample_count=reference_samples,
+                require_exact=require_exact,
+            )
+            audio_latent = _encode_audio(audio_vae, waveform)[0]
+            tensors[_audio_key(f"{role_prefix}_audio", audio_latent)] = audio_latent
 
 
 def encode_one_frame_silence_latent(audio_vae) -> torch.Tensor:
@@ -435,17 +470,35 @@ def build_one_frame_latent_tensors(
     media_fingerprints: Mapping[Path, str],
     control_frames: Sequence[torch.Tensor | np.ndarray] | None = None,
     control_indices: Sequence[int] | None = None,
+    record: H3Record | None = None,
+    audio_vae=None,
+    media_decoder: H3MediaDecoder | None = None,
 ) -> H3LatentCachePayload:
     """One-frame (image) target: a single video latent token, the silence audio placeholder,
     and the target's 24 fps pixel-frame index as a tensor entry for the trainer's RoPE override.
 
     With control_frames/control_indices (K=1..2, fl2va editing/inbetween), each bucket-resized
     control image becomes a condition latent under the packed (first, last) role keys, and the
-    indices ride along as an int64 tensor for the trainer's condition-time overrides."""
+    indices ride along as an int64 tensor for the trainer's condition-time overrides.
+
+    With a record carrying references (ref2va), the ordered references become numbered
+    ``ref_{i:03d}`` condition latents exactly like video Ref2VA caches (image references are
+    canvas-capped to the target area, video references keep their released span and audio);
+    references are untimed, only the target index enters the time overrides."""
     if target_index < 0:
         raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
     if (control_frames is None) != (control_indices is None):
         raise ValueError("MiniMax-H3 one-frame control frames and control indices must be provided together")
+    references = () if record is None else record.references
+    if references:
+        if control_frames is not None:
+            raise ValueError("MiniMax-H3 one-frame caching cannot combine control images with references")
+        if media_decoder is None:
+            raise ValueError("MiniMax-H3 one-frame references require a media decoder")
+        _validate_task_record(record, "ref2va")
+        reject_one_frame_audio_references(record)
+        if audio_vae is None and any(reference.audio is not None for reference in references):
+            raise ValueError("MiniMax-H3 one-frame audio-bearing references require the audio VAE")
     image_frames = torch.as_tensor(image_frames)
     if image_frames.ndim == 3:
         image_frames = image_frames.unsqueeze(0)
@@ -489,13 +542,30 @@ def build_one_frame_latent_tensors(
                 )
             condition = _encode_condition_video(video_vae, _prepare_pixels(control.unsqueeze(0)))[0]
             tensors[_visual_key(role, condition)] = condition
+    if references:
+        _encode_reference_conditions(
+            tensors,
+            record=record,
+            reference_frame_cap=ONE_FRAME_REFERENCE_FRAME_CAP,
+            target_size=(int(width), int(height)),
+            target_samples=None,
+            video_vae=video_vae,
+            audio_vae=audio_vae,
+            media_decoder=media_decoder,
+        )
     append_audio_present_entry(tensors, False)
     append_one_frame_target_index_entry(tensors, target_index)
     if control_indices is not None:
         append_one_frame_control_indices_entry(tensors, list(control_indices))
 
+    if references:
+        task: H3Task = "ref2va"
+    elif control_frames is not None:
+        task = "fl2va"
+    else:
+        task = "t2va"
     metadata = build_latent_metadata(
-        task="t2va" if control_frames is None else "fl2va",
+        task=task,
         crop_start_frame=0,
         cache_seed=cache_seed,
         video_vae_fingerprint=video_vae_fingerprint,
@@ -538,6 +608,20 @@ def validate_h3_dataset(dataset: VideoDataset | ImageDataset) -> None:
     # dataset layer); the shared control-VIDEO fields stay unsupported
     if isinstance(dataset, VideoDataset) and (dataset.control_directory is not None or dataset.has_control):
         raise ValueError("MiniMax-H3 does not use the shared control-video fields")
+
+
+def validate_h3_image_dataset_task(dataset: ImageDataset, task: H3Task, one_frame: bool) -> None:
+    """The one-frame task matrix, shared by both cache scripts: plain images cache as t2va,
+    control images (time-annotated) require fl2va, and ref2va takes a control-free image
+    JSONL dataset whose records carry references (checked when the records are built)."""
+    if not one_frame:
+        raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
+    if dataset.has_control and task != "fl2va":
+        raise ValueError("MiniMax-H3 image datasets with control images require --task fl2va")
+    if not dataset.has_control and task == "fl2va":
+        raise ValueError(
+            "MiniMax-H3 --task fl2va requires image datasets with control images (plain image datasets cache with --task t2va)"
+        )
 
 
 def dataset_cache_dir_key(cache_directory: str) -> str:
@@ -583,7 +667,8 @@ def setup_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="experimental one-frame (image) training caches: accept image datasets whose items become single-token"
         " video targets with a silence audio placeholder. --task t2va caches plain image targets; --task fl2va"
-        " additionally encodes 1-2 control images as time-annotated conditions (fp_1f_clean_indices)",
+        " additionally encodes 1-2 control images as time-annotated conditions (fp_1f_clean_indices); --task ref2va"
+        " encodes the per-item references of an image_jsonl_file dataset as untimed Ref2VA conditions",
     )
     parser.add_argument("--cache_seed", type=int, default=0, help="seed used for reproducible target-video posterior samples")
     parser.add_argument(
@@ -607,12 +692,11 @@ def main() -> None:
     blueprint = blueprint_generator.generate(user_config, args, architecture=ARCHITECTURE_MINIMAX_H3)
     dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group, audio_spec=H3_AUDIO_SPEC)
     datasets = dataset_group.datasets
-    if args.one_frame and args.task == "ref2va":
-        raise ValueError("MiniMax-H3 one-frame caching supports --task t2va and fl2va only")
 
     records_by_dir: dict[str, list[H3Record]] = {}
     audio_sources_by_dir: dict[str, list] = {}
     image_dirs: set[str] = set()
+    image_records_by_dir: dict[str, dict[str, H3Record]] = {}
     control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
     for dataset_index, dataset in enumerate(datasets):
         validate_h3_dataset(dataset)
@@ -625,17 +709,10 @@ def main() -> None:
             )
         key = dataset_cache_dir_key(dataset.cache_directory)
         if isinstance(dataset, ImageDataset):
-            if not args.one_frame:
-                raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
-            if dataset.has_control and args.task != "fl2va":
-                raise ValueError("MiniMax-H3 image datasets with control images require --task fl2va")
-            if not dataset.has_control and args.task != "t2va":
-                raise ValueError(
-                    "MiniMax-H3 --task fl2va requires image datasets with control images"
-                    " (plain image datasets cache with --task t2va)"
-                )
+            validate_h3_image_dataset_task(dataset, args.task, args.one_frame)
             image_dirs.add(key)
             control_paths_by_dir[key] = dataset.datasource.get_control_paths()
+            image_records_by_dir[key] = h3_image_records_from_datasource(dataset.datasource, args.task)
             continue
         if not isinstance(dataset, VideoDataset):
             raise ValueError("MiniMax-H3 latent caching accepts only image and video datasets")
@@ -666,6 +743,10 @@ def main() -> None:
         for source in audio_sources_by_dir[key]:
             if source is not None:
                 media_fingerprints[source.path] = fingerprint_file(source.path)
+    for image_records in image_records_by_dir.values():
+        for record in image_records.values():
+            for path in record_media_paths(record):
+                media_fingerprints[path] = fingerprint_file(path)
 
     logger.info("Loading MiniMax-H3 video VAE from %s", args.video_vae)
     video_vae = load_video_vae(
@@ -695,7 +776,15 @@ def main() -> None:
         image_fingerprints = {image_path: media_fingerprints.setdefault(image_path, fingerprint_file(image_path))}
         control_frames = None
         control_indices = None
-        if args.task == "fl2va":
+        record = None
+        if args.task == "ref2va":
+            record = image_records_by_dir.get(cache_dir_key, {}).get(item.item_key)
+            if record is None:
+                raise ValueError(f"MiniMax-H3 ref2va one-frame item has no JSONL record: {item.item_key}")
+            # the references are what the cache encodes, so their files join the identity
+            for path in record_media_paths(record):
+                image_fingerprints[path] = media_fingerprints[path]
+        elif args.task == "fl2va":
             control_frames = item.control_content
             control_indices = item.fp_1f_clean_indices
             if not control_indices or control_frames is None or len(control_frames) != len(control_indices):
@@ -735,6 +824,9 @@ def main() -> None:
             media_fingerprints=image_fingerprints,
             control_frames=control_frames,
             control_indices=control_indices,
+            record=record,
+            audio_vae=audio_vae,
+            media_decoder=decoder,
         )
         logger.info("Saving MiniMax-H3 one-frame latent cache for %s to %s", item.item_key, item.latent_cache_path)
         save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -27,7 +27,15 @@ from musubi_tuner.minimax_h3.text_encoder import (
     save_h3_uncond_cache,
     wrap_ref_teacher_caption,
 )
-from musubi_tuner.minimax_h3.media import H3AudioSource, H3Record, H3Reference, h3_records_from_datasource
+from musubi_tuner.minimax_h3.media import (
+    ONE_FRAME_REFERENCE_FRAME_CAP,
+    H3AudioSource,
+    H3Record,
+    H3Reference,
+    h3_image_records_from_datasource,
+    h3_records_from_datasource,
+    reject_one_frame_audio_references,
+)
 from musubi_tuner.minimax_h3_cache_latents import (
     PyAVH3MediaDecoder,
     _adapt_canvas,
@@ -38,6 +46,7 @@ from musubi_tuner.minimax_h3_cache_latents import (
     fingerprint_file,
     item_record_inputs,
     validate_h3_dataset,
+    validate_h3_image_dataset_task,
 )
 from musubi_tuner.utils.model_utils import dtype_to_str
 
@@ -74,29 +83,43 @@ def _build_visuals(
         }
 
     target_size = (int(target_frames.shape[2]), int(target_frames.shape[1]))
+    return _reference_visuals(record, item.frame_count, target_size, decoder, decoded_reference_cache)
+
+
+def _reference_visuals(
+    record,
+    reference_frame_cap: int,
+    target_size: tuple[int, int],
+    decoder: PyAVH3MediaDecoder,
+    decoded_reference_cache: dict[tuple, torch.Tensor],
+) -> dict[object, H3TextVisual]:
+    """Text visuals of the record's references: image references as single frames, video
+    references sampled at 2 fps, decoded through the same reference canvas policy as the
+    latent cache (target_size caps images, reference_frame_cap caps videos)."""
     visuals = {}
     for reference in record.references:
         if reference.type not in {"image", "video"}:
             continue
-        cache_key = (reference.path, reference.type, item.frame_count, target_size)
+        cache_key = (reference.path, reference.type, reference_frame_cap, target_size)
         frames = decoded_reference_cache.get(cache_key)
         if frames is None:
             frames = decoder.decode_reference_visual(
                 reference,
-                target_frame_count=item.frame_count,
+                target_frame_count=reference_frame_cap,
                 target_size=target_size,
             )
             decoded_reference_cache[cache_key] = frames
         if reference.type == "image":
             visuals[reference.path] = H3TextVisual(frames)
         else:
-            sampled = frames[::12]
+            sampled = frames[::REF_TEACHER_TEXT_FRAME_STRIDE]
             timestamps = tuple(index / 2.0 for index in range(sampled.shape[0]))
             visuals[reference.path] = H3TextVisual(sampled, timestamps)
     return visuals
 
 
-# the same 2 fps text-visual sampling as the Ref2VA reference path (decode_generation_visuals)
+# the 2 fps text-visual sampling of the Ref2VA reference path (decode_generation_visuals),
+# shared by the ref teacher presentation
 REF_TEACHER_TEXT_FRAME_STRIDE = 12
 
 
@@ -203,7 +226,8 @@ def setup_parser() -> argparse.ArgumentParser:
         "--one_frame",
         action="store_true",
         help="experimental one-frame (image) training caches: accept image datasets. --task t2va encodes plain"
-        " caption presentations; --task fl2va embeds the bucket-resized control images as <Picture i> visuals",
+        " caption presentations; --task fl2va embeds the bucket-resized control images as <Picture i> visuals;"
+        " --task ref2va embeds the per-item references of an image_jsonl_file dataset in the Ref2VA presentation",
     )
     parser.add_argument(
         "--teacher_conditions",
@@ -242,8 +266,6 @@ def main() -> None:
         if args.one_frame:
             raise ValueError("--teacher_conditions does not support --one_frame yet")
         teacher_conditions = normalize_teacher_conditions(args.teacher_conditions)
-    if args.one_frame and args.task == "ref2va":
-        raise ValueError("MiniMax-H3 one-frame caching supports --task t2va and fl2va only")
 
     blueprint_generator = BlueprintGenerator(ConfigSanitizer())
     logger.info("Loading dataset config from %s", args.dataset_config)
@@ -255,22 +277,16 @@ def main() -> None:
     decoder = PyAVH3MediaDecoder()
     records_by_dir = {}
     image_dirs: set[str] = set()
+    image_records_by_dir: dict[str, dict[str, H3Record]] = {}
     control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
     for dataset in datasets:
         validate_h3_dataset(dataset)
         if isinstance(dataset, ImageDataset):
-            if not args.one_frame:
-                raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
-            if dataset.has_control and args.task != "fl2va":
-                raise ValueError("MiniMax-H3 image datasets with control images require --task fl2va")
-            if not dataset.has_control and args.task != "t2va":
-                raise ValueError(
-                    "MiniMax-H3 --task fl2va requires image datasets with control images"
-                    " (plain image datasets cache with --task t2va)"
-                )
+            validate_h3_image_dataset_task(dataset, args.task, args.one_frame)
             key = dataset_cache_dir_key(dataset.cache_directory)
             image_dirs.add(key)
             control_paths_by_dir[key] = dataset.datasource.get_control_paths()
+            image_records_by_dir[key] = h3_image_records_from_datasource(dataset.datasource, args.task)
             continue
         if not isinstance(dataset, VideoDataset):
             raise ValueError("MiniMax-H3 text caching accepts only image and video datasets")
@@ -292,6 +308,13 @@ def main() -> None:
         for control_paths in control_paths_by_dir.values()
         for paths in control_paths.values()
         for path in paths
+    )
+    # ... and one-frame ref2va presentations embed the reference visuals
+    text_paths.update(
+        path
+        for image_records in image_records_by_dir.values()
+        for record in image_records.values()
+        for path in _text_media_paths(record, args.task)
     )
     media_fingerprints = {path: fingerprint_file(path) for path in text_paths}
 
@@ -338,9 +361,10 @@ def main() -> None:
         for item in batch:
             cache_dir_key = dataset_cache_dir_key(str(Path(item.text_encoder_output_cache_path).parent))
             if cache_dir_key in image_dirs:
-                # one-frame image item: the caption as a T2VA presentation, or an FL2VA
-                # presentation embedding the bucket-resized control images; all time indices
-                # live in the latent cache, never in the text rows
+                # one-frame image item: the caption as a T2VA presentation, an FL2VA
+                # presentation embedding the bucket-resized control images, or a Ref2VA
+                # presentation embedding the item's references; all time indices live in the
+                # latent cache, never in the text rows
                 record = H3Record(
                     video_path=Path(item.item_key).resolve(),
                     caption=item.caption,
@@ -351,7 +375,25 @@ def main() -> None:
                 frame_count = 1
                 visuals = {}
                 record_media_fingerprints = {}
-                if args.task == "fl2va":
+                if args.task == "ref2va":
+                    record = image_records_by_dir.get(cache_dir_key, {}).get(item.item_key)
+                    if record is None:
+                        raise ValueError(f"MiniMax-H3 ref2va one-frame item has no JSONL record: {item.item_key}")
+                    reject_one_frame_audio_references(record)
+                    target = torch.as_tensor(item.content)
+                    if target.ndim != 3:
+                        raise ValueError(f"MiniMax-H3 one-frame target must be [H,W,C], got {tuple(target.shape)}")
+                    # the same canvas policy as the latent cache: images capped to the target
+                    # area, videos to the released 15 s span with 2 fps text sampling
+                    visuals = _reference_visuals(
+                        record,
+                        ONE_FRAME_REFERENCE_FRAME_CAP,
+                        (int(target.shape[1]), int(target.shape[0])),
+                        decoder,
+                        decoded_reference_cache,
+                    )
+                    record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
+                elif args.task == "fl2va":
                     controls = item.control_content
                     control_indices = item.fp_1f_clean_indices
                     if not control_indices or controls is None or len(controls) != len(control_indices):

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -31,6 +31,7 @@ from musubi_tuner.minimax_h3.media import (
     TARGET_FPS,
     H3Record,
     audio_latent_frames,
+    reject_one_frame_audio_references,
     video_latent_frames,
 )
 from musubi_tuner.minimax_h3.checkpoint import resolve_safetensors_files
@@ -651,11 +652,8 @@ def _acquire_transformer(
 
 
 def _reject_one_frame_audio_references(args: argparse.Namespace, record: H3Record) -> None:
-    if args.frame_count == 1 and any(reference.type == "audio" for reference in record.references):
-        raise ValueError(
-            "MiniMax-H3 one-frame generation does not accept standalone audio references"
-            " (their window is defined by the target duration); video references keep their embedded audio"
-        )
+    if args.frame_count == 1:
+        reject_one_frame_audio_references(record)
 
 
 def _encode_conditions(

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -32,7 +32,13 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     module_device_dtype,
     parse_one_frame_options,
 )
-from musubi_tuner.minimax_h3.media import H3_AUDIO_SPEC, audio_latent_frames, parse_inline_references, video_latent_frames
+from musubi_tuner.minimax_h3.media import (
+    H3_AUDIO_SPEC,
+    audio_latent_frames,
+    parse_inline_references,
+    reject_one_frame_audio_references,
+    video_latent_frames,
+)
 from musubi_tuner.minimax_h3.model import load_h3_transformer
 from musubi_tuner.minimax_h3.packing import (
     FRAME_RESCALE,
@@ -107,12 +113,10 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
     one_frame_spec = sample.get("one_frame")
     if requested_frame_count == 1:
         # experimental one-frame (image) sample: single-token target, no duration semantics
-        if args.task not in {"t2va", "fl2va"}:
-            raise ValueError("MiniMax-H3 one-frame training samples (--f 1) support --task t2va and fl2va only")
         frame_count = 1
         target_index, control_indices = parse_one_frame_options(one_frame_spec) if one_frame_spec else (0, None)
-        if args.task == "t2va" and control_indices is not None:
-            raise ValueError("MiniMax-H3 T2VA one-frame training sample does not accept control_index")
+        if args.task != "fl2va" and control_indices is not None:
+            raise ValueError(f"MiniMax-H3 {args.task.upper()} one-frame training sample does not accept control_index")
         sample["one_frame_target_index"] = target_index
         sample["one_frame_control_indices"] = control_indices
     else:
@@ -374,8 +378,8 @@ def _runtime_batch_plan(
     if is_one_frame_batch:
         if not one_frame:
             raise ValueError("MiniMax-H3 batch carries a one-frame latent cache; pass --one_frame to train on image targets")
-        if reference_roles or teacher_conditions is not None:
-            raise ValueError("MiniMax-H3 one-frame training currently supports plain T2VA and FL2VA caches only")
+        if teacher_conditions is not None:
+            raise ValueError("MiniMax-H3 one-frame training does not support teacher matching yet")
         if (
             not isinstance(one_frame_index_value, torch.Tensor)
             or one_frame_index_value.shape != (batch_size,)
@@ -406,7 +410,8 @@ def _runtime_batch_plan(
             _warn_once_coinciding_indices(control_indices, target_index)
             condition_times = tuple(FRAME_RESCALE * index for index in control_indices)
         elif one_frame_control_value is not None:
-            raise ValueError("MiniMax-H3 one-frame T2VA batch cannot carry one_frame_control_indices; re-run latent caching")
+            # references are untimed: only FL2VA controls carry condition indices
+            raise ValueError("MiniMax-H3 one-frame T2VA/Ref2VA batch cannot carry one_frame_control_indices; re-run latent caching")
         time_overrides = H3TimeOverrides(condition_times=condition_times, target_time=FRAME_RESCALE * target_index)
     elif one_frame_index_value is not None or one_frame_control_value is not None:
         raise ValueError("MiniMax-H3 video batch cannot carry one-frame index tensors; re-run latent caching")
@@ -720,8 +725,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         if getattr(args, "task", None) not in {"t2va", "fl2va", "ref2va"}:
             raise ValueError("MiniMax-H3 requires --task t2va, fl2va, or ref2va")
         if getattr(args, "one_frame", False):
-            if args.task not in {"t2va", "fl2va"}:
-                raise ValueError("MiniMax-H3 one-frame training requires --task t2va or fl2va")
             if getattr(args, "h3_teacher_matching", False):
                 raise ValueError("--h3_teacher_matching does not support --one_frame yet")
             logger.info(
@@ -894,6 +897,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             for parameter in parameters:
                 request = SimpleNamespace(**parameter)
                 record = load_generation_record(request)
+                if parameter["frame_count"] == 1:
+                    reject_one_frame_audio_references(record)
                 raw_visuals, text_visuals = decode_generation_visuals(request, record, decoder)
                 presentation = build_presentation(record, args.task, text_visuals)
                 hidden_states, token_tags = encode_h3_presentation(processor, text_encoder, presentation)
@@ -1461,9 +1466,14 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             )
         # the probe swaps only the text rows; the one-frame times stay valid because they
         # are relative to the target-block cursor, which moves with the text length. The
-        # condition roles are recovered from the segments so a one-frame FL2VA layout with a
-        # single condition rebuilds identically (roles are required for K=1).
-        uncond_condition_roles = tuple(segment.role for segment in runtime.layout.segments if segment.kind == "visual_condition")
+        # FL2VA condition roles are recovered from the segments so a one-frame FL2VA layout
+        # with a single condition rebuilds identically (roles are required for K=1); Ref2VA
+        # reference blocks share the segment kind but are addressed by the references tuple
+        uncond_condition_roles = ()
+        if runtime.layout.task == "fl2va":
+            uncond_condition_roles = tuple(
+                segment.role for segment in runtime.layout.segments if segment.kind == "visual_condition"
+            )
         uncond_layout = build_h3_layout(
             task=runtime.layout.task,
             text_length=uncond_hidden.shape[0],
@@ -1778,9 +1788,9 @@ def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.Argumen
         "--one_frame",
         action="store_true",
         help="experimental one-frame (image) training: accept single-token latent caches written by"
-        " minimax_h3_cache_latents.py --one_frame — plain image targets (t2va) or editing/inbetween targets"
-        " with 1-2 time-annotated control images (fl2va). Video batches are unaffected, so image and video"
-        " datasets can mix in one run",
+        " minimax_h3_cache_latents.py --one_frame — plain image targets (t2va), editing/inbetween targets"
+        " with 1-2 time-annotated control images (fl2va), or reference-conditioned targets (ref2va)."
+        " Video batches are unaffected, so image and video datasets can mix in one run",
     )
     add_audio_train_args(parser)
     parser.add_argument("--h3_shift_video", type=float, default=12.0, help="MiniMax-H3 target-video flow shift")

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -10,12 +10,15 @@ import torch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
+from musubi_tuner.dataset.datasources import ImageDirectoryDatasource, ImageJsonlDatasource
 from musubi_tuner.minimax_h3.media import (
+    ONE_FRAME_REFERENCE_FRAME_CAP,
     H3AudioSource,
     H3MediaInfo,
     H3Record,
     H3Reference,
     audio_latent_frames,
+    h3_image_records_from_datasource,
     h3_records_from_datasource,
     load_h3_jsonl_records,
     parse_inline_references,
@@ -1147,6 +1150,197 @@ def test_one_frame_control_cache_keys_round_trip_through_the_bucket_collator(tmp
     assert batch["latents_first"].shape == (1, 24, 1, 4, 4)
     torch.testing.assert_close(batch["one_frame_target_index"], torch.tensor([24], dtype=torch.int64))
     torch.testing.assert_close(batch["one_frame_control_indices"], torch.tensor([[0]], dtype=torch.int64))
+
+
+def _one_frame_reference_record(tmp_path: Path, *, with_video: bool = True, with_audio_reference: bool = False) -> H3Record:
+    image = _touch(tmp_path / "refs" / "face.png")
+    references = [H3Reference(type="image", path=image)]
+    if with_video:
+        video = _touch(tmp_path / "refs" / "motion.mp4")
+        references.append(
+            H3Reference(type="video", path=video, audio=H3AudioSource(path=video, embedded=True), duration_seconds=4.0)
+        )
+    if with_audio_reference:
+        voice = _touch(tmp_path / "refs" / "voice.wav")
+        references.append(
+            H3Reference(type="audio", path=voice, audio=H3AudioSource(path=voice, embedded=False), duration_seconds=1.0)
+        )
+    return H3Record(
+        video_path=_touch(tmp_path / "target.png"),
+        caption="a novel view of the character",
+        references=tuple(references),
+        jsonl_line=1,
+    )
+
+
+def test_build_one_frame_latents_pack_references_under_numbered_roles(tmp_path: Path):
+    record = _one_frame_reference_record(tmp_path)
+    image, video = (reference.path for reference in record.references)
+    decoder = _FakeH3MediaDecoder(
+        visuals={
+            image: torch.zeros(1, 32, 64, 3, dtype=torch.uint8),
+            video: torch.zeros(5, 64, 32, 3, dtype=torch.uint8),
+        }
+    )
+    video_vae = _FakeH3VideoVAE()
+    audio_vae = _FakeH3AudioVAE()
+
+    payload = build_one_frame_latent_tensors(
+        image_frames=torch.zeros(64, 64, 3, dtype=torch.uint8),
+        target_index=24,
+        video_vae=video_vae,
+        silence_audio_latent=torch.zeros(32, 2, 2),
+        cache_seed=123,
+        item_key=str(record.video_path),
+        video_vae_fingerprint="video-fingerprint",
+        audio_vae_fingerprint="audio-fingerprint",
+        media_fingerprints={record.video_path: "target-image", image: "face", video: "motion"},
+        record=record,
+        audio_vae=audio_vae,
+        media_decoder=decoder,
+    )
+
+    assert set(payload.tensors) == {
+        "latents_1x4x4_float32",
+        "latents_audio_32x2x2_float32",
+        AUDIO_PRESENT_KEY,
+        ONE_FRAME_TARGET_INDEX_KEY,
+        "latents_ref_000_image_1x2x4_float32",
+        "latents_ref_001_video_2x4x2_float32",
+        "latents_ref_001_audio_32x2x8_float32",
+    }
+    assert ONE_FRAME_CONTROL_INDICES_KEY not in payload.tensors
+    # references are decoded with the one-frame policy: images capped to the target area,
+    # videos to the released 15 s span (not a target duration, which a single frame lacks)
+    assert [(call[1], call[2]) for call in decoder.visual_calls] == [(ONE_FRAME_REFERENCE_FRAME_CAP, (64, 64))] * 2
+    # the reference video keeps its own audio duration
+    assert decoder.audio_calls[0][1:] == (0, 6400, True)
+    assert [call.shape for call in video_vae.calls] == [(1, 3, 1, 64, 64), (1, 3, 1, 32, 64), (1, 3, 5, 64, 32)]
+    assert payload.metadata["task"] == "ref2va"
+    assert payload.metadata["one_frame"] == "1"
+    assert payload.metadata["one_frame_target_index"] == "24"
+    assert "one_frame_control_indices" not in payload.metadata
+    assert json.loads(payload.metadata["media_fingerprints"]) == {
+        str(record.video_path): "target-image",
+        str(image): "face",
+        str(video): "motion",
+    }
+
+
+@pytest.mark.parametrize(
+    ("record_kwargs", "overrides", "message"),
+    [
+        ({"with_audio_reference": True}, {}, "standalone audio references"),
+        ({}, {"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)], "control_indices": [0]}, "cannot combine"),
+        ({}, {"media_decoder": None}, "media decoder"),
+        ({}, {"audio_vae": None}, "audio VAE"),
+    ],
+)
+def test_build_one_frame_latents_reject_invalid_references(tmp_path: Path, record_kwargs: dict, overrides: dict, message: str):
+    record = _one_frame_reference_record(tmp_path, **record_kwargs)
+    decoder = _FakeH3MediaDecoder(
+        visuals={reference.path: torch.zeros(1, 64, 64, 3, dtype=torch.uint8) for reference in record.references}
+    )
+    video_vae = _FakeH3VideoVAE()
+    inputs = dict(
+        image_frames=torch.zeros(64, 64, 3, dtype=torch.uint8),
+        target_index=24,
+        video_vae=video_vae,
+        silence_audio_latent=torch.zeros(32, 2, 2),
+        cache_seed=0,
+        item_key=str(record.video_path),
+        video_vae_fingerprint="video-fingerprint",
+        audio_vae_fingerprint="audio-fingerprint",
+        media_fingerprints={},
+        record=record,
+        audio_vae=_FakeH3AudioVAE(),
+        media_decoder=decoder,
+    )
+    inputs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        build_one_frame_latent_tensors(**inputs)
+
+    assert video_vae.calls == []
+
+
+def test_one_frame_reference_cache_keys_round_trip_through_the_bucket_collator(tmp_path: Path):
+    item = ItemInfo("view", "a reference caption", (64, 64), (64, 64))
+    item.latent_cache_path = str(tmp_path / "view_0064x0064_mmh3.safetensors")
+    item.text_encoder_output_cache_path = str(tmp_path / "view_mmh3_te.safetensors")
+    latent_tensors = {
+        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
+        "latents_ref_000_image_1x4x4_float32": torch.ones(24, 1, 4, 4),
+        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
+        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
+        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
+    }
+    text_tensors = {
+        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
+        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
+    }
+    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "ref2va", "one_frame": "1"})
+    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "ref2va"})
+
+    manager = BucketBatchManager({(64, 64): [item]}, batch_size=1)
+    batch = manager[0]
+
+    assert batch["latents"].shape == (1, 24, 1, 4, 4)
+    assert batch["latents_ref_000_image"].shape == (1, 24, 1, 4, 4)
+    torch.testing.assert_close(batch["one_frame_target_index"], torch.tensor([24], dtype=torch.int64))
+
+
+def test_h3_image_records_come_from_the_image_jsonl_keyed_by_item_key(tmp_path: Path):
+    target = _touch(tmp_path / "data" / "target.png")
+    face = _touch(tmp_path / "data" / "refs" / "face.png")
+    jsonl = tmp_path / "data" / "items.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            {
+                "image_path": str(target),
+                "caption": "a novel view",
+                "references": [{"type": "image", "path": "refs/face.png"}],
+            }
+        ],
+    )
+    datasource = ImageJsonlDatasource(str(jsonl), control_count_per_image=1)
+
+    records = h3_image_records_from_datasource(datasource, "ref2va")
+
+    # keyed by the JSONL image_path string (ItemInfo.item_key), references resolved from the JSONL directory
+    assert list(records) == [str(target)]
+    record = records[str(target)]
+    assert record.video_path == target
+    assert record.caption == "a novel view"
+    assert [(reference.type, reference.path) for reference in record.references] == [("image", face)]
+    assert record.jsonl_line == 1
+
+    with pytest.raises(ValueError, match="references require task ref2va"):
+        h3_image_records_from_datasource(datasource, "t2va")
+
+
+def test_h3_image_records_require_a_jsonl_for_ref2va_and_reject_duplicates(tmp_path: Path):
+    directory = tmp_path / "images"
+    directory.mkdir()
+    directory_datasource = ImageDirectoryDatasource(str(directory), ".txt", None, 1, False)
+
+    assert h3_image_records_from_datasource(directory_datasource, "t2va") == {}
+    with pytest.raises(ValueError, match="requires image_jsonl_file"):
+        h3_image_records_from_datasource(directory_datasource, "ref2va")
+
+    target = _touch(tmp_path / "target.png")
+    face = _touch(tmp_path / "face.png")
+    jsonl = tmp_path / "items.jsonl"
+    line = {"image_path": str(target), "caption": "c", "references": [{"type": "image", "path": str(face)}]}
+    _write_jsonl(jsonl, [line, line])
+
+    with pytest.raises(ValueError, match="duplicate image_path"):
+        h3_image_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
+
+    _write_jsonl(jsonl, [{"image_path": str(target), "caption": "c"}])
+    with pytest.raises(ValueError, match="at least one visual reference"):
+        h3_image_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
 
 
 def test_h3_latent_writer_rejects_invalid_one_frame_control_indices(tmp_path: Path):

--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -46,6 +46,7 @@ def _load_training_module(monkeypatch):
         H3_AUDIO_SPEC=object(),
         audio_latent_frames=noop,
         parse_inline_references=noop,
+        reject_one_frame_audio_references=noop,
         video_latent_frames=noop,
     )
     _stub(

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -28,9 +28,14 @@ from musubi_tuner.minimax_h3.text_encoder import (
 )
 
 try:
-    from musubi_tuner.minimax_h3_cache_text_encoder_outputs import _ref_teacher_presentation, _text_cache_metadata
+    from musubi_tuner.minimax_h3_cache_text_encoder_outputs import (
+        _ref_teacher_presentation,
+        _reference_visuals,
+        _text_cache_metadata,
+    )
 except ImportError as error:
     _ref_teacher_presentation = None
+    _reference_visuals = None
     _text_cache_metadata = None
     _text_cache_import_error = str(error)
 else:
@@ -175,6 +180,46 @@ def test_ref_teacher_presentation_wraps_the_caption_and_samples_the_target_crop(
     assert presentation.processor_text == f"<Audio 1>: <Video 1>: {VIDEO_PLACEHOLDER}{wrapped}"
     assert presentation.images == ()
     assert [tuple(video_block.shape) for video_block in presentation.videos] == [(3, 32, 32, 3)]
+
+
+@pytest.mark.skipif(_reference_visuals is None, reason="cache script import failed")
+def test_reference_visuals_follow_the_one_frame_reference_policy(tmp_path: Path):
+    # one-frame Ref2VA text caches decode references with the generation policy: images as a
+    # single frame capped to the target area, videos capped to the released span and sampled
+    # at 2 fps, both through the shared decoder cache keyed by that policy
+    image = tmp_path / "face.png"
+    video = tmp_path / "motion.mp4"
+    record = _record(
+        tmp_path,
+        (
+            H3Reference(type="image", path=image),
+            H3Reference(type="video", path=video, audio=None, duration_seconds=2.0),
+        ),
+    )
+
+    class FakeDecoder:
+        def __init__(self):
+            self.calls = []
+
+        def decode_reference_visual(self, reference, *, target_frame_count, target_size):
+            self.calls.append((reference.path, target_frame_count, target_size))
+            frames = 1 if reference.type == "image" else 29
+            return torch.zeros(frames, 32, 32, 3)
+
+    decoder = FakeDecoder()
+    cache = {}
+
+    visuals = _reference_visuals(record, 360, (64, 96), decoder, cache)
+    presentation = build_presentation(record, "ref2va", visuals)
+
+    assert decoder.calls == [(image, 360, (64, 96)), (video, 360, (64, 96))]
+    assert visuals[image].frames.shape == (1, 32, 32, 3)
+    assert visuals[video].frames.shape == (3, 32, 32, 3)
+    assert visuals[video].timestamps == (0.0, 0.5, 1.0)
+    assert presentation.text.startswith(f"<Picture 1>: {IMAGE_PLACEHOLDER}<Video 1>: <0.2 seconds>")
+    # a second item sharing the references reuses the decoded frames
+    _reference_visuals(record, 360, (64, 96), decoder, cache)
+    assert len(decoder.calls) == 2
 
 
 def test_token_tags_cover_expanded_vision_rows_and_both_flanking_tokens():

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -1126,7 +1126,65 @@ def test_one_frame_t2va_batch_rejects_stray_control_indices():
     batch = _one_frame_batch()
     batch["one_frame_control_indices"] = torch.tensor([[0]], dtype=torch.int64)
 
-    with pytest.raises(ValueError, match="T2VA batch cannot carry one_frame_control_indices"):
+    with pytest.raises(ValueError, match="T2VA/Ref2VA batch cannot carry one_frame_control_indices"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+def _one_frame_ref_batch(target_index: int = 24, *, with_video_reference: bool = False):
+    batch = _one_frame_batch(target_index=target_index)
+    batch["latents_ref_000_image"] = torch.ones(1, 24, 1, 4, 4)
+    if with_video_reference:
+        batch["latents_ref_001_video"] = torch.ones(1, 24, 2, 4, 4)
+        batch["latents_ref_001_audio"] = torch.ones(1, 32, 2, 8)
+    return batch
+
+
+@pytest.mark.parametrize("with_video_reference", [False, True])
+def test_one_frame_ref2va_batch_builds_the_reference_layout(monkeypatch, with_video_reference):
+    # references are untimed condition blocks before the target; only the target index enters
+    # the time overrides, exactly like one-frame Ref2VA generation
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="ref2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    transformer = _RecordingTransformer()
+
+    _one_frame_process_batch(trainer, args, _one_frame_ref_batch(with_video_reference=with_video_reference), transformer)
+
+    call = transformer.calls[0]
+    layout = call["layout"]
+    assert layout.task == "ref2va"
+    assert layout.target_video.frames == 1
+    assert layout.target_audio_frames == 2
+    expected_kinds = ["image", "video"] if with_video_reference else ["image"]
+    assert [reference.kind for reference in layout.references] == expected_kinds
+    assert layout.time_overrides.condition_times == ()
+    assert layout.time_overrides.target_time == FRAME_RESCALE * 24
+    assert len(call["visual_condition_latents"]) == (2 if with_video_reference else 1)
+    assert len(call["audio_condition_latents"]) == (1 if with_video_reference else 0)
+    # the silence placeholder stays excluded from audio supervision
+    assert trainer._audio_supervised_seen == 0
+
+
+def test_one_frame_ref2va_batch_rejects_stray_control_indices():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="ref2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_ref_batch()
+    batch["one_frame_control_indices"] = torch.tensor([[0]], dtype=torch.int64)
+
+    with pytest.raises(ValueError, match="T2VA/Ref2VA batch cannot carry one_frame_control_indices"):
+        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
+
+
+def test_one_frame_ref2va_batch_rejects_mixed_fl_conditions():
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(task="ref2va", one_frame=True)
+    trainer.handle_model_specific_args(args)
+    batch = _one_frame_ref_batch()
+    batch["latents_first"] = torch.zeros(1, 24, 1, 4, 4)
+
+    with pytest.raises(ValueError, match="cannot mix FL2VA and Ref2VA"):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
 
 
@@ -1183,7 +1241,6 @@ def test_video_batch_rejects_stray_one_frame_index_tensors(extra_key, message):
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
-        ({"one_frame": True, "task": "ref2va"}, "requires --task t2va or fl2va"),
         ({"one_frame": True, "h3_teacher_matching": True}, "does not support --one_frame"),
     ],
 )
@@ -1192,8 +1249,9 @@ def test_one_frame_training_flag_validations(overrides, message):
         MiniMaxH3NetworkTrainer().handle_model_specific_args(_trainer_args(**overrides))
 
 
-def test_one_frame_training_accepts_the_fl2va_task():
-    MiniMaxH3NetworkTrainer().handle_model_specific_args(_trainer_args(one_frame=True, task="fl2va"))
+@pytest.mark.parametrize("task", ["fl2va", "ref2va"])
+def test_one_frame_training_accepts_every_task(task):
+    MiniMaxH3NetworkTrainer().handle_model_specific_args(_trainer_args(one_frame=True, task=task))
 
 
 def test_one_frame_training_records_provenance_metadata():
@@ -1219,8 +1277,12 @@ def test_one_frame_sample_normalization_parses_the_of_option():
 @pytest.mark.parametrize(
     ("args_overrides", "sample", "message"),
     [
-        ({"task": "ref2va"}, {"prompt": "x", "frame_count": 1}, "t2va and fl2va only"),
         ({}, {"prompt": "x", "frame_count": 1, "one_frame": "target_index=0,control_index=0"}, "control_index"),
+        (
+            {"task": "ref2va", "sample_prompts": "prompts.txt"},
+            {"prompt": "x", "frame_count": 1, "ref": ["face.png"], "one_frame": "target_index=0,control_index=0"},
+            "REF2VA one-frame training sample does not accept control_index",
+        ),
         ({}, {"prompt": "x", "frame_count": 124, "one_frame": "target_index=24"}, r"require --f 1"),
         # fl2va one-frame: control_index is mandatory, one entry per provided frame
         (
@@ -1263,6 +1325,30 @@ def test_one_frame_fl2va_sample_normalization_parses_control_indices(tmp_path):
     assert sample["frame_count"] == 1
     assert sample["one_frame_target_index"] == 24
     assert sample["one_frame_control_indices"] == (0,)
+
+
+def test_one_frame_ref2va_sample_normalization_accepts_inline_refs(tmp_path):
+    prompt_file = tmp_path / "prompts.txt"
+    prompt_file.touch()
+    (tmp_path / "face.png").touch()
+    args = _trainer_args(task="ref2va", one_frame=True, sample_prompts=str(prompt_file))
+
+    sample = _normalize_h3_sample_parameter(
+        args,
+        {
+            "prompt": "a novel view",
+            "frame_count": 1,
+            "ref": ["face.png"],
+            "one_frame": "target_index=24",
+            "width": 64,
+            "height": 64,
+        },
+    )
+
+    assert sample["frame_count"] == 1
+    assert sample["one_frame_target_index"] == 24
+    assert sample["one_frame_control_indices"] is None
+    assert sample["ref"] == ["face.png"]
 
 
 def test_t2va_draws_no_condition_noise(monkeypatch):
@@ -1720,6 +1806,34 @@ def test_guidance_loss_uncond_layout_carries_one_frame_fl_condition_roles(tmp_pa
         assert tuple(segment.role for segment in call["layout"].segments if segment.kind == "visual_condition") == ("first",)
     assert uncond_call["layout"].time_overrides == cond_call["layout"].time_overrides
     assert uncond_call["layout"].time_overrides.condition_times == (0.0,)
+    assert metrics["guidance/applied"] == 1.0
+
+
+def test_guidance_loss_uncond_layout_carries_one_frame_references(tmp_path, monkeypatch):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(
+        task="ref2va",
+        one_frame=True,
+        h3_guidance_loss_scale=3.0,
+        h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
+    )
+    trainer.handle_model_specific_args(args)
+    transformer = _RecordingTransformer()
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
+
+    _, metrics = _one_frame_process_batch(trainer, args, _one_frame_ref_batch(with_video_reference=True), transformer)
+
+    assert len(transformer.calls) == 2
+    uncond_call, cond_call = transformer.calls
+    for call in (uncond_call, cond_call):
+        assert call["layout"].task == "ref2va"
+        assert [reference.kind for reference in call["layout"].references] == ["image", "video"]
+    assert uncond_call["layout"].references == cond_call["layout"].references
+    assert uncond_call["layout"].time_overrides == cond_call["layout"].time_overrides
+    # the probe swaps only the text rows; the reference conditions are shared
+    assert len(uncond_call["visual_condition_latents"]) == 2
+    assert len(uncond_call["audio_condition_latents"]) == 1
     assert metrics["guidance/applied"] == 1.0
 
 


### PR DESCRIPTION
## Summary

Adds one-frame (image target) **Ref2VA** training: `--task ref2va --one_frame` on both cache scripts and the trainer. Each image target is conditioned on its own ordered references, presented exactly as in one-frame Ref2VA generation (untimed reference blocks before the target, `<Picture i>`/`<Video i>` visuals in the text). Closes the "Ref2VA one-frame training is not implemented yet" gap in `docs/minimax_h3_1f.md`.

Intended uses: identity/character LoRAs on (reference image → different target image of the same subject) pairs, view-synthesis / restyling pairs. It is also the presentation/cache groundwork for a reference-conditioned teacher (follow-up).

### Dataset input

- `image_jsonl_file` lines carry `image_path`, `caption`, and ordered `references` (same schema and limits as the video Ref2VA JSONL; reference paths resolve from the JSONL directory, `image_path` follows the usual image JSONL rule).
- `image_directory` datasets cannot carry references; control images (`control_path` / `fp_1f_clean_indices`) cannot be combined with references; `references` on a t2va/fl2va JSONL is rejected.

### Caches

- Latent cache: target token, silence placeholder, target index, plus the references under the numbered `latents_ref_{i:03d}_{image|video|audio}` keys of video Ref2VA caches. Same policy as one-frame generation: image references canvas-capped to the target area, video references keep their released 15 s span and audio, standalone audio references rejected. Reference files join the cache identity (`--skip_existing` rebuilds on change).
- Text cache: Ref2VA presentation with the reference visuals embedded (2 fps sampling for videos), reference files in the presentation fingerprint.

### Trainer

- `_runtime_batch_plan` accepts reference roles on one-frame batches: `ref2va` layout with `H3TimeOverrides(condition_times=(), target_time=...)`; FL2VA control indices are rejected on such batches.
- `--one_frame` no longer restricts `--task`; training-time samples accept `--f 1` with `--ref` (standalone audio references rejected like the generation CLI).

### Shared pieces

- `ONE_FRAME_REFERENCE_FRAME_CAP`, `reject_one_frame_audio_references`, `h3_image_records_from_datasource` move to / land in `minimax_h3/media.py`; the generation CLI uses the shared rejection.
- Reference encoding is extracted into `_encode_reference_conditions` and shared by the video and one-frame latent paths; the text-cache reference visuals into `_reference_visuals`.
- `validate_h3_image_dataset_task` holds the one-frame task matrix for both cache scripts.

### Bug fix (pre-existing)

The guidance-loss uncond layout rebuild recovered FL2VA condition roles from every `visual_condition` segment, which also matched Ref2VA reference blocks and made `build_h3_layout` reject the layout. This affected video Ref2VA + `--h3_guidance_loss_scale` as well. Roles are now recovered only for `fl2va` layouts.

### Known limitations / follow-ups

- `ss_minimax_h3_base_family` is derived from the task, so `--task ref2va` trained on the FL2VA base records `ref2va` (documented).
- Control-image datasets (Qwen-Image-Edit style `control_path`) as the reference input are feasible (the shared layer has no size constraint; only the H3 resize policy is in the way) and left for a follow-up.
- `--h3_teacher_matching` × `--one_frame` remains unsupported.

## Test plan

- [x] 596 tests pass (11 new: one-frame reference caches, image JSONL records, collator round trip, reference text visuals, trainer layout/validation, sample normalization, guidance-loss uncond layout with references), ruff clean.
- [x] Smoke S1 (cache): keys/metadata as expected, `--skip_existing` staleness on reference change, misconfiguration errors.
- [x] Smoke S2 (train): 5-50 steps on the FL2VA base with guidance loss, training-time `--f 1 --ref` samples reproduce the referenced identity; video fl2va regression run unchanged.
- [ ] Learning-quality check on a real character set (base cannot reproduce the targets from the reference) — deferred, not needed for the plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2t3n5HZ3sk6mpmRFdnDKq
