### PR TITLE
Decouple MiniMax-H3 record building from the datasource implementation

### DIFF
--- a/docs/dataset_config.md
+++ b/docs/dataset_config.md
@@ -122,12 +122,16 @@ For Qwen-Image-Layered training, set `multiple_target = true`. Also, in the meta
 {"image_path_0": "/path/to/image2_base.png", "image_path_1": "/path/to/image2_layer1.png", "image_path_2": "/path/to/image2_layer2.png", "caption": "A caption for image2"}
 ```
 
+Keys outside the shared schema (`image_path`, `caption`, `control_path` and their numbered variants) are passed through to the architecture-specific cache scripts as per-item extras; for example, MiniMax-H3 reads its `references` and `teacher_caption` from them. Architectures that do not define such fields ignore them. Directory-based datasets cannot carry per-item extras.
+
 <details>
 <summary>日本語</summary>
 
 resolution, batch_size, num_repeats, enable_bucket, bucket_no_upscale は general または datasets のどちらかに設定してください。省略時は各項目のデフォルト値が使用されます。
 
 metadata jsonl ファイルを使用する場合、caption_extension は必要ありません。また、cache_directory は必須です。
+
+共通スキーマ以外のキー（`image_path`、`caption`、`control_path` と、それらの番号付きの派生キー以外）は、アーキテクチャ固有のキャッシュスクリプトに項目ごとの追加フィールドとして渡されます。たとえば MiniMax-H3 は `references` と `teacher_caption` をここから読みます。該当フィールドを定義しないアーキテクチャでは無視されます。ディレクトリ指定のデータセットは項目ごとの追加フィールドを持てません。
 
 キャプションによるデータセットと同様に、複数のデータセットを追加できます。各データセットには異なる設定を持てます。
 
@@ -244,6 +248,8 @@ Relative paths in the JSONL (`video_path`, `control_path`, `audio_path`) are res
 
 For audio-capable architectures, each record may also have an optional `audio_path` field pointing to the audio file for the video. If `audio_path` is omitted, the audio source is resolved automatically: a same-stem audio sidecar file (e.g. `video1.wav` next to `video1.mp4`; `.aac`/`.flac`/`.m4a`/`.mp3`/`.ogg`/`.opus`/`.wav`) is used if present (multiple candidates are an error), otherwise the audio track embedded in the video container is used. If none is found, the item is cached as audio-less (a silence placeholder with `audio_present=0`, excluded from audio supervision during training). Architectures without audio support ignore `audio_path`.
 
+Keys outside the shared schema (`video_path`, `caption`, `control_path`, `audio_path`) are passed through to the architecture-specific cache scripts as per-item extras; for example, MiniMax-H3 reads its `references` and `teacher_caption` from them (relative paths inside such fields resolve from the JSONL directory). Architectures that do not define such fields ignore them. Directory-based datasets cannot carry per-item extras.
+
 <details>
 <summary>日本語</summary>
 metadata jsonl ファイルを使用する場合、caption_extension は必要ありません。また、cache_directory は必須です。
@@ -253,6 +259,8 @@ metadata jsonl ファイルを使用する場合、caption_extension は必要�
 JSONL 内の相対パス（`video_path`、`control_path`、`audio_path`）は、まず作業ディレクトリ基準で解決されます（従来どおりの挙動）。そこにファイルが存在しない場合は、JSONL ファイルのあるディレクトリ基準で解決されます。両方に存在する場合は作業ディレクトリ側が使用され、warning が出力されます。
 
 audio 対応アーキテクチャでは、各レコードに任意の `audio_path` フィールドを指定できます。省略した場合は、同名の音声サイドカーファイル（例: `video1.mp4` と同じ場所の `video1.wav`。複数候補がある場合はエラー）、次に動画コンテナ内の音声トラックの順で自動解決されます。どちらも無い場合は音声なしとしてキャッシュされ（無音プレースホルダ、`audio_present=0`）、学習時の audio 教師からは除外されます。audio 非対応のアーキテクチャでは `audio_path` は無視されます。
+
+共通スキーマ以外のキー（`video_path`、`caption`、`control_path`、`audio_path` 以外）は、アーキテクチャ固有のキャッシュスクリプトに項目ごとの追加フィールドとして渡されます。たとえば MiniMax-H3 は `references` と `teacher_caption` をここから読みます（こうしたフィールド内の相対パスは JSONL のディレクトリ基準で解決されます）。該当フィールドを定義しないアーキテクチャでは無視されます。ディレクトリ指定のデータセットは項目ごとの追加フィールドを持てません。
 
 他の注意事項は今までのデータセットと同様です。
 </details>

--- a/src/musubi_tuner/dataset/datasources.py
+++ b/src/musubi_tuner/dataset/datasources.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import os
-from typing import Optional, TYPE_CHECKING
+from typing import Any, Mapping, Optional, TYPE_CHECKING
 
 import torch
 from PIL import Image
@@ -16,6 +17,33 @@ if TYPE_CHECKING:
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ItemExtras:
+    """Per-item fields beyond the shared dataset schema, for architecture-specific consumers.
+
+    ``fields`` holds the record's keys that the shared schema does not define (for example the
+    MiniMax-H3 ``references`` and ``teacher_caption``). Only record-based datasources (JSONL)
+    can carry such fields; directory datasources always report an empty mapping. Relative
+    paths inside ``fields`` resolve from ``base_directory`` (the JSONL's directory, or the
+    dataset directory), and ``label`` names the record's origin for error messages.
+    """
+
+    fields: Mapping[str, Any]
+    base_directory: str
+    label: str
+
+
+def _extra_fields(data: Mapping[str, Any], shared_keys: tuple[str, ...]) -> dict[str, Any]:
+    """The record's keys outside the shared schema; ``key_N`` counts as its ``key`` (control_path_0, image_path_1, ...)."""
+    extras = {}
+    for key, value in data.items():
+        stem, _, suffix = key.rpartition("_")
+        if key in shared_keys or (suffix.isdigit() and stem in shared_keys):
+            continue
+        extras[key] = value
+    return extras
 
 
 class ContentDatasource:
@@ -32,6 +60,13 @@ class ContentDatasource:
     def get_caption(self, idx: int) -> tuple[str, str]:
         """
         Returns caption. May not be called if is_indexable() returns False.
+        """
+        raise NotImplementedError
+
+    def get_item_extras(self, idx: int) -> ItemExtras:
+        """
+        Returns the item's fields beyond the shared schema (see ItemExtras). Indices align with
+        get_caption and with ItemInfo.datasource_index. May not be called if is_indexable() returns False.
         """
         raise NotImplementedError
 
@@ -64,6 +99,16 @@ class ImageDatasource(ContentDatasource):
         cache scripts can fingerprint the source files behind them.
         """
         return {}
+
+
+def _create_image_fetcher(datasource: ImageDatasource, index: int):
+    def fetch():
+        return datasource.get_image_data(index)
+
+    # the datasource record index travels as a fetcher attribute so that ItemInfo can
+    # reference the originating record without re-deriving it from item keys
+    fetch.datasource_index = index
+    return fetch
 
 
 class ImageDirectoryDatasource(ImageDatasource):
@@ -260,6 +305,10 @@ class ImageDirectoryDatasource(ImageDatasource):
             return {}
         return {image_path: list(paths) for image_path, paths in self.control_paths.items()}
 
+    def get_item_extras(self, idx: int) -> ItemExtras:
+        # a directory item has no place for fields beyond the shared schema
+        return ItemExtras(fields={}, base_directory=self.image_directory, label=self.image_paths[idx])
+
     def __iter__(self):
         self.current_idx = 0
         return self
@@ -278,17 +327,16 @@ class ImageDirectoryDatasource(ImageDatasource):
 
             fetcher = create_caption_fetcher(self.current_idx)
         else:
-
-            def create_image_fetcher(index):
-                return lambda: self.get_image_data(index)
-
-            fetcher = create_image_fetcher(self.current_idx)
+            fetcher = _create_image_fetcher(self, self.current_idx)
 
         self.current_idx += 1
         return fetcher
 
 
 class ImageJsonlDatasource(ImageDatasource):
+    # the shared image JSONL schema (numbered variants included); every other key is an item extra
+    SHARED_KEYS = ("image_path", "caption", "control_path")
+
     def __init__(self, image_jsonl_file: str, control_count_per_image: Optional[int] = None, multiple_target: bool = False):
         super().__init__()
         self.image_jsonl_file = image_jsonl_file
@@ -404,6 +452,13 @@ class ImageJsonlDatasource(ImageDatasource):
             control_paths[image_path] = paths
         return control_paths
 
+    def get_item_extras(self, idx: int) -> ItemExtras:
+        return ItemExtras(
+            fields=_extra_fields(self.data[idx], ImageJsonlDatasource.SHARED_KEYS),
+            base_directory=os.path.dirname(os.path.abspath(self.image_jsonl_file)),
+            label=f"{os.path.basename(self.image_jsonl_file)} line {idx + 1}",
+        )
+
     def __iter__(self):
         self.current_idx = 0
         return self
@@ -420,11 +475,7 @@ class ImageJsonlDatasource(ImageDatasource):
             fetcher = create_caption_fetcher(self.current_idx)
 
         else:
-
-            def create_fetcher(index):
-                return lambda: self.get_image_data(index)
-
-            fetcher = create_fetcher(self.current_idx)
+            fetcher = _create_image_fetcher(self, self.current_idx)
 
         self.current_idx += 1
         return fetcher
@@ -669,6 +720,10 @@ class VideoDirectoryDatasource(VideoDatasource):
     def _audio_resolution_inputs(self, idx: int) -> tuple[str, Optional[str]]:
         return self.video_paths[idx], None
 
+    def get_item_extras(self, idx: int) -> ItemExtras:
+        # a directory item has no place for fields beyond the shared schema
+        return ItemExtras(fields={}, base_directory=self.video_directory, label=self.video_paths[idx])
+
     def __iter__(self):
         self.current_idx = 0
         return self
@@ -693,6 +748,8 @@ class VideoDirectoryDatasource(VideoDatasource):
 
 class VideoJsonlDatasource(VideoDatasource):
     PATH_KEYS = ("video_path", "control_path", "audio_path")
+    # the shared video JSONL schema; every other key is an item extra
+    SHARED_KEYS = ("video_path", "caption", "control_path", "audio_path")
 
     def __init__(self, video_jsonl_file: str):
         super().__init__()
@@ -776,6 +833,13 @@ class VideoJsonlDatasource(VideoDatasource):
     def _audio_resolution_inputs(self, idx: int) -> tuple[str, Optional[str]]:
         data = self.data[idx]
         return data["video_path"], data.get("audio_path")
+
+    def get_item_extras(self, idx: int) -> ItemExtras:
+        return ItemExtras(
+            fields=_extra_fields(self.data[idx], VideoJsonlDatasource.SHARED_KEYS),
+            base_directory=os.path.dirname(os.path.abspath(self.video_jsonl_file)),
+            label=f"{os.path.basename(self.video_jsonl_file)} line {idx + 1}",
+        )
 
     def __iter__(self):
         self.current_idx = 0

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -67,8 +67,8 @@ class ItemInfo:
         # np.ndarray for video, list[np.ndarray] for image with multiple controls
         self.control_content: Optional[Union[np.ndarray, list[np.ndarray]]] = None
 
-        # crop provenance (video datasets): start frame of the crop in target-fps space and
-        # the index of the originating datasource record
+        # provenance: the index of the originating datasource record (image and video datasets)
+        # and, for video crops, the start frame of the crop in target-fps space
         self.frame_pos: Optional[int] = None
         self.datasource_index: Optional[int] = None
 
@@ -429,7 +429,7 @@ class ImageDataset(BaseDataset):
                         break  # submit batch if possible
 
                 for future in completed_futures:
-                    original_size, item_key, images, caption, controls = future.result()
+                    original_size, item_key, images, caption, controls, datasource_index = future.result()
                     image = images[0]  # use the first image as the main content
                     bucket_height, bucket_width = image.shape[:2]
                     bucket_reso = (bucket_width, bucket_height)
@@ -437,6 +437,7 @@ class ImageDataset(BaseDataset):
                     item_info = ItemInfo(
                         item_key, caption, original_size, bucket_reso, content=image if len(images) == 1 else images
                     )
+                    item_info.datasource_index = datasource_index
                     item_info.latent_cache_path = self.get_latent_cache_path(item_info)
 
                     # for VLM, which require image in addition to text, like Qwen-Image-Edit
@@ -490,7 +491,7 @@ class ImageDataset(BaseDataset):
 
         for fetch_op in self.datasource:
             # fetch and resize image in a separate thread
-            def fetch_and_resize(op: callable) -> tuple[tuple[int, int], str, Image.Image, str, Optional[Image.Image]]:
+            def fetch_and_resize(op: callable) -> tuple:
                 image_key, images, caption, controls = op()
                 images: list[Image.Image]
                 image: Image.Image = images[0]  # use the first image as the main content
@@ -532,7 +533,7 @@ class ImageDataset(BaseDataset):
                             resized_control = resize_image_to_bucket(control, bucket_reso)
                             resized_controls.append(resized_control)
 
-                return image_size, image_key, images, caption, resized_controls
+                return image_size, image_key, images, caption, resized_controls, getattr(op, "datasource_index", None)
 
             future = executor.submit(fetch_and_resize, fetch_op)
             futures.append(future)

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -61,12 +61,7 @@ def parse_one_frame_options(spec: str) -> tuple[int, tuple[int, ...] | None]:
 
 
 def dummy_record(prompt: str) -> H3Record:
-    return H3Record(
-        video_path=Path("."),
-        caption=prompt,
-        references=(),
-        jsonl_line=0,
-    )
+    return H3Record(video_path=Path("."), caption=prompt, references=(), label="--prompt")
 
 
 def load_image_frames(path: str | Path, *, width: int, height: int) -> torch.Tensor:
@@ -94,7 +89,7 @@ def load_generation_record(args) -> H3Record:
     if ref_specs:
         base_directory = Path(getattr(args, "ref_base_directory", None) or Path.cwd())
         references = parse_inline_references(ref_specs, base_directory)
-        return H3Record(video_path=Path("."), caption=args.prompt or "", references=references, jsonl_line=0)
+        return H3Record(video_path=Path("."), caption=args.prompt or "", references=references, label="--ref")
 
     records = load_h3_jsonl_records(args.reference_jsonl, "ref2va")
     if args.reference_index >= len(records):

--- a/src/musubi_tuner/minimax_h3/media.py
+++ b/src/musubi_tuner/minimax_h3/media.py
@@ -4,13 +4,13 @@ from dataclasses import dataclass
 from fractions import Fraction
 import json
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Callable, Literal, Mapping, Optional
 
 import av
 
 from musubi_tuner.dataset.audio_utils import AudioSource as H3AudioSource
 from musubi_tuner.dataset.audio_utils import AudioSpec
-from musubi_tuner.dataset.datasources import ImageDatasource, ImageJsonlDatasource, VideoDatasource, VideoJsonlDatasource
+from musubi_tuner.dataset.datasources import ContentDatasource
 
 
 H3Task = Literal["t2va", "fl2va", "ref2va"]
@@ -44,16 +44,21 @@ class H3Record:
     video_path: Path
     caption: str
     references: tuple[H3Reference, ...]
-    jsonl_line: int
-    # optional JSONL `teacher_caption`: the caption of the subject-reference teacher presentation
+    # where the record came from (e.g. "items.jsonl line 3"), for error messages only
+    label: str = ""
+    # optional per-item `teacher_caption`: the caption of the subject-reference teacher presentation
     # (text cache only); None means the teacher wraps `caption` with the boilerplate declaration
     teacher_caption: Optional[str] = None
 
+    @property
+    def context(self) -> str:
+        return f"H3 {self.label}" if self.label else "H3 record"
 
-def _parse_teacher_caption(data: dict, line_number: int) -> Optional[str]:
-    teacher_caption = data.get("teacher_caption")
+
+def _parse_teacher_caption(fields: Mapping[str, object], context: str) -> Optional[str]:
+    teacher_caption = fields.get("teacher_caption")
     if teacher_caption is not None and (not isinstance(teacher_caption, str) or not teacher_caption.strip()):
-        raise ValueError(f"H3 JSONL line {line_number}: teacher_caption must be a non-empty string when present")
+        raise ValueError(f"{context}: teacher_caption must be a non-empty string when present")
     return teacher_caption
 
 
@@ -301,35 +306,36 @@ def reject_one_frame_audio_references(record: H3Record) -> None:
         )
 
 
-def _record_from_jsonl_data(
-    data: object,
+def _record_from_fields(
+    *,
+    target_path: Path,
+    caption: object,
+    fields: Mapping[str, object],
     base_directory: Path,
-    line_number: int,
+    label: str,
     task: H3Task,
     probe: H3MediaProbe,
 ) -> H3Record:
-    if not isinstance(data, dict):
-        raise ValueError(f"H3 JSONL line {line_number}: each record must be an object")
-
-    video_path = _resolve_existing_path(data.get("video_path"), base_directory, "video_path", line_number)
-    caption = data.get("caption")
+    """Builds a record from a validated target path plus the item's H3-specific fields
+    (``references``, ``teacher_caption``); relative reference paths resolve from base_directory."""
+    context = f"H3 {label}"
     if not isinstance(caption, str):
-        raise ValueError(f"H3 JSONL line {line_number}: caption must be a string")
+        raise ValueError(f"{context}: caption must be a string")
 
-    raw_references = data.get("references", [])
+    raw_references = fields.get("references", [])
     if task == "ref2va":
-        references = _parse_references(raw_references, base_directory, line_number, probe)
+        references = _parse_references(raw_references, base_directory, context, probe)
     else:
         if raw_references:
-            raise ValueError(f"H3 JSONL line {line_number}: references require task ref2va")
+            raise ValueError(f"{context}: references require task ref2va")
         references = ()
 
     return H3Record(
-        video_path=video_path,
+        video_path=target_path,
         caption=caption,
         references=references,
-        jsonl_line=line_number,
-        teacher_caption=_parse_teacher_caption(data, line_number),
+        label=label,
+        teacher_caption=_parse_teacher_caption(fields, context),
     )
 
 
@@ -338,6 +344,7 @@ def load_h3_jsonl_records(
     task: H3Task,
     probe: H3MediaProbe = probe_h3_media,
 ) -> list[H3Record]:
+    """Reads a standalone Ref2VA JSONL (generation --reference_jsonl); relative paths resolve from its directory."""
     if task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
 
@@ -351,11 +358,25 @@ def load_h3_jsonl_records(
         for line_number, line in enumerate(handle, start=1):
             if not line.strip():
                 continue
+            label = f"{jsonl_path.name} line {line_number}"
+            context = f"H3 {label}"
             try:
                 data = json.loads(line)
             except json.JSONDecodeError as error:
-                raise ValueError(f"H3 JSONL line {line_number}: invalid JSON: {error.msg}") from error
-            records.append(_record_from_jsonl_data(data, base_directory, line_number, task, probe))
+                raise ValueError(f"{context}: invalid JSON: {error.msg}") from error
+            if not isinstance(data, dict):
+                raise ValueError(f"{context}: each record must be an object")
+            records.append(
+                _record_from_fields(
+                    target_path=_resolve_existing_path(data.get("video_path"), base_directory, "video_path", context),
+                    caption=data.get("caption"),
+                    fields=data,
+                    base_directory=base_directory,
+                    label=label,
+                    task=task,
+                    probe=probe,
+                )
+            )
 
     if not records:
         raise ValueError(f"MiniMax-H3 JSONL contains no records: {jsonl_path}")
@@ -363,93 +384,51 @@ def load_h3_jsonl_records(
 
 
 def h3_records_from_datasource(
-    datasource: VideoDatasource,
+    datasource: ContentDatasource,
     task: H3Task,
     probe: H3MediaProbe = probe_h3_media,
 ) -> list[H3Record]:
-    """Builds H3 records from the datasource's already-parsed data (no JSONL re-read).
+    """Builds the H3 records of a dataset's datasource (image or video), aligned with the
+    datasource indices so cache items find theirs through ItemInfo.datasource_index.
 
-    Records align with datasource indices, so cache items reference them through
-    ItemInfo.datasource_index.
+    The target path and caption come from the shared accessor; the H3-specific fields
+    (``references``, ``teacher_caption``) come from the item extras, which only record-based
+    datasources (``video_jsonl_file`` / ``image_jsonl_file``) can carry, so Ref2VA requires one
+    of those. The target path is resolved the way the dataset layer opens it.
     """
     if task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
+    if len(datasource) == 0:
+        raise ValueError("MiniMax-H3 dataset contains no items")
 
-    if isinstance(datasource, VideoJsonlDatasource):
-        base_directory = Path(datasource.video_jsonl_file).resolve().parent
-        records = [
-            _record_from_jsonl_data(data, base_directory, index + 1, task, probe) for index, data in enumerate(datasource.data)
-        ]
-        if not records:
-            raise ValueError(f"MiniMax-H3 JSONL contains no records: {datasource.video_jsonl_file}")
-        return records
-
-    if task == "ref2va":
-        raise ValueError("MiniMax-H3 Ref2VA requires video_jsonl_file")
+    if task == "ref2va" and not any("references" in datasource.get_item_extras(index).fields for index in range(len(datasource))):
+        raise ValueError(
+            "MiniMax-H3 Ref2VA requires per-item references, which only video_jsonl_file / image_jsonl_file records can carry"
+        )
 
     records = []
+    seen_targets: dict[Path, str] = {}
     for index in range(len(datasource)):
-        video_path, caption = datasource.get_caption(index)
-        video_path = Path(video_path).resolve()
-        if not video_path.is_file():
-            raise ValueError(f"MiniMax-H3 target video does not exist: {video_path}")
-        if not isinstance(caption, str):
-            raise ValueError("MiniMax-H3 directory caption must be a string")
-        records.append(H3Record(video_path=video_path, caption=caption, references=(), jsonl_line=0))
-    return records
-
-
-def h3_image_records_from_datasource(
-    datasource: ImageDatasource,
-    task: H3Task,
-    probe: H3MediaProbe = probe_h3_media,
-) -> dict[str, H3Record]:
-    """Builds one-frame (image target) Ref2VA records from an image datasource's parsed data.
-
-    Only ``image_jsonl_file`` datasets can carry ``references`` (the same schema as the
-    Ref2VA video JSONL, resolved from the JSONL directory), so Ref2VA requires one. The result
-    is keyed by the JSONL ``image_path`` string exactly as the dataset layer stores it in
-    ``ItemInfo.item_key`` (image items carry no datasource index); the record's target path
-    is that image path resolved the way the dataset layer opens it. For the other tasks the
-    JSONL is only checked for stray ``references`` and no records are built.
-    """
-    if task not in {"t2va", "fl2va", "ref2va"}:
-        raise ValueError(f"Unsupported MiniMax-H3 task: {task}")
-    if not isinstance(datasource, ImageJsonlDatasource):
-        if task == "ref2va":
-            raise ValueError("MiniMax-H3 one-frame Ref2VA requires image_jsonl_file with per-item references")
-        return {}
-
-    base_directory = Path(datasource.image_jsonl_file).resolve().parent
-    records: dict[str, H3Record] = {}
-    for index, data in enumerate(datasource.data):
-        line_number = index + 1
-        if not isinstance(data, dict):
-            raise ValueError(f"H3 JSONL line {line_number}: each record must be an object")
-        raw_references = data.get("references", [])
-        if task != "ref2va":
-            if raw_references:
-                raise ValueError(f"H3 JSONL line {line_number}: references require task ref2va")
-            continue
-        item_key = data.get("image_path")
-        if not isinstance(item_key, str) or not item_key.strip():
-            raise ValueError(f"H3 JSONL line {line_number}: image_path must be a non-empty path")
-        target = Path(item_key).expanduser().resolve()
+        target_path, caption = datasource.get_caption(index)
+        extras = datasource.get_item_extras(index)
+        context = f"H3 {extras.label}"
+        if not isinstance(target_path, str) or not target_path.strip():
+            raise ValueError(f"{context}: target path must be a non-empty path")
+        target = Path(target_path).expanduser().resolve()
         if not target.is_file():
-            raise ValueError(f"H3 JSONL line {line_number}: image_path does not exist: {target}")
-        caption = data.get("caption")
-        if not isinstance(caption, str):
-            raise ValueError(f"H3 JSONL line {line_number}: caption must be a string")
-        if item_key in records:
-            raise ValueError(f"H3 JSONL line {line_number}: duplicate image_path {item_key!r}")
-        references = _parse_references(raw_references, base_directory, line_number, probe)
-        records[item_key] = H3Record(
-            video_path=target,
-            caption=caption,
-            references=references,
-            jsonl_line=line_number,
-            teacher_caption=_parse_teacher_caption(data, line_number),
+            raise ValueError(f"{context}: target does not exist: {target}")
+        if target in seen_targets:
+            raise ValueError(f"{context}: duplicate target {target} (also {seen_targets[target]})")
+        seen_targets[target] = extras.label
+        records.append(
+            _record_from_fields(
+                target_path=target,
+                caption=caption,
+                fields=extras.fields,
+                base_directory=Path(extras.base_directory),
+                label=extras.label,
+                task=task,
+                probe=probe,
+            )
         )
-    if task == "ref2va" and not records:
-        raise ValueError(f"MiniMax-H3 JSONL contains no records: {datasource.image_jsonl_file}")
     return records

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -46,7 +46,6 @@ from musubi_tuner.minimax_h3.media import (
     H3Task,
     TARGET_FPS,
     audio_latent_frames,
-    h3_image_records_from_datasource,
     h3_records_from_datasource,
     reject_one_frame_audio_references,
     video_latent_frames,
@@ -613,7 +612,7 @@ def validate_h3_dataset(dataset: VideoDataset | ImageDataset) -> None:
 def validate_h3_image_dataset_task(dataset: ImageDataset, task: H3Task, one_frame: bool) -> None:
     """The one-frame task matrix, shared by both cache scripts: plain images cache as t2va,
     control images (time-annotated) require fl2va, and ref2va takes a control-free image
-    JSONL dataset whose records carry references (checked when the records are built)."""
+    dataset whose records carry references (checked when the records are built)."""
     if not one_frame:
         raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
     if dataset.has_control and task != "fl2va":
@@ -632,11 +631,18 @@ def item_cache_dir_key(item: ItemInfo) -> str:
     return dataset_cache_dir_key(os.path.dirname(item.latent_cache_path))
 
 
-def item_record_inputs(item: ItemInfo) -> tuple[int, int]:
-    """Returns (datasource_index, crop_start_frame) with presence validation."""
-    if item.datasource_index is None or item.frame_pos is None:
+def item_datasource_index(item: ItemInfo) -> int:
+    """The index of the item's record in its datasource (and in the H3 records built from it)."""
+    if item.datasource_index is None:
         raise ValueError(f"MiniMax-H3 cache item is missing datasource provenance: {item.item_key}")
-    return item.datasource_index, item.frame_pos
+    return item.datasource_index
+
+
+def item_record_inputs(item: ItemInfo) -> tuple[int, int]:
+    """Returns (datasource_index, crop_start_frame) of a video item with presence validation."""
+    if item.frame_pos is None:
+        raise ValueError(f"MiniMax-H3 cache item is missing its crop provenance: {item.item_key}")
+    return item_datasource_index(item), item.frame_pos
 
 
 def log_audio_presence_summary(presence_counts: Mapping[bool, int]) -> None:
@@ -668,7 +674,7 @@ def setup_parser() -> argparse.ArgumentParser:
         help="experimental one-frame (image) training caches: accept image datasets whose items become single-token"
         " video targets with a silence audio placeholder. --task t2va caches plain image targets; --task fl2va"
         " additionally encodes 1-2 control images as time-annotated conditions (fp_1f_clean_indices); --task ref2va"
-        " encodes the per-item references of an image_jsonl_file dataset as untimed Ref2VA conditions",
+        " encodes the per-item references of the image records (image_jsonl_file) as untimed Ref2VA conditions",
     )
     parser.add_argument("--cache_seed", type=int, default=0, help="seed used for reproducible target-video posterior samples")
     parser.add_argument(
@@ -693,10 +699,10 @@ def main() -> None:
     dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group, audio_spec=H3_AUDIO_SPEC)
     datasets = dataset_group.datasets
 
+    # H3 records per cache directory (image and video datasets alike), aligned with the datasource indices
     records_by_dir: dict[str, list[H3Record]] = {}
     audio_sources_by_dir: dict[str, list] = {}
     image_dirs: set[str] = set()
-    image_records_by_dir: dict[str, dict[str, H3Record]] = {}
     control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
     for dataset_index, dataset in enumerate(datasets):
         validate_h3_dataset(dataset)
@@ -708,19 +714,17 @@ def main() -> None:
                 int(dataset.batch_size),
             )
         key = dataset_cache_dir_key(dataset.cache_directory)
+        if key in records_by_dir:
+            raise ValueError(f"MiniMax-H3 datasets cannot share a cache_directory: {key}")
         if isinstance(dataset, ImageDataset):
             validate_h3_image_dataset_task(dataset, args.task, args.one_frame)
             image_dirs.add(key)
             control_paths_by_dir[key] = dataset.datasource.get_control_paths()
-            image_records_by_dir[key] = h3_image_records_from_datasource(dataset.datasource, args.task)
-            continue
-        if not isinstance(dataset, VideoDataset):
+        elif isinstance(dataset, VideoDataset):
+            audio_sources_by_dir[key] = dataset.datasource.audio_sources
+        else:
             raise ValueError("MiniMax-H3 latent caching accepts only image and video datasets")
         records_by_dir[key] = h3_records_from_datasource(dataset.datasource, args.task)
-        audio_sources_by_dir[key] = dataset.datasource.audio_sources
-    colliding = image_dirs & set(records_by_dir)
-    if colliding:
-        raise ValueError(f"MiniMax-H3 image and video datasets cannot share a cache_directory: {sorted(colliding)}")
 
     if args.debug_mode is not None:
         cache_latents.show_datasets(
@@ -740,13 +744,9 @@ def main() -> None:
         for record in records:
             for path in record_media_paths(record):
                 media_fingerprints[path] = fingerprint_file(path)
-        for source in audio_sources_by_dir[key]:
+        for source in audio_sources_by_dir.get(key, ()):
             if source is not None:
                 media_fingerprints[source.path] = fingerprint_file(source.path)
-    for image_records in image_records_by_dir.values():
-        for record in image_records.values():
-            for path in record_media_paths(record):
-                media_fingerprints[path] = fingerprint_file(path)
 
     logger.info("Loading MiniMax-H3 video VAE from %s", args.video_vae)
     video_vae = load_video_vae(
@@ -772,19 +772,12 @@ def main() -> None:
     def encode_one_frame(item: ItemInfo, cache_dir_key: str) -> None:
         nonlocal one_frame_item_count
         one_frame_item_count += 1
-        image_path = Path(item.item_key).resolve()
-        image_fingerprints = {image_path: media_fingerprints.setdefault(image_path, fingerprint_file(image_path))}
+        record = records_by_dir[cache_dir_key][item_datasource_index(item)]
+        # the target image and, for ref2va, the references the cache encodes form the identity
+        image_fingerprints = {path: media_fingerprints[path] for path in record_media_paths(record)}
         control_frames = None
         control_indices = None
-        record = None
-        if args.task == "ref2va":
-            record = image_records_by_dir.get(cache_dir_key, {}).get(item.item_key)
-            if record is None:
-                raise ValueError(f"MiniMax-H3 ref2va one-frame item has no JSONL record: {item.item_key}")
-            # the references are what the cache encodes, so their files join the identity
-            for path in record_media_paths(record):
-                image_fingerprints[path] = media_fingerprints[path]
-        elif args.task == "fl2va":
+        if args.task == "fl2va":
             control_frames = item.control_content
             control_indices = item.fp_1f_clean_indices
             if not control_indices or control_frames is None or len(control_frames) != len(control_indices):
@@ -818,7 +811,7 @@ def main() -> None:
             video_vae=video_vae,
             silence_audio_latent=silence_audio_latent,
             cache_seed=args.cache_seed,
-            item_key=str(image_path),
+            item_key=str(record.video_path),
             video_vae_fingerprint=video_vae_fingerprint,
             audio_vae_fingerprint=audio_vae_fingerprint,
             media_fingerprints=image_fingerprints,

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -35,7 +35,6 @@ from musubi_tuner.minimax_h3.media import (
     H3AudioSource,
     H3Record,
     H3Reference,
-    h3_image_records_from_datasource,
     h3_records_from_datasource,
     reject_one_frame_audio_references,
     validate_subject_reference_record,
@@ -48,6 +47,7 @@ from musubi_tuner.minimax_h3_cache_latents import (
     dataset_cache_dir_key,
     fingerprint_checkpoint,
     fingerprint_file,
+    item_datasource_index,
     item_record_inputs,
     validate_h3_dataset,
     validate_h3_image_dataset_task,
@@ -150,7 +150,7 @@ def _ref_teacher_presentation(record, item: ItemInfo) -> H3Presentation:
         video_path=record.video_path,
         caption=wrap_ref_teacher_caption(record.caption),
         references=(reference,),
-        jsonl_line=record.jsonl_line,
+        label=record.label,
     )
     sampled = target_frames[::REF_TEACHER_TEXT_FRAME_STRIDE]
     # the same downscale-only canvas cap that decode_reference_visual applies to reference
@@ -179,7 +179,7 @@ def _subject_ref_teacher_presentation(
     in the subject-reference declaration boilerplate. The student rows never see the
     references: the same record minus references is the plain T2VA presentation.
     """
-    validate_subject_reference_record(record, f"H3 JSONL line {record.jsonl_line}")
+    validate_subject_reference_record(record, record.context)
     if record.teacher_caption is not None:
         caption = record.teacher_caption
     else:
@@ -258,7 +258,7 @@ def setup_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="experimental one-frame (image) training caches: accept image datasets. --task t2va encodes plain"
         " caption presentations; --task fl2va embeds the bucket-resized control images as <Picture i> visuals;"
-        " --task ref2va embeds the per-item references of an image_jsonl_file dataset in the Ref2VA presentation",
+        " --task ref2va embeds the per-item references of the image records (image_jsonl_file) in the Ref2VA presentation",
     )
     parser.add_argument(
         "--teacher_conditions",
@@ -267,7 +267,7 @@ def setup_parser() -> argparse.ArgumentParser:
         help="also cache a teacher presentation for --h3_teacher_matching training (--task t2va only)."
         " 'first,last' stores the FL2VA presentation with the crop endpoints; 'ref' stores the Ref2VA"
         " presentation with the training crop itself (video + audio copy declaration) as the reference;"
-        " 'subject_ref' stores the Ref2VA presentation with the item's own JSONL image references (subject"
+        " 'subject_ref' stores the Ref2VA presentation with the item's own image references (subject"
         " declaration wrapped around the caption, or the item's teacher_caption), for image or video targets",
     )
     parser.add_argument("--text_cache_dtype", choices=("bf16", "float32"), default="bf16")
@@ -311,53 +311,43 @@ def main() -> None:
     datasets = dataset_group.datasets
 
     decoder = PyAVH3MediaDecoder()
-    records_by_dir = {}
+    # H3 records per cache directory (image and video datasets alike), aligned with the datasource indices
+    records_by_dir: dict[str, list[H3Record]] = {}
     image_dirs: set[str] = set()
-    image_records_by_dir: dict[str, dict[str, H3Record]] = {}
     control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
     for dataset in datasets:
         validate_h3_dataset(dataset)
+        key = dataset_cache_dir_key(dataset.cache_directory)
+        if key in records_by_dir:
+            raise ValueError(f"MiniMax-H3 datasets cannot share a cache_directory: {key}")
         if isinstance(dataset, ImageDataset):
             validate_h3_image_dataset_task(dataset, args.task, args.one_frame)
-            key = dataset_cache_dir_key(dataset.cache_directory)
             image_dirs.add(key)
             control_paths_by_dir[key] = dataset.datasource.get_control_paths()
-            image_records_by_dir[key] = h3_image_records_from_datasource(dataset.datasource, record_task)
-            continue
-        if not isinstance(dataset, VideoDataset):
+        elif not isinstance(dataset, VideoDataset):
             raise ValueError("MiniMax-H3 text caching accepts only image and video datasets")
-        records_by_dir[dataset_cache_dir_key(dataset.cache_directory)] = h3_records_from_datasource(dataset.datasource, record_task)
-    colliding = image_dirs & set(records_by_dir)
-    if colliding:
-        raise ValueError(f"MiniMax-H3 image and video datasets cannot share a cache_directory: {sorted(colliding)}")
+        records_by_dir[key] = h3_records_from_datasource(dataset.datasource, record_task)
     if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF:
         # fail on the data contract before any model is loaded
-        for record in (
-            *(r for records in records_by_dir.values() for r in records),
-            *(r for m in image_records_by_dir.values() for r in m.values()),
-        ):
-            validate_subject_reference_record(record, f"H3 JSONL line {record.jsonl_line}")
+        for records in records_by_dir.values():
+            for record in records:
+                validate_subject_reference_record(record, record.context)
 
     all_cache_files, all_cache_paths = cache_text_encoder_outputs.prepare_cache_files_and_paths(datasets)
+    # the presentations embed the FL2VA endpoints / the reference visuals (video and one-frame
+    # ref2va or subject-reference teacher alike), so those files join the identity
     text_paths = {
         path
         for records in records_by_dir.values()
         for record in records
         for path in _text_media_paths(record, args.task, teacher_conditions)
     }
-    # one-frame fl2va presentations embed the control images, so their files join the identity
+    # ... and one-frame fl2va presentations embed the control images
     text_paths.update(
         Path(path).resolve()
         for control_paths in control_paths_by_dir.values()
         for paths in control_paths.values()
         for path in paths
-    )
-    # ... and one-frame ref2va (or subject-reference teacher) presentations embed the reference visuals
-    text_paths.update(
-        path
-        for image_records in image_records_by_dir.values()
-        for record in image_records.values()
-        for path in _text_media_paths(record, args.task, teacher_conditions)
     )
     media_fingerprints = {path: fingerprint_file(path) for path in text_paths}
 
@@ -403,17 +393,13 @@ def main() -> None:
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:
             cache_dir_key = dataset_cache_dir_key(str(Path(item.text_encoder_output_cache_path).parent))
+            records = records_by_dir[cache_dir_key]
             if cache_dir_key in image_dirs:
                 # one-frame image item: the caption as a T2VA presentation, an FL2VA
                 # presentation embedding the bucket-resized control images, or a Ref2VA
                 # presentation embedding the item's references; all time indices live in the
                 # latent cache, never in the text rows
-                record = H3Record(
-                    video_path=Path(item.item_key).resolve(),
-                    caption=item.caption,
-                    references=(),
-                    jsonl_line=0,
-                )
+                record = records[item_datasource_index(item)]
                 crop_start = 0
                 frame_count = 1
                 visuals = {}
@@ -422,10 +408,8 @@ def main() -> None:
                 if target.ndim != 3:
                     raise ValueError(f"MiniMax-H3 one-frame target must be [H,W,C], got {tuple(target.shape)}")
                 target_size = (int(target.shape[1]), int(target.shape[0]))
-                if args.task == "ref2va" or teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF:
-                    record = image_records_by_dir.get(cache_dir_key, {}).get(item.item_key)
-                    if record is None:
-                        raise ValueError(f"MiniMax-H3 {record_task} one-frame item has no JSONL record: {item.item_key}")
+                if record.references:
+                    # ref2va targets or subject-reference teachers (the records are parsed as Ref2VA)
                     reject_one_frame_audio_references(record)
                 if args.task == "ref2va":
                     # the same canvas policy as the latent cache: images capped to the target
@@ -459,7 +443,6 @@ def main() -> None:
                 presentation = build_presentation(student_record, args.task, visuals)
                 reference_frame_cap = ONE_FRAME_REFERENCE_FRAME_CAP
             else:
-                records = records_by_dir[cache_dir_key]
                 datasource_index, crop_start = item_record_inputs(item)
                 record = records[datasource_index]
                 frame_count = item.frame_count

--- a/tests/test_datasource_item_extras.py
+++ b/tests/test_datasource_item_extras.py
@@ -1,0 +1,121 @@
+"""The per-item extras accessor: architecture-specific consumers read the fields a dataset
+carries beyond the shared schema through it, without knowing the datasource implementation."""
+
+import json
+from pathlib import Path
+import sys
+
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from musubi_tuner.dataset.architectures import ARCHITECTURE_QWEN_IMAGE
+from musubi_tuner.dataset.datasources import (
+    ImageDirectoryDatasource,
+    ImageJsonlDatasource,
+    ItemExtras,
+    VideoDirectoryDatasource,
+    VideoJsonlDatasource,
+)
+from musubi_tuner.dataset.image_video_dataset import ImageDataset
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    return path
+
+
+def test_image_jsonl_extras_exclude_the_shared_schema_including_numbered_keys(tmp_path: Path):
+    jsonl = tmp_path / "data" / "items.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            {
+                "image_path": "a.png",
+                "image_path_1": "a_1.png",
+                "caption": "c",
+                "control_path": "ctrl.png",
+                "references": [{"type": "image", "path": "refs/face.png"}],
+                "teacher_caption": "t",
+                "custom": 1,
+            },
+            {"image_path": "b.png", "caption": "c"},
+        ],
+    )
+
+    datasource = ImageJsonlDatasource(str(jsonl), control_count_per_image=None)
+
+    first = datasource.get_item_extras(0)
+    assert isinstance(first, ItemExtras)
+    assert first.fields == {"references": [{"type": "image", "path": "refs/face.png"}], "teacher_caption": "t", "custom": 1}
+    assert Path(first.base_directory) == jsonl.parent.resolve()
+    assert first.label == "items.jsonl line 1"
+    assert datasource.get_item_extras(1).fields == {}
+    assert datasource.get_item_extras(1).label == "items.jsonl line 2"
+
+
+def test_video_jsonl_extras_exclude_the_shared_schema(tmp_path: Path):
+    jsonl = tmp_path / "videos.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            {
+                "video_path": "clip.mp4",
+                "caption": "c",
+                "control_path": "ctrl.mp4",
+                "audio_path": "clip.wav",
+                "references": [{"type": "video", "path": "ref.mp4"}],
+            }
+        ],
+    )
+
+    extras = VideoJsonlDatasource(str(jsonl)).get_item_extras(0)
+
+    assert extras.fields == {"references": [{"type": "video", "path": "ref.mp4"}]}
+    assert Path(extras.base_directory) == tmp_path.resolve()
+    assert extras.label == "videos.jsonl line 1"
+
+
+def test_directory_datasources_have_no_extras(tmp_path: Path):
+    image = _touch(tmp_path / "images" / "a.png")
+    (tmp_path / "images" / "a.txt").write_text("c", encoding="utf-8")
+    video = _touch(tmp_path / "videos" / "a.mp4")
+    (tmp_path / "videos" / "a.txt").write_text("c", encoding="utf-8")
+
+    image_extras = ImageDirectoryDatasource(str(tmp_path / "images"), ".txt").get_item_extras(0)
+    video_extras = VideoDirectoryDatasource(str(tmp_path / "videos"), ".txt").get_item_extras(0)
+
+    assert image_extras == ItemExtras(fields={}, base_directory=str(tmp_path / "images"), label=str(image))
+    assert video_extras == ItemExtras(fields={}, base_directory=str(tmp_path / "videos"), label=str(video))
+
+
+def test_image_items_carry_their_datasource_index(tmp_path: Path):
+    for name in ("first", "second"):
+        Image.new("RGB", (64, 64)).save(tmp_path / f"{name}.png")
+        (tmp_path / f"{name}.txt").write_text(name, encoding="utf-8")
+
+    dataset = ImageDataset(
+        resolution=(64, 64),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=True,
+        bucket_no_upscale=False,
+        image_directory=str(tmp_path),
+        cache_directory=str(tmp_path / "cache"),
+        architecture=ARCHITECTURE_QWEN_IMAGE,
+    )
+
+    fetchers = list(dataset.datasource)
+    assert [fetcher.datasource_index for fetcher in fetchers] == [0, 1]
+
+    items = [item for _, batch in dataset.retrieve_latent_cache_batches(num_workers=1) for item in batch]
+    by_key = {item.item_key: item.datasource_index for item in items}
+    assert by_key == {dataset.datasource.image_paths[0]: 0, dataset.datasource.image_paths[1]: 1}

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -10,7 +10,7 @@ import torch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from musubi_tuner.dataset.datasources import ImageDirectoryDatasource, ImageJsonlDatasource
+from musubi_tuner.dataset.datasources import ImageDirectoryDatasource, ImageJsonlDatasource, ItemExtras, VideoDirectoryDatasource
 from musubi_tuner.minimax_h3.media import (
     ONE_FRAME_REFERENCE_FRAME_CAP,
     H3AudioSource,
@@ -18,7 +18,6 @@ from musubi_tuner.minimax_h3.media import (
     H3Record,
     H3Reference,
     audio_latent_frames,
-    h3_image_records_from_datasource,
     h3_records_from_datasource,
     load_h3_jsonl_records,
     parse_inline_references,
@@ -199,28 +198,57 @@ def test_records_from_jsonl_datasource_share_the_parsed_data(tmp_path: Path):
     datasource = VideoJsonlDatasource(str(jsonl))
     records = h3_records_from_datasource(datasource, "t2va", lambda path: H3MediaInfo(has_audio=False, duration_seconds=5.0))
 
-    assert len(records) == len(datasource.data) == 1
+    assert len(records) == len(datasource) == 1
     assert records[0].video_path == video
     assert records[0].caption == "caption"
     assert records[0].references == ()
+    assert records[0].label == "data.jsonl line 1"
 
 
 def test_records_from_directory_datasource_use_captions_and_resolved_paths(tmp_path: Path):
     video = _touch(tmp_path / "clip.mp4")
+    (tmp_path / "clip.txt").write_text("caption", encoding="utf-8")
 
-    class FakeDirectoryDatasource:
+    datasource = VideoDirectoryDatasource(str(tmp_path), ".txt")
+    records = h3_records_from_datasource(datasource, "t2va")
+
+    assert records == [H3Record(video_path=video, caption="caption", references=(), label=str(video))]
+
+    # a directory item has no place for references, so Ref2VA needs a record-based dataset
+    with pytest.raises(ValueError, match="only video_jsonl_file / image_jsonl_file records can carry"):
+        h3_records_from_datasource(datasource, "ref2va")
+
+
+def test_records_read_only_the_shared_accessors_of_the_datasource(tmp_path: Path):
+    """The H3 record builder must not depend on the datasource implementation (no isinstance,
+    no JSONL internals): a minimal datasource exposing the shared accessors is enough."""
+    video = _touch(tmp_path / "clip.mp4")
+    face = _touch(tmp_path / "refs" / "face.png")
+
+    class MinimalDatasource:
         def __len__(self):
             return 1
 
         def get_caption(self, idx):
             return str(video), "caption"
 
-    records = h3_records_from_datasource(FakeDirectoryDatasource(), "t2va")
+        def get_item_extras(self, idx):
+            return ItemExtras(
+                fields={"references": [{"type": "image", "path": "refs/face.png"}], "teacher_caption": "teacher"},
+                base_directory=str(tmp_path),
+                label="custom item 1",
+            )
 
-    assert records == [H3Record(video_path=video, caption="caption", references=(), jsonl_line=0)]
+    (record,) = h3_records_from_datasource(MinimalDatasource(), "ref2va")
 
-    with pytest.raises(ValueError, match="Ref2VA requires video_jsonl_file"):
-        h3_records_from_datasource(FakeDirectoryDatasource(), "ref2va")
+    assert record.video_path == video
+    assert [(reference.type, reference.path) for reference in record.references] == [("image", face)]
+    assert record.teacher_caption == "teacher"
+    assert record.label == "custom item 1"
+    assert record.context == "H3 custom item 1"
+
+    with pytest.raises(ValueError, match="H3 custom item 1: references require task ref2va"):
+        h3_records_from_datasource(MinimalDatasource(), "t2va")
 
 
 def test_ref2va_reference_audio_resolution_and_media_paths(tmp_path: Path):
@@ -705,7 +733,7 @@ def _cache_record(tmp_path: Path, references=()) -> H3Record:
         video_path=video,
         caption="scene and sound",
         references=tuple(references),
-        jsonl_line=1,
+        label="items.jsonl line 1",
     )
 
 
@@ -1209,7 +1237,7 @@ def _one_frame_reference_record(tmp_path: Path, *, with_video: bool = True, with
         video_path=_touch(tmp_path / "target.png"),
         caption="a novel view of the character",
         references=tuple(references),
-        jsonl_line=1,
+        label="items.jsonl line 1",
     )
 
 
@@ -1330,7 +1358,7 @@ def test_one_frame_reference_cache_keys_round_trip_through_the_bucket_collator(t
     torch.testing.assert_close(batch["one_frame_target_index"], torch.tensor([24], dtype=torch.int64))
 
 
-def test_h3_image_records_come_from_the_image_jsonl_keyed_by_item_key(tmp_path: Path):
+def test_h3_image_records_come_from_the_image_jsonl_aligned_with_datasource_indices(tmp_path: Path):
     target = _touch(tmp_path / "data" / "target.png")
     face = _touch(tmp_path / "data" / "refs" / "face.png")
     jsonl = tmp_path / "data" / "items.jsonl"
@@ -1346,18 +1374,18 @@ def test_h3_image_records_come_from_the_image_jsonl_keyed_by_item_key(tmp_path: 
     )
     datasource = ImageJsonlDatasource(str(jsonl), control_count_per_image=1)
 
-    records = h3_image_records_from_datasource(datasource, "ref2va")
+    records = h3_records_from_datasource(datasource, "ref2va")
 
-    # keyed by the JSONL image_path string (ItemInfo.item_key), references resolved from the JSONL directory
-    assert list(records) == [str(target)]
-    record = records[str(target)]
+    # one record per datasource index (ItemInfo.datasource_index), references resolved from the JSONL directory
+    assert len(records) == 1
+    record = records[0]
     assert record.video_path == target
     assert record.caption == "a novel view"
     assert [(reference.type, reference.path) for reference in record.references] == [("image", face)]
-    assert record.jsonl_line == 1
+    assert record.label == "items.jsonl line 1"
 
-    with pytest.raises(ValueError, match="references require task ref2va"):
-        h3_image_records_from_datasource(datasource, "t2va")
+    with pytest.raises(ValueError, match="H3 items.jsonl line 1: references require task ref2va"):
+        h3_records_from_datasource(datasource, "t2va")
 
 
 def test_h3_records_carry_the_optional_teacher_caption(tmp_path: Path):
@@ -1378,10 +1406,10 @@ def test_h3_records_carry_the_optional_teacher_caption(tmp_path: Path):
         ],
     )
 
-    records = h3_image_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
+    records = h3_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
 
-    assert records[str(target)].teacher_caption is None
-    assert records[str(face)].teacher_caption == "subject_definitions:\n<Subject 1> ..."
+    assert records[0].teacher_caption is None
+    assert records[1].teacher_caption == "subject_definitions:\n<Subject 1> ..."
 
     video_jsonl = tmp_path / "videos.jsonl"
     _write_jsonl(
@@ -1397,17 +1425,21 @@ def test_h3_records_carry_the_optional_teacher_caption(tmp_path: Path):
         [{"image_path": str(target), "caption": "c", "teacher_caption": "", "references": [{"type": "image", "path": "face.png"}]}],
     )
     with pytest.raises(ValueError, match="teacher_caption must be a non-empty string"):
-        h3_image_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
+        h3_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
 
 
-def test_h3_image_records_require_a_jsonl_for_ref2va_and_reject_duplicates(tmp_path: Path):
+def test_h3_image_records_require_references_for_ref2va_and_reject_duplicates(tmp_path: Path):
     directory = tmp_path / "images"
-    directory.mkdir()
+    image = _touch(directory / "plain.png")
+    (directory / "plain.txt").write_text("plain caption", encoding="utf-8")
     directory_datasource = ImageDirectoryDatasource(str(directory), ".txt", None, 1, False)
 
-    assert h3_image_records_from_datasource(directory_datasource, "t2va") == {}
-    with pytest.raises(ValueError, match="requires image_jsonl_file"):
-        h3_image_records_from_datasource(directory_datasource, "ref2va")
+    # image directories build plain records (t2va / fl2va) but cannot carry references
+    assert h3_records_from_datasource(directory_datasource, "t2va") == [
+        H3Record(video_path=image, caption="plain caption", references=(), label=str(image))
+    ]
+    with pytest.raises(ValueError, match="only video_jsonl_file / image_jsonl_file records can carry"):
+        h3_records_from_datasource(directory_datasource, "ref2va")
 
     target = _touch(tmp_path / "target.png")
     face = _touch(tmp_path / "face.png")
@@ -1415,12 +1447,13 @@ def test_h3_image_records_require_a_jsonl_for_ref2va_and_reject_duplicates(tmp_p
     line = {"image_path": str(target), "caption": "c", "references": [{"type": "image", "path": str(face)}]}
     _write_jsonl(jsonl, [line, line])
 
-    with pytest.raises(ValueError, match="duplicate image_path"):
-        h3_image_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
+    with pytest.raises(ValueError, match="items.jsonl line 2: duplicate target"):
+        h3_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
 
-    _write_jsonl(jsonl, [{"image_path": str(target), "caption": "c"}])
-    with pytest.raises(ValueError, match="at least one visual reference"):
-        h3_image_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
+    # a record without references among records that have them fails on its own line
+    _write_jsonl(jsonl, [line, {"image_path": str(face), "caption": "c"}])
+    with pytest.raises(ValueError, match="items.jsonl line 2: Ref2VA requires at least one visual reference"):
+        h3_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
 
 
 def test_h3_latent_writer_rejects_invalid_one_frame_control_indices(tmp_path: Path):

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -51,7 +51,7 @@ def _record(tmp_path: Path, references=()) -> H3Record:
         video_path=tmp_path / "target.mp4",
         caption="A bright scene with clear sound.",
         references=tuple(references),
-        jsonl_line=1,
+        label="items.jsonl line 1",
     )
 
 


### PR DESCRIPTION
## Summary

The MiniMax-H3 cache scripts were the only architecture code that read the datasource implementation directly: `isinstance(datasource, VideoJsonlDatasource / ImageJsonlDatasource)` plus `.data` / `.video_jsonl_file` / `.image_jsonl_file` access in `minimax_h3/media.py`. The only JSONL-only fields are `references` and `teacher_caption`; everything else (`audio_path`, `control_path`, `datasource_index`, `get_control_paths`) already went through the dataset abstraction.

This PR adds a generic per-item extras accessor to the datasource layer and rewrites the H3 record builder on top of it, so H3 no longer depends on the datasource type. Cache formats, fingerprints, the TOML / JSONL schemas and the trainer are unchanged (no re-cache needed).

### Dataset layer

- `ContentDatasource.get_item_extras(idx) -> ItemExtras(fields, base_directory, label)`: the record's fields beyond the shared schema. JSONL datasources return the keys outside the shared schema (`image_path` / `caption` / `control_path` for images, plus `video_path` / `audio_path` for videos; numbered variants like `control_path_0` count as their base key). Directory datasources return an empty mapping. `base_directory` is the JSONL's directory, `label` reads like `items.jsonl line 3`.
- Image fetchers now carry `datasource_index` like video fetchers, so `ImageDataset` items record their originating index too.

### MiniMax-H3

- One `h3_records_from_datasource()` serves image and video datasets alike (the item_key-keyed image record map is gone): target path and caption come from `get_caption()`, `references` / `teacher_caption` from the extras, and the result is aligned with the datasource indices. Both cache scripts look records up through `ItemInfo.datasource_index` for image and video items.
- `H3Record.jsonl_line` becomes a free-form `label` (`record.context` gives the `H3 <label>` prefix for error messages).
- A directory dataset used with `--task ref2va` now fails with "Ref2VA requires per-item references, which only video_jsonl_file / image_jsonl_file records can carry".

### Behavior change

Datasets sharing a `cache_directory` now fail up front in both H3 cache scripts. Previously two video datasets on one directory silently overwrote each other's record table, so the second dataset's items were matched against the wrong records.

## Test plan

- [x] `pytest tests/` (610 passed) incl. new `tests/test_datasource_item_extras.py`
- [x] Alignment check through the real config path (`BlueprintGenerator`): image JSONL (ref2va) and image directory (t2va) items resolve to their own records
- [x] Existing one-frame ref2va + `--teacher_conditions subject_ref` dataset: `--skip_existing` skips every item (fingerprints unchanged); deleting the caches rebuilds them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHVxauiSby5yfAWSCNkywY
