### PR TITLE
MiniMax-H3: any number of one-frame FL2VA conditions (ordered cond_ slots)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -346,7 +346,7 @@ All entries in one run use the training `--task`. T2VA JSON entries use the comm
 ]
 ```
 
-FL2VA entries additionally use `first_frame` and `last_frame`; the common `image_path` and `end_image_path` names are accepted as aliases. Ref2VA entries use `reference_jsonl`, optional `reference_index`, and an optional `prompt` override. Ref2VA keeps the same ordered JSONL schema as caching and standalone generation.
+FL2VA entries additionally use `first_frame` and `last_frame`; the common `image_path` and `end_image_path` names are accepted as aliases, and one-frame samples may instead give the ordered condition list with `--ci` (see `docs/minimax_h3_1f.md`). Ref2VA entries use `reference_jsonl`, optional `reference_index`, and an optional `prompt` override. Ref2VA keeps the same ordered JSONL schema as caching and standalone generation.
 
 Ref2VA entries may instead carry inline references with the same `--ref` spec strings as generation (see [Generation](#generation)): the `ref` key holds the ordered spec list (in `.txt` prompt files, repeat `--ref` on the line; `--rj` likewise sets `reference_jsonl` per line), the entry's prompt is the caption, and `reference_index` does not apply. `ref` and `reference_jsonl` are mutually exclusive per entry. Relative `ref` paths — and relative `reference_jsonl` paths, when the file exists there — resolve from the prompt file's directory. Because prompt lines split on ` --`, a caption containing that character sequence cannot be expressed in `.txt` prompt files (a pre-existing limitation).
 
@@ -502,6 +502,7 @@ A singer performs under stage lights. --w 768 --h 1344 --f 124 --d 42 --s 30
 | `--fs`, `--fsa` | `--h3_shift_video`, `--h3_shift_audio` |
 | `--ofps`, `--skb` | `--output_fps`, `--stretch_keep_bands` |
 | `--i`, `--ei` | `--first_frame`, `--last_frame` (end image) |
+| `--ci` | `--condition_image` (one-frame FL2VA; repeatable, ordered; replaces the session-level list) |
 | `--ref` | `--ref` (repeatable; replaces the session-level list) |
 | `--of` | `--one_frame` |
 | `--o` | output filename inside the output directory |

--- a/docs/minimax_h3_1f.md
+++ b/docs/minimax_h3_1f.md
@@ -9,12 +9,12 @@
 
 - The target is one video latent token plus the two audio latent frames the joint layout requires. The audio is a byproduct and is never decoded; the output is a PNG (`--output` must use `.png`).
 - The single-token VAE decode duplicates the latent to a pseudo two-token clip and keeps pixel frame 0 (a solo token decode breaks down; the duplication decodes within ~1-2 dB of a true two-token decode). This happens inside the VAE automatically.
-- All tasks are available: `t2va` (plain image), `fl2va` with one or two condition images (editing/inbetween-style probes), and `ref2va` (reference-driven images, including single-image novel-view generation).
+- All tasks are available: `t2va` (plain image), `fl2va` with one or more condition images (editing/inbetween-style probes; one or two is the released API, three or more is experimental), and `ref2va` (reference-driven images, including single-image novel-view generation).
 - `--trajectory_dir` writes per-step PNGs instead of per-step videos.
 - Standalone `audio` references are rejected in one-frame mode (their window is defined by the target duration, which a single frame does not have); video references keep their embedded audio.
 - The released 5-15 s duration gate does not apply; `--allow_experimental_duration` is not needed.
 
-Training on one-frame targets is available for plain image LoRA (T2VA), for editing/inbetween LoRA with 1-2 control images (FL2VA), and for reference-conditioned image LoRA (Ref2VA); see [One-frame training](#one-frame-training-t2va-image-lora), [One-frame editing training](#one-frame-editing-training-fl2va-control-images), and [One-frame reference training](#one-frame-reference-training-ref2va-image-references) below.
+Training on one-frame targets is available for plain image LoRA (T2VA), for editing/inbetween LoRA with time-annotated control images (FL2VA), and for reference-conditioned image LoRA (Ref2VA); see [One-frame training](#one-frame-training-t2va-image-lora), [One-frame editing training](#one-frame-editing-training-fl2va-control-images), and [One-frame reference training](#one-frame-reference-training-ref2va-image-references) below.
 
 ## Time semantics: `--one_frame`
 
@@ -25,7 +25,7 @@ Training on one-frame targets is available for plain image LoRA (T2VA), for edit
 Positions on H3's rotary time axis are expressed as **0-based 24 fps pixel-frame indices** on a nominal timeline (one pixel frame = 5/3 rotary units = 1/24 s). All times are relative to the target-block cursor, which itself moves with the text length — only relative placement carries meaning.
 
 - `target_index` (default 0) places the generated frame.
-- `control_index` places the FL2VA condition images, in `--first_frame`/`--last_frame` order, `;`-separated. It is required when condition images are present and rejected otherwise.
+- `control_index` places the FL2VA condition images, in `--condition_image` order (or `--first_frame`, `--last_frame`), `;`-separated. It is required when condition images are present and rejected otherwise.
 - There is no separate duration parameter: "frame 24 of a 10-second video" is `control_index=0;240` with `target_index=24`.
 
 The base model reads these times as a real signal: an FL2VA anchor at the target's exact time is reproduced almost verbatim (anchor snapping), and intermediate positions interpolate when the caption follows the official alignment-line prompt format. For plain T2VA the index is nearly inert for the base model but remains a trainable input.
@@ -47,15 +47,23 @@ python minimax_h3_generate_video.py \
   --output output.png
 ```
 
-## Conditioned images (FL2VA, one or two pictures)
+## Conditioned images (FL2VA, one or more pictures)
 
-One-frame FL2VA accepts `--first_frame` and/or `--last_frame` — a single picture is officially in-distribution for the FL2VA checkpoint (its released API takes zero, one, or two pictures). The text presentation numbers `<Picture i>` over the pictures that are present, so a lone last frame is still `<Picture 1>`; the first/last distinction is carried by the rotary times alone.
+One-frame FL2VA takes an **ordered list of condition images**: the repeatable `--condition_image` (`--ci` in prompt lines), or `--first_frame` / `--last_frame` as aliases for the first two slots (the two forms cannot be mixed). The pictures are numbered `<Picture i>` in list order and placed on the time axis by `control_index` in the same order; unlike video FL2VA there are no "first"/"last" roles in one-frame mode — a slot's meaning comes from its time alone, so a lone `--last_frame` is still `<Picture 1>`.
+
+One or two pictures is officially in-distribution for the FL2VA checkpoint (its released API takes zero, one, or two pictures). **Three or more pictures is experimental**: community reports show the FL2VA model reads additional pictures as further timed anchors (e.g. first, middle, last) at inference, and Musubi Tuner exposes the same layout for generation and training; effects on quality are yours to verify.
 
 ```bash
 # generate "frame 24" of a nominal clip anchored by one condition image at frame 0
 ... --task fl2va --frame_count 1 \
   --first_frame anchor.png \
   --one_frame "target_index=24,control_index=0" \
+  --prompt "..." --output frame24.png
+
+# three anchors: frames 0, 48 and 96, generating frame 24 (experimental)
+... --task fl2va --frame_count 1 \
+  --condition_image a.png --condition_image b.png --condition_image c.png \
+  --one_frame "target_index=24,control_index=0;48;96" \
   --prompt "..." --output frame24.png
 ```
 
@@ -154,7 +162,7 @@ The LoRA metadata records `ss_minimax_h3_one_frame` for provenance. The resultin
 > [!WARNING]
 > Experimental. This trains the base model's timed-anchor pathway directly; read the index guidance below before building a dataset.
 
-With `--task fl2va`, an image dataset pairs each target image with 1-2 **time-annotated control images**: the controls become FL2VA condition latents (and `<Picture i>` visuals in the text presentation), and their positions on the rotary time axis come from the dataset config. This trains editing LoRAs (control = source image, target = edited image) and inbetween/中割り LoRAs (controls = endpoint frames, target = an intermediate frame).
+With `--task fl2va`, an image dataset pairs each target image with one or more **time-annotated control images**: the controls become FL2VA condition latents (and `<Picture i>` visuals in the text presentation), and their positions on the rotary time axis come from the dataset config. This trains editing LoRAs (control = source image, target = edited image) and inbetween/中割り LoRAs (controls = endpoint frames, target = an intermediate frame; optionally with additional intermediate anchors, see below).
 
 ### Dataset configuration
 
@@ -169,8 +177,8 @@ fp_1f_target_index = 24       # target position — REQUIRED when controls are p
 ```
 
 - `control_directory` matches controls to targets by filename (`image.png` ↔ `image.png` / `image_0.png`), or use `image_jsonl_file` with `control_path` (or `control_path_0`/`control_path_1`) per line. `fp_1f_clean_indices` is what makes the controls timed FL2VA anchors; the same control images without indices are untimed Ref2VA references instead (see the reference training section below).
-- `fp_1f_clean_indices` gives one index per control image, in packed (first, last) order: control 0 is the "first" slot, control 1 the "last" slot. With one control only the "first" slot is used; the slot name carries no time meaning of its own — only the indices do.
-- Both `fp_1f_clean_indices` and an explicit `fp_1f_target_index` are required when controls are present; there are no defaults. Controls are resized to the target's bucket resolution.
+- `fp_1f_clean_indices` gives one index per control image, in control order (`image_0.png` / `control_path_0` first): the controls become the ordered condition slots `cond_000`, `cond_001`, ... and `<Picture 1>`, `<Picture 2>`, ... in the same order. A slot has no time meaning of its own — only the indices do. Any number of controls is accepted; one or two matches the released FL2VA API, **three or more is experimental** (a first/middle/last triple for inbetween training, for example) and its benefit should be checked with an A/B against the two-anchor form.
+- Both `fp_1f_clean_indices` and an explicit `fp_1f_target_index` are required when time-annotated controls are present; there are no defaults. Controls are resized to the target's bucket resolution.
 - The alpha channel of RGBA control images is ignored (dropped before both VAE and text-encoder processing) — unlike FramePack one-frame training, it does not act as a mask.
 - Time-order is unconstrained: an anchor **after** the target (`fp_1f_clean_indices = [120]`, `fp_1f_target_index = 24`) trains an L2VA-style LoRA (generate the image that precedes an end state). Note the official pipeline stretches a lone last picture to the canvas at inference while training resizes to the bucket — a minor known divergence.
 
@@ -182,15 +190,16 @@ The base model's strongest prior is **verbatim anchor copying at coinciding time
 
 ### Caching and training
 
-Same commands as plain image training with `--task fl2va` instead of `--task t2va` on both cache scripts and the trainer. The latent cache additionally holds the condition latents (`latents_first`, plus `latents_last` for two controls) and the control indices as a tensor entry; the text cache embeds the bucket-resized control images in the FL2VA presentation. Changing `fp_1f_target_index` or `fp_1f_clean_indices` re-caches latents only (`--skip_existing` detects it); changing control image files re-caches both.
+Same commands as plain image training with `--task fl2va` instead of `--task t2va` on both cache scripts and the trainer. The latent cache additionally holds the condition latents (`latents_cond_000`, `latents_cond_001`, ... in control order) and the control indices as a tensor entry; the text cache embeds the bucket-resized control images in the FL2VA presentation. Changing `fp_1f_target_index` or `fp_1f_clean_indices` re-caches latents only (`--skip_existing` detects it); changing control image files re-caches both. One-frame FL2VA latent caches written before the ordered `cond_` slots (they used `latents_first`/`latents_last`) are rebuilt automatically by `--skip_existing`, and the trainer rejects them with a re-cache hint if they are used as-is.
 
 The guidance-loss recommendation from plain image training applies unchanged. Training-time samples mirror the generation CLI: provide the condition image(s) and the placement per prompt line:
 
 ```text
 Official-format caption... --w 1024 --h 1024 --f 1 --s 30 --i source.png --of target_index=24,control_index=0
+Official-format caption... --w 1024 --h 1024 --f 1 --s 30 --ci a.png --ci b.png --ci c.png --of target_index=24,control_index=0;48;96
 ```
 
-(`--i` is the first/only condition, `--ei` the last; `control_index` takes one `;`-separated entry per provided image, and is required.)
+(`--ci` is the ordered condition list, repeatable; `--i` / `--ei` alias its first two slots and cannot be mixed with `--ci`; `control_index` takes one `;`-separated entry per condition image, and is required.)
 
 ## One-frame reference training (Ref2VA, image references)
 

--- a/src/musubi_tuner/dataset/cache_io.py
+++ b/src/musubi_tuner/dataset/cache_io.py
@@ -51,8 +51,8 @@ AUDIO_PRESENT_KEY = "audio_present_float32"
 #   loads tensors; the trainer converts it to a RoPE time override at layout-build time.
 ONE_FRAME_TARGET_INDEX_KEY = "one_frame_target_index_int64"
 
-# - ONE_FRAME_CONTROL_INDICES_KEY holds an int64 [K] tensor (K = 1..2) with the 24 fps
-#   pixel-frame indices of the one-frame visual conditions, in packed (first, last) order.
+# - ONE_FRAME_CONTROL_INDICES_KEY holds an int64 [K] tensor (K >= 1) with the 24 fps
+#   pixel-frame indices of the one-frame visual conditions, in cond_{i} slot order.
 #   Present only when the cache carries condition latents; same tensor-not-metadata rationale.
 ONE_FRAME_CONTROL_INDICES_KEY = "one_frame_control_indices_int64"
 
@@ -68,8 +68,8 @@ def append_one_frame_target_index_entry(sd: dict[str, torch.Tensor], target_inde
 
 
 def append_one_frame_control_indices_entry(sd: dict[str, torch.Tensor], control_indices: list[int]):
-    if not 1 <= len(control_indices) <= 2:
-        raise ValueError(f"MiniMax-H3 one-frame control indices must have 1 or 2 entries, got {len(control_indices)}")
+    if len(control_indices) < 1:
+        raise ValueError("MiniMax-H3 one-frame control indices must have at least one entry")
     if any(index < 0 for index in control_indices):
         raise ValueError(f"MiniMax-H3 one-frame control indices must be nonnegative, got {control_indices}")
     sd[ONE_FRAME_CONTROL_INDICES_KEY] = torch.tensor(list(control_indices), dtype=torch.int64)
@@ -562,7 +562,7 @@ def save_latent_cache_minimax_h3(
 
     target_pattern = re.compile(r"^latents_(\d+)x(\d+)x(\d+)_(.+)$")
     audio_pattern = re.compile(r"^latents_audio_32x2x(\d+)_(.+)$")
-    visual_condition_pattern = re.compile(r"^latents_(?:first|last|ref_\d{3}_(?:image|video))_(\d+)x(\d+)x(\d+)_(.+)$")
+    visual_condition_pattern = re.compile(r"^latents_(?:first|last|cond_\d{3}|ref_\d{3}_(?:image|video))_(\d+)x(\d+)x(\d+)_(.+)$")
     audio_condition_pattern = re.compile(r"^latents_ref_\d{3}_audio_32x2x(\d+)_(.+)$")
 
     target_count = 0
@@ -580,10 +580,8 @@ def save_latent_cache_minimax_h3(
             normalized[key] = tensor.detach().cpu().contiguous()
             continue
         if key == ONE_FRAME_CONTROL_INDICES_KEY:
-            if tensor.ndim != 1 or not 1 <= tensor.shape[0] <= 2 or tensor.dtype != torch.int64 or bool((tensor < 0).any()):
-                raise ValueError(
-                    f"MiniMax-H3 {ONE_FRAME_CONTROL_INDICES_KEY} must be a nonnegative int64 [K] tensor with K in 1..2"
-                )
+            if tensor.ndim != 1 or tensor.shape[0] < 1 or tensor.dtype != torch.int64 or bool((tensor < 0).any()):
+                raise ValueError(f"MiniMax-H3 {ONE_FRAME_CONTROL_INDICES_KEY} must be a nonnegative int64 [K] tensor with K >= 1")
             normalized[key] = tensor.detach().cpu().contiguous()
             continue
 

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -325,7 +325,7 @@ class ImageDataset(BaseDataset):
 
         if self.architecture == ARCHITECTURE_MINIMAX_H3:
             # one-frame (image) training: t2va targets (K=0), fl2va editing/inbetween targets with
-            # 1..2 time-annotated control images (fp_1f_clean_indices, 24 fps pixel-frame indices),
+            # K>=1 time-annotated control images (fp_1f_clean_indices, 24 fps pixel-frame indices),
             # or ref2va targets whose control images are untimed references (no indices, any
             # count within the Ref2VA limits). Whether control data is present is only known after
             # datasource construction (JSONL control_path), so indices<->controls is validated there.
@@ -337,8 +337,8 @@ class ImageDataset(BaseDataset):
                     " no_resize_control and control_resolution are not supported"
                 )
             if fp_1f_clean_indices is not None:
-                if not 1 <= len(fp_1f_clean_indices) <= 2:
-                    raise ValueError(f"MiniMax-H3 fp_1f_clean_indices must have 1 or 2 entries, got {len(fp_1f_clean_indices)}")
+                if len(fp_1f_clean_indices) < 1:
+                    raise ValueError("MiniMax-H3 fp_1f_clean_indices must have at least one entry")
                 if any(index < 0 for index in fp_1f_clean_indices):
                     raise ValueError(f"MiniMax-H3 fp_1f_clean_indices must be nonnegative, got {fp_1f_clean_indices}")
                 if fp_1f_target_index is None:
@@ -453,7 +453,7 @@ class ImageDataset(BaseDataset):
                             bucket_reso.append(self.fp_1f_no_post)
                         bucket_reso = tuple(bucket_reso)
                     elif self.architecture == ARCHITECTURE_MINIMAX_H3 and self.fp_1f_clean_indices is not None:
-                        # split by the control count so K=0/1/2 items never share a batch
+                        # split by the control count so items with different K never share a batch
                         bucket_reso = (*bucket_reso, len(self.fp_1f_clean_indices))
 
                     if controls is not None:
@@ -585,9 +585,9 @@ class ImageDataset(BaseDataset):
                     bucket_reso.append(self.fp_1f_no_post)
                 bucket_reso = tuple(bucket_reso)
             elif self.architecture == ARCHITECTURE_MINIMAX_H3 and self.fp_1f_clean_indices is not None:
-                # split by the control count so K=0/1/2 items never share a batch (K is uniform per
-                # dataset, so the dataset-level setting is authoritative; a stale cache with the
-                # wrong condition keys fails in the trainer with a re-cache hint)
+                # split by the control count so items with different K never share a batch (K is
+                # uniform per dataset, so the dataset-level setting is authoritative; a stale cache
+                # with the wrong condition keys fails in the trainer with a re-cache hint)
                 bucket_reso = (*bucket_reso, len(self.fp_1f_clean_indices))
             # Split the bucket by control latents so that every item in a batch has the same number of
             # control images AND matching per-control shapes. The collator stacks latents_control_{i}

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -18,7 +18,7 @@ from musubi_tuner.minimax_h3.media import (
     parse_inline_references,
     waveform_samples,
 )
-from musubi_tuner.minimax_h3.packing import H3ReferenceGeometry, H3VideoGeometry
+from musubi_tuner.minimax_h3.packing import H3ReferenceGeometry, H3VideoGeometry, one_frame_condition_role
 from musubi_tuner.minimax_h3.text_encoder import H3TextVisual
 from musubi_tuner.minimax_h3.video_vae import VIDEO_VAE_ENCODE_DTYPE, encode_video_condition
 from musubi_tuner.minimax_h3_cache_latents import PyAVH3MediaDecoder
@@ -100,15 +100,40 @@ def load_generation_record(args) -> H3Record:
     return record
 
 
+def fl_condition_entries(args) -> tuple[tuple[str, str], ...]:
+    """The FL2VA condition images of a generation request as ordered (role, path) pairs.
+
+    Video targets take the released ``first``/``last`` anchors (``--first_frame`` /
+    ``--last_frame``). One-frame targets take an ordered list of any length: the repeatable
+    ``--condition_image`` (``--ci`` in prompt lines), or, as aliases for the first two slots,
+    ``--first_frame`` / ``--last_frame``; the roles are the ``cond_{i}`` slots and the times come
+    from ``--one_frame control_index`` in the same order.
+    """
+    first_frame = getattr(args, "first_frame", None)
+    last_frame = getattr(args, "last_frame", None)
+    condition_images = getattr(args, "condition_image", None) or ()
+    if getattr(args, "frame_count", None) != 1:
+        if condition_images:
+            raise ValueError(
+                "MiniMax-H3 --condition_image applies to one-frame targets (--frame_count 1); video FL2VA takes"
+                " --first_frame and/or --last_frame"
+            )
+        return tuple((role, path) for role, path in (("first", first_frame), ("last", last_frame)) if path)
+    if condition_images and (first_frame or last_frame):
+        raise ValueError(
+            "MiniMax-H3 one-frame FL2VA takes either --condition_image entries or --first_frame/--last_frame, not both"
+        )
+    paths = list(condition_images) if condition_images else [path for path in (first_frame, last_frame) if path]
+    return tuple((one_frame_condition_role(index), path) for index, path in enumerate(paths))
+
+
 def decode_generation_visuals(args, record: H3Record, decoder: PyAVH3MediaDecoder):
     raw_visuals = {}
     text_visuals = {}
     if args.task == "t2va":
         return raw_visuals, text_visuals
     if args.task == "fl2va":
-        for role, path in (("first", args.first_frame), ("last", args.last_frame)):
-            if path is None:
-                continue
+        for role, path in fl_condition_entries(args):
             frames = load_image_frames(path, width=args.width, height=args.height)
             raw_visuals[role] = frames
             text_visuals[role] = H3TextVisual(frames)
@@ -160,9 +185,8 @@ def encode_visual_conditions(args, record, raw_visuals, video_vae):
         return H3VideoGeometry(*latent.shape[2:])
 
     if args.task == "fl2va":
-        for role in ("first", "last"):
-            if role in raw_visuals:
-                visual_geometries.append(encode_visual(raw_visuals[role]))
+        for role, _ in fl_condition_entries(args):
+            visual_geometries.append(encode_visual(raw_visuals[role]))
     elif args.task == "ref2va":
         for index, reference in enumerate(record.references):
             if reference.type in {"image", "video"}:

--- a/src/musubi_tuner/minimax_h3/packing.py
+++ b/src/musubi_tuner/minimax_h3/packing.py
@@ -87,6 +87,22 @@ class H3ReferenceGeometry:
                     raise ValueError(f"MiniMax-H3 reference video audio has {self.audio_frames} frames, expected {expected}")
 
 
+def one_frame_condition_role(index: int) -> str:
+    """Role of the index-th one-frame FL2VA visual condition (``cond_000``, ``cond_001``, ...).
+
+    One-frame conditions are placed by explicit time overrides, so unlike the released video
+    FL2VA roles (``first``/``last``, whose names select the anchor time) they are plain ordered
+    slots, any number of them; the text presentation numbers ``<Picture i>`` in the same order.
+    """
+    if index < 0:
+        raise ValueError(f"MiniMax-H3 one-frame condition index must be nonnegative, got {index}")
+    return f"cond_{index:03d}"
+
+
+def one_frame_condition_roles(count: int) -> tuple[str, ...]:
+    return tuple(one_frame_condition_role(index) for index in range(count))
+
+
 @dataclass(frozen=True)
 class H3TimeOverrides:
     """Explicit RoPE times for a one-frame layout, in rotary units (1 unit = 1/40 s).
@@ -310,13 +326,20 @@ def build_h3_layout(
         if references:
             raise ValueError("MiniMax-H3 FL2VA layout requires exactly first and last visual conditions")
         if one_frame:
-            if not 1 <= len(visual_conditions) <= 2:
-                raise ValueError("MiniMax-H3 one-frame FL2VA layout requires one or two visual conditions")
+            # ordered cond_{i} slots, any count, each placed by its own time override
+            if not visual_conditions:
+                raise ValueError("MiniMax-H3 one-frame FL2VA layout requires at least one visual condition")
             if time_overrides is None or len(time_overrides.condition_times) != len(visual_conditions):
                 raise ValueError("MiniMax-H3 one-frame FL2VA layout requires one condition time override per condition")
-        elif not 1 <= len(visual_conditions) <= 2:
-            raise ValueError("MiniMax-H3 FL2VA layout requires one or two visual conditions (first and/or last)")
-        roles = _fl_condition_roles(condition_roles, len(visual_conditions))
+            roles = one_frame_condition_roles(len(visual_conditions))
+            if condition_roles is not None and tuple(condition_roles) != roles:
+                raise ValueError(
+                    f"MiniMax-H3 one-frame FL2VA condition roles are the ordered {roles}, got {tuple(condition_roles)}"
+                )
+        else:
+            if not 1 <= len(visual_conditions) <= 2:
+                raise ValueError("MiniMax-H3 FL2VA layout requires one or two visual conditions (first and/or last)")
+            roles = _fl_condition_roles(condition_roles, len(visual_conditions))
         for role, condition in zip(roles, visual_conditions):
             if condition != H3VideoGeometry(1, target_video.height, target_video.width):
                 raise ValueError(f"MiniMax-H3 FL2VA {role} condition must be one target-sized latent frame, got {condition}")

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import logging
 from pathlib import Path
+import re
 from typing import Any
 
 import numpy as np
@@ -83,6 +84,9 @@ def _require_visual(visuals: Mapping[object, H3TextVisual], key: object, label: 
         raise ValueError(f"MiniMax-H3 presentation is missing {label} visual data") from error
 
 
+_ONE_FRAME_CONDITION_KEY = re.compile(r"^cond_\d{3}$")
+
+
 def build_presentation(
     record: H3Record,
     task: H3Task,
@@ -103,8 +107,17 @@ def build_presentation(
     if task == "fl2va":
         # the released builder numbers <Picture i> over the pictures that are present,
         # in packed (first, last) order: a lone last frame is still <Picture 1>, and the
-        # first/last distinction is carried only by the rotary anchor times
+        # first/last distinction is carried only by the rotary anchor times. One-frame
+        # layouts use the ordered cond_{i} slots instead, numbered in slot order.
         present_keys = [key for key in ("first", "last") if key in visuals]
+        cond_keys = sorted(key for key in visuals if isinstance(key, str) and _ONE_FRAME_CONDITION_KEY.fullmatch(key))
+        if present_keys and cond_keys:
+            raise ValueError("MiniMax-H3 FL2VA presentation cannot mix first/last visuals with one-frame cond_ visuals")
+        if cond_keys:
+            expected = [f"cond_{index:03d}" for index in range(len(cond_keys))]
+            if cond_keys != expected:
+                raise ValueError(f"MiniMax-H3 one-frame FL2VA visuals must be the contiguous {expected}, got {cond_keys}")
+            present_keys = cond_keys
         if not present_keys:
             raise ValueError("MiniMax-H3 FL2VA presentation requires at least one of the first and last visuals")
         for index, key in enumerate(present_keys, start=1):

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -34,7 +34,7 @@ from musubi_tuner.dataset.image_video_dataset import ImageDataset, ItemInfo, Vid
 from musubi_tuner.dataset.media_utils import load_video
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode, load_audio_vae
 from musubi_tuner.minimax_h3.checkpoint import resolve_safetensors_files
-from musubi_tuner.minimax_h3.packing import ONE_FRAME_AUDIO_LATENT_FRAMES, ONE_FRAME_VIDEO_LATENT_FRAMES
+from musubi_tuner.minimax_h3.packing import ONE_FRAME_AUDIO_LATENT_FRAMES, ONE_FRAME_VIDEO_LATENT_FRAMES, one_frame_condition_role
 from musubi_tuner.minimax_h3.media import (
     AUDIO_SAMPLE_RATE,
     AUDIO_TERMINAL_TOLERANCE_SAMPLES,
@@ -264,6 +264,9 @@ def _media_fingerprint_metadata(fingerprints: Mapping[Path, str]) -> str:
 # Bump whenever the cached tensor semantics change (posterior policy, normalization constants, key
 # layout, or the fingerprint formats) so --skip_existing rebuilds stale caches.
 LATENT_CACHE_FORMAT = "minimax-h3-latent-v2"
+# The one-frame counterpart, bumped for one-frame-only layout changes so that video caches are not
+# rebuilt along: v2 packs the conditions under the ordered cond_{i} roles (was first/last).
+ONE_FRAME_CACHE_FORMAT = "minimax-h3-one-frame-v2"
 
 
 def build_latent_metadata(
@@ -290,6 +293,7 @@ def build_latent_metadata(
         # duplicated from the tensor entries so --skip_existing rebuilds when the dataset's
         # fp_1f_target_index / fp_1f_clean_indices change (runtime reads the tensors)
         metadata["one_frame"] = "1"
+        metadata["one_frame_format"] = ONE_FRAME_CACHE_FORMAT
         metadata["one_frame_target_index"] = str(one_frame_target_index)
         if one_frame_control_indices is not None:
             metadata["one_frame_control_indices"] = ";".join(str(index) for index in one_frame_control_indices)
@@ -476,9 +480,9 @@ def build_one_frame_latent_tensors(
     """One-frame (image) target: a single video latent token, the silence audio placeholder,
     and the target's 24 fps pixel-frame index as a tensor entry for the trainer's RoPE override.
 
-    With control_frames/control_indices (K=1..2, fl2va editing/inbetween), each bucket-resized
-    control image becomes a condition latent under the packed (first, last) role keys, and the
-    indices ride along as an int64 tensor for the trainer's condition-time overrides.
+    With control_frames/control_indices (K>=1, fl2va editing/inbetween), each bucket-resized
+    control image becomes a condition latent under the ordered ``cond_{i:03d}`` role keys, and
+    the indices ride along as an int64 tensor for the trainer's condition-time overrides.
 
     With a record carrying references (ref2va), the ordered references become numbered
     ``ref_{i:03d}`` condition latents exactly like video Ref2VA caches (image references are
@@ -512,8 +516,8 @@ def build_one_frame_latent_tensors(
             f" got {tuple(silence_audio_latent.shape)}"
         )
     if control_frames is not None:
-        if not 1 <= len(control_frames) <= 2:
-            raise ValueError(f"MiniMax-H3 one-frame caching accepts 1 or 2 control images, got {len(control_frames)}")
+        if len(control_frames) < 1:
+            raise ValueError("MiniMax-H3 one-frame caching requires at least one control image when controls are given")
         if len(control_frames) != len(control_indices):
             raise ValueError(
                 f"MiniMax-H3 one-frame control count {len(control_frames)} does not match {len(control_indices)} control indices"
@@ -530,7 +534,8 @@ def build_one_frame_latent_tensors(
         _audio_key("", silence_audio_latent): silence_audio_latent,
     }
     if control_frames is not None:
-        for role, control in zip(("first", "last"), control_frames):
+        for index, control in enumerate(control_frames):
+            role = one_frame_condition_role(index)
             control = torch.as_tensor(control)
             if control.ndim != 3:
                 raise ValueError(f"MiniMax-H3 one-frame control must be [H,W,C], got {tuple(control.shape)}")
@@ -684,7 +689,7 @@ def setup_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="experimental one-frame (image) training caches: accept image datasets whose items become single-token"
         " video targets with a silence audio placeholder. --task t2va caches plain image targets; --task fl2va"
-        " additionally encodes 1-2 control images as time-annotated conditions (fp_1f_clean_indices); --task ref2va"
+        " additionally encodes the control images as time-annotated conditions (fp_1f_clean_indices); --task ref2va"
         " encodes the per-item references (image_jsonl_file references, or control images without"
         " fp_1f_clean_indices) as untimed Ref2VA conditions",
     )

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -30,6 +30,7 @@ from musubi_tuner.minimax_h3.text_encoder import (
     wrap_ref_teacher_caption,
     wrap_subject_reference_caption,
 )
+from musubi_tuner.minimax_h3.packing import one_frame_condition_role
 from musubi_tuner.minimax_h3.media import (
     ONE_FRAME_REFERENCE_FRAME_CAP,
     H3AudioSource,
@@ -257,7 +258,8 @@ def setup_parser() -> argparse.ArgumentParser:
         "--one_frame",
         action="store_true",
         help="experimental one-frame (image) training caches: accept image datasets. --task t2va encodes plain"
-        " caption presentations; --task fl2va embeds the bucket-resized control images as <Picture i> visuals;"
+        " caption presentations; --task fl2va embeds the bucket-resized control images as <Picture i> visuals (in"
+        " fp_1f_clean_indices order);"
         " --task ref2va embeds the per-item references (image_jsonl_file references, or control images without"
         " fp_1f_clean_indices) in the Ref2VA presentation",
     )
@@ -433,10 +435,10 @@ def main() -> None:
                     control_indices = item.fp_1f_clean_indices
                     if not control_indices or controls is None or len(controls) != len(control_indices):
                         raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control images: {item.item_key}")
-                    for role, control in zip(("first", "last"), controls):
+                    for index, control in enumerate(controls):
                         # the dataset keeps RGBA controls as-is; drop alpha the same way the
                         # latent path does (_prepare_pixels), the processor accepts only RGB
-                        visuals[role] = H3TextVisual(torch.as_tensor(control)[..., :3].unsqueeze(0))
+                        visuals[one_frame_condition_role(index)] = H3TextVisual(torch.as_tensor(control)[..., :3].unsqueeze(0))
                     control_paths = control_paths_by_dir.get(cache_dir_key, {}).get(item.item_key)
                     if control_paths is None or len(control_paths) != len(control_indices):
                         raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control paths: {item.item_key}")

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -24,6 +24,7 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     decode_generation_visuals,
     encode_audio_conditions,
     encode_visual_conditions,
+    fl_condition_entries,
     load_generation_record,
     parse_one_frame_options,
 )
@@ -203,15 +204,15 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
     if one_frame:
         _, control_indices = parse_one_frame_options(args.one_frame) if args.one_frame else (0, None)
         if args.task == "fl2va":
-            provided_frames = int(bool(args.first_frame)) + int(bool(args.last_frame))
-            # a missing-frames error is raised by the task input checks below
-            if provided_frames and (control_indices is None or len(control_indices) != provided_frames):
+            entries = fl_condition_entries(args)
+            # a missing-images error is raised by the task input checks below
+            if entries and (control_indices is None or len(control_indices) != len(entries)):
                 given = 0 if control_indices is None else len(control_indices)
-                provided = " and ".join(label for label in ("first_frame", "last_frame") if getattr(args, label))
+                provided = ", ".join(path for _, path in entries)
                 raise ValueError(
-                    "MiniMax-H3 one-frame FL2VA requires --one_frame control_index with one entry per provided frame:"
-                    f" got {given} control_index entries for {provided_frames} condition frames ({provided}), "
-                    'e.g. --one_frame "target_index=24,control_index=0" for a first frame at index 0'
+                    "MiniMax-H3 one-frame FL2VA requires --one_frame control_index with one entry per condition image:"
+                    f" got {given} control_index entries for {len(entries)} condition images ({provided}), "
+                    'e.g. --one_frame "target_index=24,control_index=0" for one condition at index 0'
                 )
         elif control_indices is not None:
             raise ValueError("MiniMax-H3 --one_frame control_index applies only to FL2VA conditions")
@@ -262,11 +263,12 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
     if args.trajectory_dir and args.output_type == "latent":
         raise ValueError("MiniMax-H3 --trajectory_dir decodes per-step estimates and cannot combine with --output_type latent")
 
+    condition_images = getattr(args, "condition_image", None)
     if args.task == "t2va":
         if not args.prompt:
             raise ValueError("MiniMax-H3 T2VA requires --prompt")
-        if args.first_frame or args.last_frame or args.reference_jsonl or args.ref:
-            raise ValueError("MiniMax-H3 T2VA does not accept first/last/reference inputs")
+        if args.first_frame or args.last_frame or condition_images or args.reference_jsonl or args.ref:
+            raise ValueError("MiniMax-H3 T2VA does not accept condition/first/last/reference inputs")
     elif args.task == "fl2va":
         if getattr(args, "text_cache", None) is not None:
             raise ValueError("MiniMax-H3 FL2VA generation does not accept --text_cache")
@@ -274,19 +276,20 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
             raise ValueError("MiniMax-H3 FL2VA requires --prompt")
         if args.reference_jsonl or args.ref:
             raise ValueError("MiniMax-H3 FL2VA does not accept --reference_jsonl or --ref")
-        if not args.first_frame and not args.last_frame:
+        entries = fl_condition_entries(args)  # rejects --condition_image for video targets and mixed one-frame inputs
+        if not entries:
             raise ValueError(
                 "MiniMax-H3 FL2VA requires --first_frame and/or --last_frame"
-                " (first only = I2VA, last only = L2VA; use --task t2va to condition on neither)"
+                " (first only = I2VA, last only = L2VA; use --task t2va to condition on neither;"
+                " one-frame targets may also take the ordered --condition_image list)"
             )
-        for label in ("first_frame", "last_frame"):
-            if getattr(args, label):
-                _require_path(getattr(args, label), label)
+        for label, path in entries:
+            _require_path(path, label)
     else:
         if bool(args.reference_jsonl) == bool(args.ref):
             raise ValueError("MiniMax-H3 Ref2VA requires exactly one of --reference_jsonl or --ref")
-        if args.first_frame or args.last_frame:
-            raise ValueError("MiniMax-H3 Ref2VA does not accept --first_frame or --last_frame")
+        if args.first_frame or args.last_frame or condition_images:
+            raise ValueError("MiniMax-H3 Ref2VA does not accept --first_frame, --last_frame or --condition_image")
         if args.ref:
             if not args.prompt:
                 raise ValueError("MiniMax-H3 Ref2VA with --ref requires --prompt")
@@ -423,7 +426,7 @@ def _text_conditioning_cache_key(args: argparse.Namespace, record: H3Record, pre
     # the presentation fingerprint hashes text and media shapes; media contents enter through
     # per-file fingerprints. FL2VA frames are not record references, so they are added here.
     if args.task == "fl2va":
-        media_fingerprints = {Path(path): fingerprint_file(path) for path in (args.first_frame, args.last_frame) if path}
+        media_fingerprints = {Path(path): fingerprint_file(path) for _, path in fl_condition_entries(args)}
     else:
         media_fingerprints = {
             reference.path: fingerprint_file(reference.path)
@@ -706,8 +709,9 @@ def _encode_conditions(
 def _build_layout(args: argparse.Namespace, text_length: int, visual_geometries, reference_geometries):
     one_frame = args.frame_count == 1
     condition_roles = None
-    if args.task == "fl2va":
-        condition_roles = tuple(role for role, path in (("first", args.first_frame), ("last", args.last_frame)) if path)
+    if args.task == "fl2va" and not one_frame:
+        # video FL2VA roles select the anchor times; one-frame layouts derive their ordered cond_{i} roles
+        condition_roles = tuple(role for role, _ in fl_condition_entries(args))
     layout = build_h3_layout(
         task=args.task,
         text_length=text_length,
@@ -1020,8 +1024,9 @@ def parse_prompt_line(line: str) -> dict:
     """Parse an interactive/from-file prompt line into argument overrides.
 
     Format: "prompt text --w 768 --h 1344 --f 1 --d 42 --s 30 --fs 12.0 --fsa 3.0
-    --ofps 12 --skb 3 --i first.png --ei last.png --ref face.png --of target_index=24 --o name.png".
-    --ref is repeatable and replaces any session-level --ref list. A line starting
+    --ofps 12 --skb 3 --i first.png --ei last.png --ci cond.png --ref face.png --of target_index=24 --o name.png".
+    --ref and --ci are repeatable and each replaces its session-level list (--ci is the
+    ordered one-frame FL2VA condition list, --condition_image). A line starting
     with "--" carries only options; without prompt text the command-line --prompt
     (when given) stays in effect. The literal string "\\n" in the prompt text becomes
     a newline, for the multi-line official prompt format.
@@ -1032,6 +1037,7 @@ def parse_prompt_line(line: str) -> dict:
     if parts[0].strip():
         overrides["prompt"] = parts[0].strip().replace("\\n", "\n")
     refs: list[str] = []
+    condition_images: list[str] = []
     for part in parts[1:]:
         part = part.strip()
         if not part:
@@ -1060,6 +1066,8 @@ def parse_prompt_line(line: str) -> dict:
             overrides["first_frame"] = value
         elif option == "ei":
             overrides["last_frame"] = value
+        elif option == "ci":
+            condition_images.append(value)
         elif option == "ref":
             refs.append(value)
         elif option == "of":
@@ -1070,6 +1078,8 @@ def parse_prompt_line(line: str) -> dict:
             raise ValueError(f"MiniMax-H3 prompt line has unknown option --{option}")
     if refs:
         overrides["ref"] = refs
+    if condition_images:
+        overrides["condition_image"] = condition_images
     return overrides
 
 
@@ -1452,6 +1462,16 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--first_frame", default=None)
     parser.add_argument("--last_frame", default=None)
+    parser.add_argument(
+        "--condition_image",
+        action="append",
+        default=None,
+        metavar="PATH",
+        help="one-frame FL2VA condition image, repeatable (requires --frame_count 1): the ordered condition list,"
+        " numbered <Picture i> in this order and placed by --one_frame control_index in the same order. Any count"
+        " (the released FL2VA API takes one or two pictures; three or more is experimental). --first_frame /"
+        " --last_frame are aliases for the first two slots and cannot be combined with this option",
+    )
     parser.add_argument("--reference_jsonl", default=None)
     parser.add_argument("--reference_index", type=int, default=0)
     parser.add_argument(
@@ -1479,9 +1499,9 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar="target_index=N,control_index=A;B",
         help="one-frame mode time options (requires --frame_count 1): 0-based 24 fps pixel-frame indices on the"
         " nominal timeline, converted to RoPE times relative to the target-block cursor. target_index (default 0)"
-        " places the generated frame; control_index places the FL2VA condition frames in --first_frame/--last_frame"
-        " order and is required when conditions are present. The base model reads these as trainable time inputs;"
-        " see docs/minimax_h3_1f.md",
+        " places the generated frame; control_index places the FL2VA condition images in --condition_image order"
+        " (or --first_frame, --last_frame) and is required when conditions are present. The base model reads these"
+        " as trainable time inputs; see docs/minimax_h3_1f.md",
     )
     parser.add_argument(
         "--output_fps",
@@ -1528,7 +1548,7 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--from_file",
         default=None,
-        help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--ofps/--skb/--i/--ei/--ref/--of/--o"
+        help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--ofps/--skb/--i/--ei/--ci/--ref/--of/--o"
         " options) from a file and run them in phases, loading each model family once. Sampled latents are saved"
         " to the --output directory before decoding so a crash loses nothing; the files are removed after their"
         " output is written unless --output_type keeps latents. See docs/minimax_h3.md",

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -5,7 +5,7 @@ import gc
 import logging
 import re
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +28,7 @@ from musubi_tuner.minimax_h3.generation_inputs import (
     decode_generation_visuals,
     encode_audio_conditions,
     encode_visual_conditions,
+    fl_condition_entries,
     load_generation_record,
     module_device_dtype,
     parse_one_frame_options,
@@ -49,6 +50,7 @@ from musubi_tuner.minimax_h3.packing import (
     ONE_FRAME_AUDIO_LATENT_FRAMES,
     ONE_FRAME_VIDEO_LATENT_FRAMES,
     build_h3_layout,
+    one_frame_condition_roles,
 )
 from musubi_tuner.minimax_h3.sampling import (
     augment_condition_latents,
@@ -83,6 +85,8 @@ logger = logging.getLogger(__name__)
 
 
 _RUNTIME_REF_KEY = re.compile(r"^latents_ref_(\d{3})_(image|video|audio)$")
+# one-frame FL2VA condition latents (ordered cond_{i} slots); video FL2VA caches use latents_first/last
+_RUNTIME_COND_KEY = re.compile(r"^latents_cond_(\d{3})$")
 # validated --h3_teacher_condition_sigma_max for the endpoint (first,last) and clip (ref) teachers:
 # above it the conditioned content is unpredictable from the text (and the FL2VA weights stop
 # aligning a reference near ~0.85), so the band is better spent as a base-preservation anchor
@@ -158,43 +162,51 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
         sample["prompt"] = prompt
     first_frame = sample.get("first_frame") or sample.get("image_path")
     last_frame = sample.get("last_frame") or sample.get("end_image_path")
+    condition_images = sample.get("condition_image") or sample.get("control_image_path")
     reference_jsonl = sample.get("reference_jsonl")
     ref_specs = sample.get("ref")
     reference_index = int(sample.get("reference_index", 0))
     if ref_specs is not None:
         if not isinstance(ref_specs, list) or not all(isinstance(spec, str) and spec.strip() for spec in ref_specs):
             raise ValueError("MiniMax-H3 training sample --ref entries must be non-empty strings")
+    if condition_images is not None:
+        if not isinstance(condition_images, list) or not all(isinstance(path, str) and path.strip() for path in condition_images):
+            raise ValueError("MiniMax-H3 training sample --ci entries must be non-empty paths")
     if args.task == "t2va":
         if not prompt:
             raise ValueError("MiniMax-H3 T2VA training sample requires a prompt")
-        if first_frame or last_frame or reference_jsonl or ref_specs:
-            raise ValueError("MiniMax-H3 T2VA training sample does not accept first/last/reference inputs")
+        if first_frame or last_frame or condition_images or reference_jsonl or ref_specs:
+            raise ValueError("MiniMax-H3 T2VA training sample does not accept condition/first/last/reference inputs")
     elif args.task == "fl2va":
         if not prompt:
             raise ValueError("MiniMax-H3 FL2VA training sample requires a prompt")
         if reference_jsonl or ref_specs:
             raise ValueError("MiniMax-H3 FL2VA training sample does not accept reference_jsonl or --ref")
+        # the same condition rules as the generation CLI: video samples take first/last, one-frame
+        # samples an ordered list (--ci, or --i/--ei for the first two slots)
+        entries = fl_condition_entries(
+            SimpleNamespace(
+                frame_count=frame_count, first_frame=first_frame, last_frame=last_frame, condition_image=condition_images
+            )
+        )
         if frame_count == 1:
-            # mirror the generation rules: any subset of first/last, one control_index per
-            # provided frame (mandatory — the placement is the training signal)
-            if not first_frame and not last_frame:
-                raise ValueError("MiniMax-H3 one-frame FL2VA training sample requires first_frame and/or last_frame")
-            provided_frames = int(bool(first_frame)) + int(bool(last_frame))
+            # one control_index per condition image (mandatory: the placement is the training signal)
+            if not entries:
+                raise ValueError("MiniMax-H3 one-frame FL2VA training sample requires condition images (--ci, or --i/--ei)")
             control_indices = sample.get("one_frame_control_indices")
-            if control_indices is None or len(control_indices) != provided_frames:
+            if control_indices is None or len(control_indices) != len(entries):
                 raise ValueError(
                     "MiniMax-H3 one-frame FL2VA training sample requires --of control_index with one entry"
-                    " per provided frame, e.g. --of target_index=24,control_index=0"
+                    " per condition image, e.g. --of target_index=24,control_index=0"
                 )
-            for label, value in (("first_frame", first_frame), ("last_frame", last_frame)):
-                if value:
-                    _require_sampling_path(value, label)
+            for role, value in entries:
+                _require_sampling_path(value, role)
         else:
             _require_sampling_path(first_frame, "first_frame")
             _require_sampling_path(last_frame, "last_frame")
     else:
-        if first_frame or last_frame:
-            raise ValueError("MiniMax-H3 Ref2VA training sample does not accept first/last frames")
+        if first_frame or last_frame or condition_images:
+            raise ValueError("MiniMax-H3 Ref2VA training sample does not accept condition/first/last frames")
         prompt_directory = Path(args.sample_prompts).expanduser().resolve().parent
         if ref_specs:
             if reference_jsonl:
@@ -224,6 +236,7 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
         prompt=prompt,
         first_frame=first_frame,
         last_frame=last_frame,
+        condition_image=condition_images,
         reference_jsonl=reference_jsonl,
         ref=ref_specs,
         reference_index=reference_index,
@@ -288,25 +301,39 @@ def _warn_once_coinciding_indices(control_indices: list[int], target_index: int)
     )
 
 
+def _one_frame_condition_roles_in(batch: Mapping[str, Any]) -> tuple[str, ...]:
+    """The ordered cond_{i} roles whose latents the batch carries (empty for video FL2VA caches)."""
+    indices = sorted(int(match.group(1)) for key in batch if (match := _RUNTIME_COND_KEY.fullmatch(key)) is not None)
+    if indices and indices != list(range(len(indices))):
+        raise ValueError(f"MiniMax-H3 one-frame FL2VA condition latents must be the contiguous cond_000..., got {indices}")
+    return one_frame_condition_roles(len(indices))
+
+
 def _collect_fl_conditions(
     batch: dict[str, Any],
     batch_size: int,
     visual_conditions: list[torch.Tensor],
     condition_geometries: list[H3VideoGeometry],
     *,
-    allow_single_first: bool = False,
+    one_frame: bool = False,
 ) -> tuple[str, ...]:
-    roles = tuple(role for role in ("first", "last") if f"latents_{role}" in batch)
-    if not allow_single_first:
-        if roles != ("first", "last"):
+    fl_roles = tuple(role for role in ("first", "last") if f"latents_{role}" in batch)
+    cond_roles = _one_frame_condition_roles_in(batch)
+    if one_frame:
+        # one-frame conditions are the ordered cond_{i} slots; their temporal positions are
+        # carried by one_frame_control_indices, not by role names
+        if fl_roles or not cond_roles:
+            raise ValueError(
+                "MiniMax-H3 one-frame FL2VA batch requires latents_cond_000... condition latents (first/last keys are the"
+                " video layout); re-run minimax_h3_cache_latents.py --one_frame --task fl2va"
+            )
+        roles = cond_roles
+    else:
+        if cond_roles:
+            raise ValueError("MiniMax-H3 video FL2VA batch cannot carry one-frame cond_ condition latents; re-run latent caching")
+        if fl_roles != ("first", "last"):
             raise ValueError("MiniMax-H3 FL2VA batch requires both first and last conditions")
-    elif roles not in {("first",), ("first", "last")}:
-        # a single one-frame condition is always packed as latents_first; its temporal
-        # position is carried by one_frame_control_indices, not the role name
-        raise ValueError(
-            "MiniMax-H3 one-frame FL2VA batch requires latents_first (plus optional latents_last);"
-            " re-run minimax_h3_cache_latents.py --one_frame --task fl2va"
-        )
+        roles = fl_roles
     for role in roles:
         key = f"latents_{role}"
         tensor = batch[key]
@@ -408,7 +435,7 @@ def _runtime_batch_plan(
         raise ValueError("MiniMax-H3 hidden states and token tags must share [B,L]")
     if token_tags.dtype != torch.int64 or not torch.all((token_tags == 0) | (token_tags == 1)):
         raise ValueError("MiniMax-H3 text token tags must be int64 values 0 or 1")
-    has_fl_condition = "latents_first" in batch or "latents_last" in batch
+    has_fl_condition = "latents_first" in batch or "latents_last" in batch or any(_RUNTIME_COND_KEY.fullmatch(key) for key in batch)
     has_fl_teacher_text = "mmh3_teacher_hidden_states" in batch or "mmh3_teacher_token_tags" in batch
     has_ref_teacher_text = "mmh3_teacher_ref_hidden_states" in batch or "mmh3_teacher_ref_token_tags" in batch
     has_subject_ref_teacher_text = (
@@ -600,7 +627,7 @@ def _runtime_batch_plan(
     elif has_fl_condition:
         task = "fl2va"
         fl_condition_roles = _collect_fl_conditions(
-            batch, batch_size, visual_conditions, condition_geometries, allow_single_first=is_one_frame_batch
+            batch, batch_size, visual_conditions, condition_geometries, one_frame=is_one_frame_batch
         )
     elif reference_roles:
         task = "ref2va"
@@ -1108,16 +1135,11 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 else ()
             )
             one_frame_sample = parameter["frame_count"] == 1
-            condition_roles = None
             time_overrides = None
             if one_frame_sample:
-                # roles follow the provided frames (mirrors the generation CLI); condition
-                # times come from --of control_index, one per provided frame
+                # one-frame FL2VA conditions are the ordered cond_{i} slots (the layout derives the
+                # roles); their times come from --of control_index, one per condition image
                 control_indices = parameter.get("one_frame_control_indices")
-                if args.task == "fl2va":
-                    condition_roles = tuple(
-                        role for role, key in (("first", "first_frame"), ("last", "last_frame")) if parameter.get(key)
-                    )
                 time_overrides = H3TimeOverrides(
                     condition_times=(
                         tuple(FRAME_RESCALE * index for index in control_indices) if control_indices is not None else ()
@@ -1138,7 +1160,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 visual_conditions=parameter["_h3_visual_geometries"],
                 references=references,
                 one_frame=one_frame_sample,
-                condition_roles=condition_roles,
                 time_overrides=time_overrides,
             )
             layout = parameter["h3_layout"]

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -1112,7 +1112,7 @@ def test_h3_latent_writer_rejects_invalid_one_frame_target_indices(tmp_path: Pat
             save_latent_cache_minimax_h3(item, {**base, ONE_FRAME_TARGET_INDEX_KEY: index}, {"task": "t2va"})
 
 
-@pytest.mark.parametrize("control_indices", [[0], [0, 48]])
+@pytest.mark.parametrize("control_indices", [[0], [0, 48], [0, 24, 48]])
 def test_build_one_frame_latents_pack_controls_and_their_indices(tmp_path: Path, control_indices: list[int]):
     image_path = _touch(tmp_path / "target.png")
     video_vae = _FakeH3VideoVAE()
@@ -1132,7 +1132,8 @@ def test_build_one_frame_latents_pack_controls_and_their_indices(tmp_path: Path,
         control_indices=control_indices,
     )
 
-    expected_roles = ("first", "last")[: len(control_indices)]
+    # one-frame conditions are the ordered cond_{i} slots (any count), never the video first/last roles
+    expected_roles = tuple(f"cond_{index:03d}" for index in range(len(control_indices)))
     assert set(payload.tensors) == {
         "latents_1x4x4_float32",
         "latents_audio_32x2x2_float32",
@@ -1147,6 +1148,7 @@ def test_build_one_frame_latents_pack_controls_and_their_indices(tmp_path: Path,
     assert [call.shape for call in video_vae.calls] == [(1, 3, 1, 64, 64)] * (1 + len(control_indices))
     assert payload.metadata["task"] == "fl2va"
     assert payload.metadata["one_frame"] == "1"
+    assert payload.metadata["one_frame_format"] == "minimax-h3-one-frame-v2"
     assert payload.metadata["one_frame_control_indices"] == ";".join(str(index) for index in control_indices)
 
 
@@ -1155,10 +1157,7 @@ def test_build_one_frame_latents_pack_controls_and_their_indices(tmp_path: Path,
     [
         ({"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)]}, "together"),
         ({"control_indices": [0]}, "together"),
-        (
-            {"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)] * 3, "control_indices": [0, 1, 2]},
-            "1 or 2 control images",
-        ),
+        ({"control_frames": [], "control_indices": []}, "at least one control image"),
         (
             {"control_frames": [torch.zeros(64, 64, 3, dtype=torch.uint8)], "control_indices": [0, 48]},
             "does not match",
@@ -1558,11 +1557,37 @@ def test_h3_image_records_require_references_for_ref2va_and_reject_duplicates(tm
         h3_records_from_datasource(ImageJsonlDatasource(str(jsonl), control_count_per_image=1), "ref2va")
 
 
+def test_one_frame_format_tag_makes_skip_existing_rebuild_pre_cond_caches(tmp_path: Path):
+    from safetensors.torch import save_file
+
+    from musubi_tuner.minimax_h3_cache_latents import build_latent_metadata
+
+    expected = build_latent_metadata(
+        task="fl2va",
+        crop_start_frame=0,
+        cache_seed=0,
+        video_vae_fingerprint="v",
+        audio_vae_fingerprint="a",
+        media_fingerprints={},
+        one_frame_target_index=24,
+        one_frame_control_indices=[0],
+    )
+    assert expected["one_frame_format"] == "minimax-h3-one-frame-v2"
+
+    # a cache written before the ordered cond_ slots carries every other key but not the one-frame format tag
+    legacy = {key: value for key, value in expected.items() if key != "one_frame_format"}
+    path = tmp_path / "legacy.safetensors"
+    save_file({"latents_1x4x4_float32": torch.zeros(24, 1, 4, 4)}, str(path), metadata=legacy)
+    assert not cache_metadata_matches(path, expected)
+    save_file({"latents_1x4x4_float32": torch.zeros(24, 1, 4, 4)}, str(path), metadata=expected)
+    assert cache_metadata_matches(path, expected)
+
+
 def test_h3_latent_writer_rejects_invalid_one_frame_control_indices(tmp_path: Path):
     item = _h3_item(tmp_path)
     base = {
         "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_first_1x4x4_float32": torch.zeros(24, 1, 4, 4),
+        "latents_cond_000_1x4x4_float32": torch.zeros(24, 1, 4, 4),
         "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
         AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
         ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
@@ -1571,7 +1596,7 @@ def test_h3_latent_writer_rejects_invalid_one_frame_control_indices(tmp_path: Pa
         torch.tensor(0, dtype=torch.int64),
         torch.tensor([0], dtype=torch.int32),
         torch.tensor([-1], dtype=torch.int64),
-        torch.tensor([0, 1, 2], dtype=torch.int64),
+        torch.tensor([], dtype=torch.int64),
         torch.zeros(1, 1, dtype=torch.int64),
     )
     for indices in invalid:

--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -36,6 +36,7 @@ def _load_training_module(monkeypatch):
         decode_generation_visuals=noop,
         encode_audio_conditions=noop,
         encode_visual_conditions=noop,
+        fl_condition_entries=noop,
         load_generation_record=noop,
         module_device_dtype=noop,
         parse_one_frame_options=noop,
@@ -194,6 +195,7 @@ def _load_generation_module(monkeypatch):
         decode_generation_visuals=noop,
         encode_audio_conditions=noop,
         encode_visual_conditions=noop,
+        fl_condition_entries=noop,
         load_generation_record=noop,
         parse_one_frame_options=noop,
     )

--- a/tests/test_minimax_h3_dataset.py
+++ b/tests/test_minimax_h3_dataset.py
@@ -170,7 +170,7 @@ def _h3_image_dataset(tmp_path: Path, **overrides):
         # 1..2 nonnegative entries (controls without indices are untimed references, accepted)
         ({"fp_1f_clean_indices": [0]}, "explicit fp_1f_target_index"),
         ({"fp_1f_clean_indices": [0], "fp_1f_target_index": 24}, "requires control images"),
-        ({"fp_1f_clean_indices": [0, 1, 2], "fp_1f_target_index": 24}, "1 or 2 entries"),
+        ({"fp_1f_clean_indices": [], "fp_1f_target_index": 24}, "at least one entry"),
         ({"fp_1f_clean_indices": [-1], "fp_1f_target_index": 24}, "nonnegative"),
     ],
 )

--- a/tests/test_minimax_h3_generation_modes.py
+++ b/tests/test_minimax_h3_generation_modes.py
@@ -237,8 +237,41 @@ def test_one_frame_fl2va_control_index_error_reports_the_counts(tmp_path):
         output=str(tmp_path / "out.png"),
     )
 
-    with pytest.raises(ValueError, match=r"got 2 control_index entries for 1 condition frames \(first_frame\)"):
+    with pytest.raises(ValueError, match=r"got 2 control_index entries for 1 condition images \(.*first\.png\)"):
         validate_prompt_args(args)
+
+
+def test_one_frame_fl2va_accepts_an_ordered_condition_image_list(tmp_path):
+    conditions = []
+    for name in ("char", "mid", "end"):
+        path = tmp_path / f"{name}.png"
+        path.touch()
+        conditions.append(str(path))
+    base = dict(task="fl2va", frame_count=1, output=str(tmp_path / "out.png"))
+
+    validate_prompt_args(
+        _session_args(tmp_path, **base, condition_image=conditions, one_frame="target_index=24,control_index=0;24;48")
+    )
+    # --first_frame / --last_frame alias the first two slots and cannot be combined with the list
+    with pytest.raises(ValueError, match="not both"):
+        validate_prompt_args(
+            _session_args(
+                tmp_path,
+                **base,
+                condition_image=conditions[:1],
+                first_frame=conditions[0],
+                one_frame="target_index=24,control_index=0;24",
+            )
+        )
+    # ... and the list is a one-frame feature
+    with pytest.raises(ValueError, match="applies to one-frame targets"):
+        validate_prompt_args(_session_args(tmp_path, task="fl2va", condition_image=conditions))
+    # the prompt-line form
+    assert parse_prompt_line("x --ci a.png --ci b.png --of control_index=0;48") == {
+        "prompt": "x",
+        "condition_image": ["a.png", "b.png"],
+        "one_frame": "control_index=0;48",
+    }
 
 
 def test_from_file_records_invalid_lines_without_aborting_the_batch(tmp_path, monkeypatch, caplog):

--- a/tests/test_minimax_h3_packing.py
+++ b/tests/test_minimax_h3_packing.py
@@ -369,27 +369,27 @@ def test_one_frame_layout_validation_rules():
         H3TimeOverrides(condition_times=(-1.0,), target_time=0.0)
 
 
-def test_one_frame_fl2va_layout_supports_one_or_two_roled_conditions():
+def test_one_frame_fl2va_layout_takes_any_number_of_ordered_cond_slots():
     condition = H3VideoGeometry(1, 4, 4)
     overrides = H3TimeOverrides(condition_times=(0.0,), target_time=FRAME_RESCALE * 24)
 
-    for role in ("first", "last"):
-        layout = _one_frame_layout("fl2va", conditions=(condition,), roles=(role,), overrides=overrides)
-        assert [segment.role for segment in layout.segments] == ["text", role, "target_audio", "target_video"]
-
-    both = H3TimeOverrides(condition_times=(0.0, FRAME_RESCALE * 240), target_time=FRAME_RESCALE * 24)
-    layout = _one_frame_layout("fl2va", conditions=(condition, condition), overrides=both)
-    assert [segment.role for segment in layout.segments] == ["text", "first", "last", "target_audio", "target_video"]
+    # one-frame conditions are ordered cond_{i} slots placed by their time overrides; the video
+    # first/last role names (which select anchor times) do not apply
+    for count in (1, 2, 3, 5):
+        times = H3TimeOverrides(condition_times=tuple(float(index) for index in range(count)), target_time=FRAME_RESCALE * 24)
+        layout = _one_frame_layout("fl2va", conditions=(condition,) * count, overrides=times)
+        expected_roles = [f"cond_{index:03d}" for index in range(count)]
+        assert [segment.role for segment in layout.segments] == ["text", *expected_roles, "target_audio", "target_video"]
+        # explicit roles are accepted when they are exactly the derived ones (the uncond rebuild passes them back)
+        assert _one_frame_layout("fl2va", conditions=(condition,) * count, roles=tuple(expected_roles), overrides=times) == layout
 
     with pytest.raises(ValueError, match="one condition time override per condition"):
-        _one_frame_layout("fl2va", conditions=(condition,), roles=("first",))
+        _one_frame_layout("fl2va", conditions=(condition,))
     with pytest.raises(ValueError, match="one condition time override per condition"):
         _one_frame_layout("fl2va", conditions=(condition, condition), overrides=overrides)
-    with pytest.raises(ValueError, match="explicit condition roles"):
-        _one_frame_layout("fl2va", conditions=(condition,), overrides=overrides)
-    with pytest.raises(ValueError, match="first, last, or first\\+last"):
-        _one_frame_layout("fl2va", conditions=(condition, condition), roles=("last", "first"), overrides=both)
-    with pytest.raises(ValueError, match="one or two visual conditions"):
+    with pytest.raises(ValueError, match="ordered"):
+        _one_frame_layout("fl2va", conditions=(condition,), roles=("first",), overrides=overrides)
+    with pytest.raises(ValueError, match="at least one visual condition"):
         _one_frame_layout("fl2va", overrides=H3TimeOverrides(condition_times=(), target_time=0.0))
 
 

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -448,9 +448,9 @@ def test_generation_validation_gates_the_one_frame_mode(tmp_path):
             one_frame="target_index=24,control_index=0",
         )
     )
-    with pytest.raises(ValueError, match="one entry per provided frame"):
+    with pytest.raises(ValueError, match="one entry per condition image"):
         validate_generation_args(_generation_args(tmp_path, task="fl2va", frame_count=1, output=png, first_frame=str(first)))
-    with pytest.raises(ValueError, match="one entry per provided frame"):
+    with pytest.raises(ValueError, match="one entry per condition image"):
         validate_generation_args(
             _generation_args(
                 tmp_path,

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -90,6 +90,20 @@ def test_fl2va_presentation_numbers_a_lone_picture_one_for_either_role(tmp_path:
         build_presentation(record, "fl2va", {})
 
 
+def test_one_frame_fl2va_presentation_numbers_the_cond_slots_in_order(tmp_path: Path):
+    record = _record(tmp_path)
+
+    # the same <Picture i> numbering as the released first/last builder, over the ordered cond_ slots
+    presentation = build_presentation(record, "fl2va", {"cond_002": _visual(1), "cond_000": _visual(1), "cond_001": _visual(1)})
+    assert presentation.text == "".join(f"<Picture {index}>: {IMAGE_PLACEHOLDER}" for index in (1, 2, 3)) + record.caption
+    assert len(presentation.images) == 3
+
+    with pytest.raises(ValueError, match="contiguous"):
+        build_presentation(record, "fl2va", {"cond_001": _visual(1)})
+    with pytest.raises(ValueError, match="cannot mix"):
+        build_presentation(record, "fl2va", {"first": _visual(1), "cond_000": _visual(1)})
+
+
 def test_ref2va_presentation_preserves_jsonl_order_and_timestamp_format(tmp_path: Path):
     image = tmp_path / "face.png"
     video = tmp_path / "motion.mp4"

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -1047,7 +1047,7 @@ def test_one_frame_batch_requires_a_valid_index_tensor(index):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
 
 
-def _one_frame_fl_batch(target_index: int = 24, control_indices: list[int] | None = None, roles=("first",)):
+def _one_frame_fl_batch(target_index: int = 24, control_indices: list[int] | None = None, roles=("cond_000",)):
     batch = _one_frame_batch(target_index=target_index)
     for role in roles:
         batch[f"latents_{role}"] = torch.zeros(1, 24, 1, 4, 4)
@@ -1058,10 +1058,16 @@ def _one_frame_fl_batch(target_index: int = 24, control_indices: list[int] | Non
 
 @pytest.mark.parametrize(
     ("roles", "control_indices"),
-    [(("first",), [0]), (("first", "last"), [0, 48]), (("first",), [120])],
+    [
+        (("cond_000",), [0]),
+        (("cond_000", "cond_001"), [0, 48]),
+        (("cond_000",), [120]),
+        (("cond_000", "cond_001", "cond_002"), [0, 24, 48]),
+    ],
 )
 def test_one_frame_fl2va_batch_builds_condition_time_overrides(monkeypatch, roles, control_indices):
-    # the last case places the lone control AFTER the target (l2va-style) — ordering is free
+    # the third case places the lone control AFTER the target (l2va-style) — ordering is free;
+    # the last one is a three-condition (inbetween with a middle anchor) batch
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(task="fl2va", one_frame=True)
     trainer.handle_model_specific_args(args)
@@ -1107,13 +1113,16 @@ def test_one_frame_fl2va_batch_requires_a_valid_control_indices_tensor(indices):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
 
 
-def test_one_frame_fl2va_batch_rejects_a_lone_last_condition():
+@pytest.mark.parametrize("roles", [("first",), ("last",), ("first", "last"), ("cond_001",)])
+def test_one_frame_fl2va_batch_rejects_legacy_or_gapped_condition_keys(roles):
+    # one-frame caches carry the ordered cond_000... keys; first/last are the video layout (a
+    # pre-cond one-frame cache), and a gap means a broken cache -- both ask for re-caching
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(task="fl2va", one_frame=True)
     trainer.handle_model_specific_args(args)
-    batch = _one_frame_fl_batch(control_indices=[0], roles=("last",))
+    batch = _one_frame_fl_batch(control_indices=[0] * len(roles), roles=roles)
 
-    with pytest.raises(ValueError, match="latents_first"):
+    with pytest.raises(ValueError, match="latents_cond_000|contiguous cond_000"):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
 
 
@@ -1121,7 +1130,7 @@ def test_one_frame_fl2va_batch_requires_matching_condition_and_index_counts():
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(task="fl2va", one_frame=True)
     trainer.handle_model_specific_args(args)
-    batch = _one_frame_fl_batch(control_indices=[0, 48], roles=("first",))
+    batch = _one_frame_fl_batch(control_indices=[0, 48], roles=("cond_000",))
 
     with pytest.raises(ValueError, match="re-run latent caching"):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
@@ -1206,9 +1215,7 @@ def test_one_frame_coinciding_control_and_target_indices_warn_once(monkeypatch, 
     monkeypatch.setattr(train_module, "_coinciding_one_frame_indices_warned", False)
     with caplog.at_level(logging.WARNING):
         for _ in range(2):
-            _one_frame_process_batch(
-                trainer, args, _one_frame_fl_batch(control_indices=[24], roles=("first",)), _RecordingTransformer()
-            )
+            _one_frame_process_batch(trainer, args, _one_frame_fl_batch(control_indices=[24]), _RecordingTransformer())
 
     warnings = [record for record in caplog.records if "verbatim anchor copying" in record.getMessage()]
     assert len(warnings) == 1
@@ -1293,18 +1300,38 @@ def test_one_frame_sample_normalization_parses_the_of_option():
             "REF2VA one-frame training sample does not accept control_index",
         ),
         ({}, {"prompt": "x", "frame_count": 124, "one_frame": "target_index=24"}, r"require --f 1"),
-        # fl2va one-frame: control_index is mandatory, one entry per provided frame
+        # fl2va one-frame: control_index is mandatory, one entry per condition image
         (
             {"task": "fl2va"},
             {"prompt": "x", "frame_count": 1, "first_frame": "a.png", "last_frame": "b.png"},
-            "one entry per provided frame",
+            "one entry per condition image",
         ),
         (
             {"task": "fl2va"},
             {"prompt": "x", "frame_count": 1, "first_frame": "a.png", "one_frame": "control_index=0;48"},
-            "one entry per provided frame",
+            "one entry per condition image",
         ),
-        ({"task": "fl2va"}, {"prompt": "x", "frame_count": 1, "one_frame": "control_index=0"}, "first_frame and/or last_frame"),
+        (
+            {"task": "fl2va"},
+            {"prompt": "x", "frame_count": 1, "control_image_path": ["a.png", "b.png"], "one_frame": "control_index=0"},
+            "one entry per condition image",
+        ),
+        ({"task": "fl2va"}, {"prompt": "x", "frame_count": 1, "one_frame": "control_index=0"}, "requires condition images"),
+        # --ci is the ordered one-frame list; --i/--ei alias its first two slots and cannot be mixed in
+        (
+            {"task": "fl2va"},
+            {
+                "prompt": "x",
+                "frame_count": 1,
+                "control_image_path": ["a.png"],
+                "first_frame": "b.png",
+                "one_frame": "control_index=0;1",
+            },
+            "not both",
+        ),
+        # ... and it is a one-frame feature (video FL2VA samples take first/last)
+        ({"task": "fl2va"}, {"prompt": "x", "frame_count": 124, "control_image_path": ["a.png"]}, "applies to one-frame targets"),
+        ({}, {"prompt": "x", "frame_count": 1, "control_image_path": ["a.png"]}, "does not accept condition"),
     ],
 )
 def test_one_frame_sample_normalization_rejects_invalid_requests(args_overrides, sample, message):
@@ -1334,6 +1361,27 @@ def test_one_frame_fl2va_sample_normalization_parses_control_indices(tmp_path):
     assert sample["frame_count"] == 1
     assert sample["one_frame_target_index"] == 24
     assert sample["one_frame_control_indices"] == (0,)
+    assert sample["condition_image"] is None
+
+    # the ordered --ci list (sampling_prompts parses it as control_image_path), three conditions
+    conditions = []
+    for name in ("a", "b", "c"):
+        path = tmp_path / f"{name}.png"
+        path.touch()
+        conditions.append(str(path))
+    sample = _normalize_h3_sample_parameter(
+        args,
+        {
+            "prompt": "an inbetween",
+            "frame_count": 1,
+            "control_image_path": conditions,
+            "one_frame": "target_index=24,control_index=0;24;48",
+            "width": 64,
+            "height": 64,
+        },
+    )
+    assert sample["condition_image"] == conditions
+    assert sample["one_frame_control_indices"] == (0, 24, 48)
 
 
 def test_one_frame_ref2va_sample_normalization_accepts_inline_refs(tmp_path):
@@ -1805,14 +1853,14 @@ def test_guidance_loss_uncond_layout_carries_one_frame_fl_condition_roles(tmp_pa
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
 
-    batch = _one_frame_fl_batch(control_indices=[0], roles=("first",))
+    batch = _one_frame_fl_batch(control_indices=[0])
     _, metrics = _one_frame_process_batch(trainer, args, batch, transformer)
 
     assert len(transformer.calls) == 2
     uncond_call, cond_call = transformer.calls
     for call in (uncond_call, cond_call):
         assert call["layout"].task == "fl2va"
-        assert tuple(segment.role for segment in call["layout"].segments if segment.kind == "visual_condition") == ("first",)
+        assert tuple(segment.role for segment in call["layout"].segments if segment.kind == "visual_condition") == ("cond_000",)
     assert uncond_call["layout"].time_overrides == cond_call["layout"].time_overrides
     assert uncond_call["layout"].time_overrides.condition_times == (0.0,)
     assert metrics["guidance/applied"] == 1.0


### PR DESCRIPTION
## Summary

Stage 3 of the H3 dataset clean-up (after #1094, #1095): the one-frame FL2VA condition count is no longer capped at two.

One-frame FL2VA layouts no longer borrow the video `first`/`last` roles. The conditions are **ordered slots `cond_000`, `cond_001`, ... of any count**, each placed by its own time (`--one_frame control_index` at inference, `fp_1f_clean_indices` in training), and numbered `<Picture i>` in the same order. In one-frame mode the role names never carried time meaning (the times are explicit overrides), so nothing is lost; the model side is untouched (visual-condition rows are generic packed rows with per-segment RoPE times). Video FL2VA keeps `first`/`last` with the released anchor times.

Motivation: community reports that the FL2VA checkpoint reads a third picture (`<Picture 3>`, e.g. a middle frame) as a further timed anchor at inference; this exposes the same layout for generation and for inbetween training. Three or more anchors are documented as experimental, to be checked with an A/B against the two-anchor form.

### Changes

- **packing**: one-frame fl2va derives the `cond_` roles from the condition count (explicit roles must match, so the guidance-loss uncond rebuild keeps working); the 1..2 cap applies to video layouts only.
- **text presentation**: `cond_` visuals are numbered in slot order; mixing with `first`/`last` or a gap in the slots is an error.
- **latent cache**: one-frame conditions are written as `latents_cond_NNN_*`; the control-indices tensor takes K ≥ 1. A one-frame format tag (`minimax-h3-one-frame-v2`) joins the cache metadata, so `--skip_existing` rebuilds pre-cond one-frame caches **without touching video caches**; the trainer rejects legacy `latents_first`/`latents_last` keys in one-frame batches with a re-cache hint.
- **dataset**: `fp_1f_clean_indices` takes one or more entries for H3 (still pinned to the control count).
- **trainer / generation**: `fl_condition_entries()` is the single source of the ordered condition list. Video targets take `--first_frame`/`--last_frame`; one-frame targets take the repeatable `--condition_image` (`--ci` in prompt lines and training-sample prompts), or `--first_frame`/`--last_frame` as aliases for the first two slots (not both); the `control_index` count must match.
- **docs**: `minimax_h3_1f.md` one-frame FL2VA sections describe the ordered list, the experimental status of three or more anchors, and the automatic re-cache; `minimax_h3.md` prompt-line table gains `--ci`.

### Re-cache

Existing **one-frame FL2VA** latent caches must be regenerated (`--skip_existing` does it automatically via the new format tag). Video caches, one-frame T2VA/Ref2VA caches and all text caches are unchanged (`<Picture i>` numbering is identical for one and two pictures).

## Test plan

- [x] `pytest tests/` (633 passed): K=1/2/3 one-frame cache keys and indices, trainer batches with K=3 and legacy/gapped keys rejected, layout roles for K=1..5, presentation numbering for `cond_` slots, `--condition_image` / `--ci` validation and mixing rules for generation and training samples, legacy cache detection by the format tag
- [x] Real smoke: one-frame FL2VA dataset with `fp_1f_clean_indices = [0, 48, 96]` (cache both scripts, train a few steps, sample with `--ci` ×3); existing two-control dataset re-caches and trains as before (user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEK1d1RFXGCoFfpiQDnRfR
