### PR TITLE
fix: handle corrupted cache files instead of hanging silently

### DIFF
--- a/docs/dataset_config.md
+++ b/docs/dataset_config.md
@@ -722,3 +722,51 @@ resolution = [960, 544] # required if general resolution is not set
 -->
 
 The metadata with .json file will be supported in the near future.
+
+## Skipping Corrupted Cache Files
+
+`skip_corrupted_cache` is an optional bool (default `false`), settable in `[general]` or per-`[[datasets]]`, following the same fallback rule as `batch_size`/`enable_bucket`/etc. By default, if a cached latent or text-encoder `.safetensors` file is corrupted (e.g. truncated by a disk-full write or interrupted transfer), training either fails at dataset setup with a clear error naming the file, or — if the corruption is only in the tensor data and not the header — the failure surfaces as a clear `RuntimeError` naming the file when the item is read by a DataLoader worker during training. Setting `skip_corrupted_cache = true` instead validates every cache file up front (once, at dataset setup) and silently drops any item whose cache is unreadable, logging a warning with the file path.
+
+```toml
+[general]
+skip_corrupted_cache = true
+```
+
+This adds a one-time cost at dataset setup (every cache file is opened once to validate it), so it's off by default. Use `verify_cache_files.py` (see below) to find and clean up corrupted cache files ahead of time instead, if you'd rather not pay this cost on every training start.
+
+<details>
+<summary>日本語</summary>
+
+`skip_corrupted_cache`はオプションのbool値（デフォルトは`false`）で、`batch_size`や`enable_bucket`などと同様に`[general]`または各`[[datasets]]`に設定できます。デフォルトでは、キャッシュされた潜在変数やテキストエンコーダの`.safetensors`ファイルが破損している場合（ディスクフルや転送中断による切り詰めなど）、データセットのセットアップ時にファイル名を明示したエラーで学習が失敗するか、ヘッダーではなくテンソルデータ部分のみが破損している場合は、学習中にDataLoaderワーカーがその項目を読み込む際に、ファイル名を明示した`RuntimeError`として失敗が表面化します。`skip_corrupted_cache = true`を設定すると、データセットのセットアップ時に一度だけ全キャッシュファイルを事前に検証し、読み込めない項目は警告ログを出力してサイレントにスキップします。
+
+```toml
+[general]
+skip_corrupted_cache = true
+```
+
+これはデータセットのセットアップ時に一度だけコストがかかるため（全キャッシュファイルを一度開いて検証するため）、デフォルトでは無効です。毎回の学習開始時にこのコストを払いたくない場合は、代わりに`verify_cache_files.py`（後述）を使って事前に破損キャッシュファイルを見つけて整理してください。
+
+</details>
+
+## Verifying Cache Files
+
+`verify_cache_files.py` scans every cached latent and text-encoder `.safetensors` file referenced by a dataset config and reports any that fail to load (corrupted or truncated). It doesn't modify anything unless `--delete_corrupted` is passed.
+
+```bash
+python src/musubi_tuner/verify_cache_files.py --dataset_config path/to/toml --architecture wan
+```
+
+`--architecture` is the short or full architecture name used when caching (e.g. `wan`, `hv`, `qi`, `flux_kontext`). `--num_workers` controls read parallelism (default: cpu count - 1). Pass `--delete_corrupted` to remove the corrupted files it finds after reporting them (irreversible — re-run the architecture's cache scripts afterward to regenerate them).
+
+<details>
+<summary>日本語</summary>
+
+`verify_cache_files.py`は、データセット設定が参照する全てのキャッシュ済み潜在変数・テキストエンコーダ`.safetensors`ファイルをスキャンし、読み込みに失敗するもの（破損または切り詰められたもの）を報告します。`--delete_corrupted`を指定しない限り、何も変更しません。
+
+```bash
+python src/musubi_tuner/verify_cache_files.py --dataset_config path/to/toml --architecture wan
+```
+
+`--architecture`はキャッシュ作成時に使用したアーキテクチャの短縮名またはフル名です（例：`wan`、`hv`、`qi`、`flux_kontext`）。`--num_workers`は読み込みの並列数を制御します（デフォルト：CPU数-1）。`--delete_corrupted`を指定すると、報告後に見つかった破損ファイルを削除します（元に戻せません。削除後は該当アーキテクチャのキャッシュスクリプトを再実行して再生成してください）。
+
+</details>

--- a/src/musubi_tuner/dataset/bucket.py
+++ b/src/musubi_tuner/dataset/bucket.py
@@ -236,6 +236,16 @@ class BucketBatchManager:
     def __len__(self):
         return len(self.bucket_batch_indices)
 
+    @staticmethod
+    def _load_cache_file(path: str) -> dict[str, torch.Tensor]:
+        try:
+            return load_file(path)
+        except Exception as e:  # noqa: BLE001 - any load failure means the cache file is corrupted/unreadable
+            # safetensors raises safetensors_rust.SafetensorError, a Rust-extension exception that fails to
+            # pickle when a DataLoader worker sends it back to the main process, silently killing the worker's
+            # feeder thread and hanging training with no visible error. Re-raise as a plain, picklable exception.
+            raise RuntimeError(f"Failed to load cache file, it may be corrupted: {path}: {e}") from None
+
     def __getitem__(self, idx):
         bucket_reso, batch_idx = self.bucket_batch_indices[idx]
         bucket = self.buckets[bucket_reso]
@@ -245,8 +255,8 @@ class BucketBatchManager:
         batch_tensor_data = {}
         varlen_keys = set()
         for item_info in bucket[start:end]:
-            sd_latent = load_file(item_info.latent_cache_path)
-            sd_te = load_file(item_info.text_encoder_output_cache_path)
+            sd_latent = self._load_cache_file(item_info.latent_cache_path)
+            sd_te = self._load_cache_file(item_info.text_encoder_output_cache_path)
             sd = {**sd_latent, **sd_te}
 
             # TODO refactor this

--- a/src/musubi_tuner/dataset/config_utils.py
+++ b/src/musubi_tuner/dataset/config_utils.py
@@ -40,6 +40,7 @@ class BaseDatasetParams:
     cache_directory: Optional[str] = None
     debug_dataset: bool = False
     architecture: str = "no_default"  # short style like "hv" or "wan"
+    skip_corrupted_cache: bool = False
 
 
 @dataclass
@@ -116,6 +117,7 @@ class ConfigSanitizer:
         "resolution": functools.partial(__validate_and_convert_scalar_or_twodim.__func__, int),
         "enable_bucket": bool,
         "bucket_no_upscale": bool,
+        "skip_corrupted_cache": bool,
     }
     IMAGE_DATASET_DISTINCT_SCHEMA = {
         "image_directory": str,

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -115,6 +115,7 @@ class BaseDataset(torch.utils.data.Dataset):
         cache_directory: Optional[str] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        skip_corrupted_cache: bool = False,
     ):
         self.resolution = resolution
         self.caption_extension = caption_extension
@@ -125,6 +126,7 @@ class BaseDataset(torch.utils.data.Dataset):
         self.cache_directory = cache_directory
         self.debug_dataset = debug_dataset
         self.architecture = architecture
+        self.skip_corrupted_cache = skip_corrupted_cache
         self.seed = None
         self.current_epoch = 0
         self.shared_epoch = None
@@ -142,6 +144,15 @@ class BaseDataset(torch.utils.data.Dataset):
             "bucket_no_upscale": bool(self.bucket_no_upscale),
         }
         return metadata
+
+    @staticmethod
+    def _is_cache_file_loadable(path: str) -> bool:
+        try:
+            BucketBatchManager._load_cache_file(path)
+            return True
+        except Exception as e:  # noqa: BLE001 - any load failure means the cache file is corrupted/unreadable
+            logger.warning(f"Skipping corrupted cache file: {e}")
+            return False
 
     def get_all_latent_cache_files(self):
         return glob.glob(os.path.join(self.cache_directory, f"*_{self.architecture}.safetensors"))
@@ -287,6 +298,7 @@ class ImageDataset(BaseDataset):
         control_resolution: Optional[Tuple[int, int]] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        skip_corrupted_cache: bool = False,
     ):
         super(ImageDataset, self).__init__(
             resolution,
@@ -298,6 +310,7 @@ class ImageDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            skip_corrupted_cache,
         )
         self.image_directory = image_directory
         self.image_jsonl_file = image_jsonl_file
@@ -540,7 +553,13 @@ class ImageDataset(BaseDataset):
             # resized to the bucket resolution share that resolution but can still differ in *count*.
             # find_keys returns the keys sorted, so the per-control order (and the index<->shape pairing,
             # which remove_dtype_suffix keeps in each element) is deterministic across cache files.
-            control_keys = safetensors_utils.find_keys(cache_file, starts_with="latents_control_")
+            try:
+                control_keys = safetensors_utils.find_keys(cache_file, starts_with="latents_control_")
+            except Exception as e:  # noqa: BLE001 - any read failure means the cache file is corrupted/unreadable
+                if self.skip_corrupted_cache:
+                    logger.warning(f"Skipping corrupted cache file: {cache_file}: {e}")
+                    continue
+                raise RuntimeError(f"Failed to read cache file, it may be corrupted: {cache_file}: {e}") from None
             if control_keys:
                 # key: latents_control_{i}_FxHxW_dtype -> "latents_control_{i}_FxHxW" (index + shape)
                 control_shapes = [remove_dtype_suffix(key) for key in control_keys]
@@ -548,6 +567,12 @@ class ImageDataset(BaseDataset):
 
             item_info = ItemInfo(item_key, "", image_size, bucket_reso, latent_cache_path=cache_file)
             item_info.text_encoder_output_cache_path = text_encoder_output_cache_file
+
+            if self.skip_corrupted_cache and (
+                not self._is_cache_file_loadable(item_info.latent_cache_path)
+                or not self._is_cache_file_loadable(item_info.text_encoder_output_cache_path)
+            ):
+                continue
 
             bucket = bucketed_item_info.get(bucket_reso, [])
             for _ in range(self.num_repeats):
@@ -603,6 +628,7 @@ class VideoDataset(BaseDataset):
         fp_latent_window_size: Optional[int] = 9,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        skip_corrupted_cache: bool = False,
     ):
         super(VideoDataset, self).__init__(
             resolution,
@@ -614,6 +640,7 @@ class VideoDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            skip_corrupted_cache,
         )
         self.video_directory = video_directory
         self.video_jsonl_file = video_jsonl_file
@@ -882,6 +909,12 @@ class VideoDataset(BaseDataset):
             bucket_reso = (*bucket_reso, frame_count)
             item_info = ItemInfo(item_key, "", image_size, bucket_reso, frame_count=frame_count, latent_cache_path=cache_file)
             item_info.text_encoder_output_cache_path = text_encoder_output_cache_file
+
+            if self.skip_corrupted_cache and (
+                not self._is_cache_file_loadable(item_info.latent_cache_path)
+                or not self._is_cache_file_loadable(item_info.text_encoder_output_cache_path)
+            ):
+                continue
 
             bucket = bucketed_item_info.get(bucket_reso, [])
             for _ in range(self.num_repeats):

--- a/src/musubi_tuner/verify_cache_files.py
+++ b/src/musubi_tuner/verify_cache_files.py
@@ -1,0 +1,134 @@
+import argparse
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from musubi_tuner.dataset import config_utils
+from musubi_tuner.dataset.architectures import (
+    ARCHITECTURE_FLUX_2_DEV,
+    ARCHITECTURE_FLUX_2_DEV_FULL,
+    ARCHITECTURE_FLUX_2_KLEIN_4B,
+    ARCHITECTURE_FLUX_2_KLEIN_4B_FULL,
+    ARCHITECTURE_FLUX_2_KLEIN_9B,
+    ARCHITECTURE_FLUX_2_KLEIN_9B_FULL,
+    ARCHITECTURE_FLUX_KONTEXT,
+    ARCHITECTURE_FLUX_KONTEXT_FULL,
+    ARCHITECTURE_FRAMEPACK,
+    ARCHITECTURE_FRAMEPACK_FULL,
+    ARCHITECTURE_HIDREAM_O1,
+    ARCHITECTURE_HIDREAM_O1_FULL,
+    ARCHITECTURE_HUNYUAN_VIDEO,
+    ARCHITECTURE_HUNYUAN_VIDEO_1_5,
+    ARCHITECTURE_HUNYUAN_VIDEO_1_5_FULL,
+    ARCHITECTURE_HUNYUAN_VIDEO_FULL,
+    ARCHITECTURE_IDEOGRAM4,
+    ARCHITECTURE_IDEOGRAM4_FULL,
+    ARCHITECTURE_KANDINSKY5,
+    ARCHITECTURE_KANDINSKY5_FULL,
+    ARCHITECTURE_KREA2,
+    ARCHITECTURE_KREA2_FULL,
+    ARCHITECTURE_QWEN_IMAGE,
+    ARCHITECTURE_QWEN_IMAGE_EDIT,
+    ARCHITECTURE_QWEN_IMAGE_EDIT_FULL,
+    ARCHITECTURE_QWEN_IMAGE_FULL,
+    ARCHITECTURE_QWEN_IMAGE_LAYERED,
+    ARCHITECTURE_QWEN_IMAGE_LAYERED_FULL,
+    ARCHITECTURE_WAN,
+    ARCHITECTURE_Z_IMAGE,
+    ARCHITECTURE_Z_IMAGE_FULL,
+)
+from musubi_tuner.dataset.bucket import BucketBatchManager
+from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# short name -> full/short aliases accepted on the CLI
+ARCHITECTURE_CHOICES = {
+    ARCHITECTURE_HUNYUAN_VIDEO: [ARCHITECTURE_HUNYUAN_VIDEO, ARCHITECTURE_HUNYUAN_VIDEO_FULL],
+    ARCHITECTURE_WAN: [ARCHITECTURE_WAN, "wan2.1", "wan2.2"],
+    ARCHITECTURE_FRAMEPACK: [ARCHITECTURE_FRAMEPACK, ARCHITECTURE_FRAMEPACK_FULL],
+    ARCHITECTURE_FLUX_KONTEXT: [ARCHITECTURE_FLUX_KONTEXT, ARCHITECTURE_FLUX_KONTEXT_FULL],
+    ARCHITECTURE_FLUX_2_DEV: [ARCHITECTURE_FLUX_2_DEV, ARCHITECTURE_FLUX_2_DEV_FULL],
+    ARCHITECTURE_FLUX_2_KLEIN_4B: [ARCHITECTURE_FLUX_2_KLEIN_4B, ARCHITECTURE_FLUX_2_KLEIN_4B_FULL],
+    ARCHITECTURE_FLUX_2_KLEIN_9B: [ARCHITECTURE_FLUX_2_KLEIN_9B, ARCHITECTURE_FLUX_2_KLEIN_9B_FULL],
+    ARCHITECTURE_QWEN_IMAGE: [ARCHITECTURE_QWEN_IMAGE, ARCHITECTURE_QWEN_IMAGE_FULL],
+    ARCHITECTURE_QWEN_IMAGE_EDIT: [ARCHITECTURE_QWEN_IMAGE_EDIT, ARCHITECTURE_QWEN_IMAGE_EDIT_FULL],
+    ARCHITECTURE_QWEN_IMAGE_LAYERED: [ARCHITECTURE_QWEN_IMAGE_LAYERED, ARCHITECTURE_QWEN_IMAGE_LAYERED_FULL],
+    ARCHITECTURE_KANDINSKY5: [ARCHITECTURE_KANDINSKY5, ARCHITECTURE_KANDINSKY5_FULL],
+    ARCHITECTURE_HUNYUAN_VIDEO_1_5: [ARCHITECTURE_HUNYUAN_VIDEO_1_5, ARCHITECTURE_HUNYUAN_VIDEO_1_5_FULL],
+    ARCHITECTURE_Z_IMAGE: [ARCHITECTURE_Z_IMAGE, ARCHITECTURE_Z_IMAGE_FULL],
+    ARCHITECTURE_HIDREAM_O1: [ARCHITECTURE_HIDREAM_O1, ARCHITECTURE_HIDREAM_O1_FULL],
+    ARCHITECTURE_IDEOGRAM4: [ARCHITECTURE_IDEOGRAM4, ARCHITECTURE_IDEOGRAM4_FULL],
+    ARCHITECTURE_KREA2: [ARCHITECTURE_KREA2, ARCHITECTURE_KREA2_FULL],
+}
+
+
+def resolve_architecture(name: str) -> str:
+    for short_name, aliases in ARCHITECTURE_CHOICES.items():
+        if name in aliases:
+            return short_name
+    all_aliases = sorted({alias for aliases in ARCHITECTURE_CHOICES.values() for alias in aliases})
+    raise ValueError(f"Unknown architecture: {name}. Valid options: {all_aliases}")
+
+
+def check_file(path: str) -> tuple[str, bool, str]:
+    try:
+        BucketBatchManager._load_cache_file(path)
+        return path, True, ""
+    except Exception as e:  # noqa: BLE001 - any load failure means the cache file is corrupted/unreadable
+        return path, False, str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify cached latent/text-encoder .safetensors files are loadable.")
+    parser.add_argument("--dataset_config", type=str, required=True, help="path to dataset config .toml file")
+    parser.add_argument("--architecture", type=str, required=True, help="architecture short/full name, e.g. wan, hv, qi")
+    parser.add_argument("--num_workers", type=int, default=None, help="number of workers, default is cpu count-1")
+    parser.add_argument(
+        "--delete_corrupted", action="store_true", help="delete corrupted cache files after reporting them (irreversible)"
+    )
+    args = parser.parse_args()
+
+    architecture = resolve_architecture(args.architecture)
+
+    blueprint_generator = BlueprintGenerator(ConfigSanitizer())
+    logger.info(f"Load dataset config from {args.dataset_config}")
+    user_config = config_utils.load_user_config(args.dataset_config)
+    blueprint = blueprint_generator.generate(user_config, args, architecture=architecture)
+    dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group)
+
+    cache_files = []
+    for dataset in dataset_group.datasets:
+        cache_files.extend(dataset.get_all_latent_cache_files())
+        cache_files.extend(dataset.get_all_text_encoder_output_cache_files())
+    cache_files = sorted(set(cache_files))
+
+    logger.info(f"Found {len(cache_files)} cache files to verify")
+    if not cache_files:
+        return
+
+    num_workers = args.num_workers if args.num_workers is not None else max(1, os.cpu_count() - 1)
+    corrupted = []
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        futures = [executor.submit(check_file, path) for path in cache_files]
+        for i, future in enumerate(as_completed(futures)):
+            path, ok, error = future.result()
+            if not ok:
+                corrupted.append(path)
+                logger.error(f"Corrupted cache file: {path}: {error}")
+            if (i + 1) % 500 == 0:
+                logger.info(f"Checked {i + 1}/{len(cache_files)} cache files")
+
+    logger.info(f"Checked {len(cache_files)} cache files, found {len(corrupted)} corrupted")
+    for path in corrupted:
+        print(path)
+
+    if corrupted and args.delete_corrupted:
+        for path in corrupted:
+            os.remove(path)
+            logger.info(f"Deleted corrupted cache file: {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add resolution for #1041

Issue is if the cache is corrupted it will throw an error inside the dataloader but block the training indefinitely. This adds some work-around for the issue (skipping) and a validation script to detect corrupted cache files instead of needing to recache everything. 

## Summary
- `safetensors.torch.load_file` raises `safetensors_rust.SafetensorError`, a Rust-extension exception that fails to pickle when a DataLoader worker sends it back through the multiprocessing queue — the worker's feeder thread dies silently and training hangs with no visible error.
- Wrap cache loads in `BucketBatchManager.__getitem__`, and the control-key header read in `prepare_for_training`, so any load failure surfaces as a plain, picklable `RuntimeError` naming the exact corrupted file instead of hanging.
- Add an opt-in per-dataset TOML option `skip_corrupted_cache` (default `false`) that validates every cache file once at dataset setup and silently skips items whose cache is unreadable, logging a warning.
- Add a standalone `verify_cache_files.py` script to scan all cache files referenced by a dataset config and report (optionally delete) corrupted ones ahead of a training run.
- Document both in `docs/dataset_config.md` (EN + JP).

## Test plan
- [x] `uv run --with pytest pytest tests/ -q` — full suite passes
- [x] Manually reproduced a corrupted `.safetensors` cache pair and verified:
  - `verify_cache_files.py` correctly reports both files as corrupted
  - `skip_corrupted_cache=True` skips the corrupted item with a warning
  - default behavior now raises a clear, picklable `RuntimeError` naming the file instead of hanging