### PR TITLE
Fix --attn_mode sdpa not working in shared attention backends

### DIFF
--- a/src/musubi_tuner/hunyuan_model/attention.py
+++ b/src/musubi_tuner/hunyuan_model/attention.py
@@ -127,6 +127,8 @@ def attention(
     q, k, v = q_or_qkv_list if type(q_or_qkv_list) == list else (q_or_qkv_list, k, v)
     if type(q_or_qkv_list) == list:
         q_or_qkv_list.clear()
+    if mode == "sdpa":
+        mode = "torch"
     split_attn = total_len is not None
     if (split_attn or cu_seqlens_q is None) and mode == "sageattn":
         mode = "sageattn_fixlen"

--- a/src/musubi_tuner/modules/attention.py
+++ b/src/musubi_tuner/modules/attention.py
@@ -37,6 +37,10 @@ class AttentionParams:
     cu_seqlens: Optional[torch.Tensor] = None
     max_seqlen: Optional[int] = None
 
+    def __post_init__(self):
+        if self.attn_mode == "sdpa":
+            self.attn_mode = "torch"
+
     @staticmethod
     def create_attention_params(attn_mode: Optional[str], split_attn: bool) -> "AttentionParams":
         return AttentionParams(attn_mode, split_attn)


### PR DESCRIPTION
--attn_mode sdpa is listed as a valid argparse choice but has no implementation branch in either dispatcher — modules/attention.py raises "Unsupported attention mode: sdpa" and hunyuan_model/attention.py hits KeyError: 'sdpa'. The underlying implementation is PyTorch's scaled-dot-product attention, already present as "torch".

Adds "sdpa" as an alias for "torch" at both entry points: AttentionParams.__post_init__ (covers all shared-attention backends) and the top of hunyuan_model/attention.attention() (covers the Hunyuan path before the MEMORY_LAYOUT lookup).

Fixes #1077.