### PR TITLE
Fix MiniMax-H3 SDPA noise past ~100k rows: materialize the fused-qkv value view

### DIFF
--- a/src/musubi_tuner/minimax_h3/model.py
+++ b/src/musubi_tuner/minimax_h3/model.py
@@ -394,6 +394,19 @@ def _apply_rope_split_half(hidden_states: torch.Tensor, rotation_table: torch.Te
     return torch.cat((rotary, hidden_states[..., 2 * pairs :]), dim=-1)
 
 
+def _element_extent(tensor: torch.Tensor) -> int:
+    """Highest storage element index addressable through the view, plus one."""
+    return tensor.storage_offset() + sum((size - 1) * stride for size, stride in zip(tensor.shape, tensor.stride())) + 1
+
+
+# torch SDPA's memory-efficient backend computes block base addresses in int32, so a view
+# whose element offsets pass 2^31 silently reads wrapped memory (verified: with the fused-qkv
+# value view, every row from the first 128-aligned block past the line is corrupt, turning
+# the whole sample into noise). The released 15 s maximum at 1344x768 packs ~109k rows and
+# crosses the line at row 99,968.
+_INT32_SAFE_EXTENT = 2**31
+
+
 class Attention(nn.Module):
     def __init__(
         self,
@@ -424,6 +437,11 @@ class Attention(nn.Module):
         query = self.q_norm(query.reshape(batch_size, sequence_length, self.num_heads, self.head_dim))
         key = self.k_norm(key.reshape(batch_size, sequence_length, self.num_heads, self.head_dim))
         value = value.reshape(batch_size, sequence_length, self.num_heads, self.head_dim)
+        # query/key leave the RMSNorms as fresh contiguous tensors, but value is still a view
+        # into the fused qkv buffer (sequence stride 3 * inner_dim): materialize it before its
+        # offsets outgrow int32 address math in the SDPA backends
+        if _element_extent(value) > _INT32_SAFE_EXTENT:
+            value = value.contiguous()
         if rotation_table is not None:
             query = _apply_rope_split_half(query, rotation_table)
             key = _apply_rope_split_half(key, rotation_table)

--- a/tests/test_minimax_h3_attention_extent.py
+++ b/tests/test_minimax_h3_attention_extent.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from musubi_tuner.minimax_h3 import model as h3_model
+from musubi_tuner.minimax_h3.model import _INT32_SAFE_EXTENT, _element_extent, Attention
+
+
+def _fused_value_view(batch: int, seq: int, heads: int, head_dim: int) -> tuple[torch.Tensor, torch.Tensor]:
+    inner = heads * head_dim
+    fused = torch.arange(batch * seq * 3 * inner, dtype=torch.float32).reshape(batch, seq, 3 * inner)
+    value = fused.split(inner, dim=-1)[2].reshape(batch, seq, heads, head_dim)
+    return fused, value
+
+
+def test_element_extent_of_fused_value_view_spans_the_buffer():
+    fused, value = _fused_value_view(batch=1, seq=4, heads=2, head_dim=3)
+    assert not value.is_contiguous()
+    # the value view's last element is the last element of the fused buffer
+    assert _element_extent(value) == fused.numel()
+    assert _element_extent(fused) == fused.numel()
+    assert _element_extent(value.contiguous()) == value.numel()
+
+
+def test_element_extent_h3_scale_decision_boundary():
+    # H3 dims: heads 56 x dim 128, fused width 21504. The strided value view crosses the
+    # int32 line between the released 277f (~85k rows, clean in practice) and 362f
+    # (~109k rows, corrupted by SDPA's memory-efficient backend before the guard).
+    def fake_value_view(seq: int) -> SimpleNamespace:
+        inner = 56 * 128
+        return SimpleNamespace(
+            storage_offset=lambda: 2 * inner,
+            shape=(1, seq, 56, 128),
+            stride=lambda: (seq * 3 * inner, 3 * inner, 128, 1),
+        )
+
+    # the view ends at the fused buffer's end, so its extent is exactly seq * 21504:
+    # 99,864 * 21504 = 2,147,475,456 is the last size inside int32
+    assert _element_extent(fake_value_view(85_000)) <= _INT32_SAFE_EXTENT
+    assert _element_extent(fake_value_view(99_864)) <= _INT32_SAFE_EXTENT
+    assert _element_extent(fake_value_view(99_865)) > _INT32_SAFE_EXTENT
+    assert _element_extent(fake_value_view(110_500)) > _INT32_SAFE_EXTENT
+
+
+def test_attention_forward_materializes_oversized_value_view(monkeypatch):
+    torch.manual_seed(0)
+    attention = Attention(
+        hidden_size=8,
+        num_heads=2,
+        head_dim=4,
+        qk_norm_eps=1e-6,
+        attn_mode="sdpa",
+        split_attn=False,
+        dtype=torch.float32,
+    )
+    hidden = torch.randn(1, 5, 8)
+    reference = attention(hidden)
+    # force the guard on and make sure the contiguous() path is taken and harmless
+    monkeypatch.setattr(h3_model, "_INT32_SAFE_EXTENT", 0)
+    contiguized = attention(hidden)
+    assert torch.allclose(reference, contiguized, atol=1e-6)


### PR DESCRIPTION
## Problem

MiniMax-H3 generation with the default `--attn_mode sdpa` produces pure noise (video and audio) once the packed sequence reaches ~100k rows. The released **15 s maximum at 1344x768 (~109k rows) is affected with default settings**; 277f-class runs (~85k rows) are fine. Discovered during 30-second temporal-stretch probes (which pack the same row count as the released maximum).

## Cause

torch SDPA's memory-efficient backend (what auto-selection picks here; FA build absent on Windows) computes KV block base addresses in **int32**. H3's attention passes `value` as a **view into the fused qkv buffer** with sequence stride `3 * inner_dim = 21504`, so the view's element extent is `S * 21504` and crosses 2^31 at **S = 99,865**. From the first 128-aligned KV block whose base offset wraps (**row 99,968**), the backend silently reads wrapped memory; the garbage values feed every attention output row and, through 50 blocks, the whole sample collapses to noise. `query`/`key` are unaffected because the RMSNorms already return fresh contiguous tensors — only `value` keeps the strided view.

Verified with a standalone repro against an exact fp32 reference at H3's shape (56 heads x 128 dim, bf16):

- contiguous q/k/v: **all backends exact** up to S = 110.5k (max err 1e-4 = bf16 floor)
- strided value, efficient backend, one-hot attention probe: `first_bad_row = 99,968` **identically at S = 105,000 and S = 110,500** (an S-independent absolute row threshold — the address-overflow signature), every row past it corrupted, max err ~12.8
- same inputs on the cudnn backend: exact (it materializes internally)

## Fix

Compute the value view's element extent and call `.contiguous()` only when it exceeds 2^31. No copy for ordinary sizes; at 110k rows the copy is ~1.6 GB / ~2 ms per layer, negligible against the step time at that scale.

## Testing

- New `tests/test_minimax_h3_attention_extent.py`: fused-view extent computation, the H3-scale decision boundary (99,864 in / 99,865 out), and forward-pass equivalence when the guard forces the copy
- Full `minimax_h3` suite: 448 passed
- Hardware: 362f generation with `--attn_mode sdpa` now samples cleanly (previously noise); `--attn_mode sageattn` output was already clean and is unchanged

An upstream PyTorch report with the minimal repro is planned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DM7ZNuT9BjTkhvRaT1xmRB