### PR TITLE
MiniMax-H3: read args directly instead of getattr(args, ...) with defaults

### DIFF
--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -81,14 +81,14 @@ def prepare_pixels(frames: torch.Tensor) -> torch.Tensor:
     return frames.permute(3, 0, 1, 2).unsqueeze(0).contiguous()
 
 
-def load_generation_record(args) -> H3Record:
+def load_generation_record(args, *, ref_base_directory: str | Path | None = None) -> H3Record:
+    """The H3 record of a generation request; ``--ref`` paths resolve from ref_base_directory
+    (the CLI resolves them from the working directory, training samples from the prompt file)."""
     if args.task in {"t2va", "fl2va"}:
         return dummy_record(args.prompt or "")
 
-    ref_specs = getattr(args, "ref", None)
-    if ref_specs:
-        base_directory = Path(getattr(args, "ref_base_directory", None) or Path.cwd())
-        references = parse_inline_references(ref_specs, base_directory)
+    if args.ref:
+        references = parse_inline_references(args.ref, Path(ref_base_directory or Path.cwd()))
         return H3Record(video_path=Path("."), caption=args.prompt or "", references=references, label="--ref")
 
     records = load_h3_jsonl_records(args.reference_jsonl, "ref2va")
@@ -109,10 +109,10 @@ def fl_condition_entries(args) -> tuple[tuple[str, str], ...]:
     ``--first_frame`` / ``--last_frame``; the roles are the ``cond_{i}`` slots and the times come
     from ``--one_frame control_index`` in the same order.
     """
-    first_frame = getattr(args, "first_frame", None)
-    last_frame = getattr(args, "last_frame", None)
-    condition_images = getattr(args, "condition_image", None) or ()
-    if getattr(args, "frame_count", None) != 1:
+    first_frame = args.first_frame
+    last_frame = args.last_frame
+    condition_images = args.condition_image or ()
+    if args.frame_count != 1:
         if condition_images:
             raise ValueError(
                 "MiniMax-H3 --condition_image applies to one-frame targets (--frame_count 1); video FL2VA takes"
@@ -144,7 +144,7 @@ def decode_generation_visuals(args, record: H3Record, decoder: PyAVH3MediaDecode
     else:
         # cap reference videos by the real target duration in native 24 fps frames; a
         # temporal stretch makes that duration exceed frame_count generated frames
-        reference_frame_cap = args.frame_count * TARGET_FPS // getattr(args, "output_fps", TARGET_FPS)
+        reference_frame_cap = args.frame_count * TARGET_FPS // args.output_fps
     for reference in record.references:
         if reference.type not in {"image", "video"}:
             continue
@@ -218,7 +218,7 @@ def encode_audio_conditions(
         else:
             # standalone audio spans the target duration (stretched when --output_fps lowers the
             # sampling rate); one-frame generation rejects it upstream
-            frames = audio_latent_frames(args.frame_count, output_fps=getattr(args, "output_fps", TARGET_FPS))
+            frames = audio_latent_frames(args.frame_count, output_fps=args.output_fps)
             require_exact = False
         waveform = decoder.decode_audio(
             reference.audio,

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -125,8 +125,7 @@ def _explicit_output_name(args: argparse.Namespace, *, directory_output: bool) -
     if args.output_type in ("images", "latent_images"):
         return None
     if directory_output:
-        output_name = getattr(args, "output_name", None)
-        return Path(output_name) if output_name else None
+        return Path(args.output_name) if args.output_name else None
     if _output_is_directory(args.output):
         return None
     return Path(args.output)
@@ -134,42 +133,38 @@ def _explicit_output_name(args: argparse.Namespace, *, directory_output: bool) -
 
 def validate_session_args(args: argparse.Namespace) -> None:
     """Validate arguments that hold for the whole invocation (model paths, mode selection)."""
-    mode_flags = [
-        bool(getattr(args, "interactive", False)),
-        bool(getattr(args, "from_file", None)),
-        bool(getattr(args, "latent_path", None)),
-    ]
+    mode_flags = [bool(args.interactive), bool(args.from_file), bool(args.latent_path)]
     if sum(mode_flags) > 1:
         raise ValueError("MiniMax-H3 --interactive, --from_file, and --latent_path are mutually exclusive")
 
-    if getattr(args, "latent_path", None):
+    if args.latent_path:
         if args.output_type not in ("video", "images"):
             raise ValueError("MiniMax-H3 --latent_path decoding supports --output_type video or images only")
         for path in args.latent_path:
             _require_path(path, "latent_path")
-        _require_path(getattr(args, "video_vae", None), "video_vae")
+        _require_path(args.video_vae, "video_vae")
         return
 
     if not args.task:
         raise ValueError("MiniMax-H3 generation requires --task")
     if args.task not in {"t2va", "fl2va", "ref2va"}:
         raise ValueError("MiniMax-H3 --task must be t2va, fl2va, or ref2va")
-    for label in ("dit", "video_vae", "audio_vae"):
-        _require_path(getattr(args, label, None), label)
+    for label, value in (("dit", args.dit), ("video_vae", args.video_vae), ("audio_vae", args.audio_vae)):
+        _require_path(value, label)
 
-    multi_prompt = bool(getattr(args, "interactive", False)) or bool(getattr(args, "from_file", None))
+    multi_prompt = bool(args.interactive) or bool(args.from_file)
     if multi_prompt:
-        if getattr(args, "text_cache", None):
+        if args.text_cache:
             raise ValueError("MiniMax-H3 --interactive and --from_file do not accept --text_cache")
-        if getattr(args, "trajectory_dir", None):
+        if args.trajectory_dir:
             raise ValueError("MiniMax-H3 --interactive and --from_file do not accept --trajectory_dir")
-        _require_path(getattr(args, "text_encoder", None), "text_encoder")
+        _require_path(args.text_encoder, "text_encoder")
     else:
-        if getattr(args, "text_cache", None) is not None:
+        if args.text_cache is not None:
             _require_path(args.text_cache, "text_cache")
         else:
-            _require_path(getattr(args, "text_encoder", None), "text_encoder")
-    if getattr(args, "from_file", None):
+            _require_path(args.text_encoder, "text_encoder")
+    if args.from_file:
         _require_path(args.from_file, "from_file")
 
     if not 0 <= args.blocks_to_swap <= 48:
@@ -230,13 +225,11 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
             )
     if args.steps <= 0:
         raise ValueError("MiniMax-H3 --steps must be positive")
-    for label in ("h3_shift_video", "h3_shift_audio"):
-        value = float(getattr(args, label))
-        if not 0.01 <= value <= 100.0:
+    for label, value in (("h3_shift_video", args.h3_shift_video), ("h3_shift_audio", args.h3_shift_audio)):
+        if not 0.01 <= float(value) <= 100.0:
             raise ValueError(f"MiniMax-H3 --{label} must be in [0.01,100.0], got {value}")
-    for label in ("h3_visual_cond_clean", "h3_audio_cond_clean"):
-        value = float(getattr(args, label))
-        if not 0.0 <= value <= 1.0:
+    for label, value in (("h3_visual_cond_clean", args.h3_visual_cond_clean), ("h3_audio_cond_clean", args.h3_audio_cond_clean)):
+        if not 0.0 <= float(value) <= 1.0:
             raise ValueError(f"MiniMax-H3 --{label} must be in [0.0,1.0], got {value}")
     if args.output_type in ("images", "latent_images"):
         # --output is a directory holding an auto-named per-generation subdirectory; a
@@ -263,14 +256,14 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
     if args.trajectory_dir and args.output_type == "latent":
         raise ValueError("MiniMax-H3 --trajectory_dir decodes per-step estimates and cannot combine with --output_type latent")
 
-    condition_images = getattr(args, "condition_image", None)
+    condition_images = args.condition_image
     if args.task == "t2va":
         if not args.prompt:
             raise ValueError("MiniMax-H3 T2VA requires --prompt")
         if args.first_frame or args.last_frame or condition_images or args.reference_jsonl or args.ref:
             raise ValueError("MiniMax-H3 T2VA does not accept condition/first/last/reference inputs")
     elif args.task == "fl2va":
-        if getattr(args, "text_cache", None) is not None:
+        if args.text_cache is not None:
             raise ValueError("MiniMax-H3 FL2VA generation does not accept --text_cache")
         if not args.prompt:
             raise ValueError("MiniMax-H3 FL2VA requires --prompt")
@@ -580,7 +573,7 @@ def _configure_lora_weights(transformer, args, device: torch.device, *, prequant
     """
     if not args.lora_weight:
         return []
-    if prequantized or getattr(args, "lora_runtime_attach", False):
+    if prequantized or args.lora_runtime_attach:
         return _apply_lora_weights(transformer, args, device)
     if not args.convrot_int8:
         _merge_lora_weights(transformer, args)
@@ -628,7 +621,7 @@ def _load_transformer(args: argparse.Namespace, device: torch.device) -> tuple[t
     else:
         transformer.to(device)
     transformer.eval().requires_grad_(False)
-    if getattr(args, "compile", False):
+    if args.compile:
         # mirrors minimax_h3_train_network.compile_transformer: ConvRot INT8 Linears are
         # excluded (custom autograd.Function + autotuned Triton kernels are not
         # dynamo-traceable), as are the Linears of swapped blocks
@@ -959,7 +952,7 @@ def _resolve_output_path(args: argparse.Namespace, seed: int, *, directory_mode:
     if directory_mode or images or _output_is_directory(args.output):
         output_dir = Path(args.output).expanduser()
         output_dir.mkdir(parents=True, exist_ok=True)
-        output_name = getattr(args, "output_name", None) if directory_mode else None
+        output_name = args.output_name if directory_mode else None
         return _dedupe_output_path(output_dir / (output_name or _auto_output_name(args, seed)))
     return _dedupe_output_path(Path(args.output).expanduser())
 
@@ -1378,7 +1371,7 @@ def process_latent_decode(args: argparse.Namespace, device: torch.device) -> Non
         source = Path(path).expanduser()
         loaded.append((source, *_load_latent_file(source)))
     if any(audio_latents is not None for _, _, audio_latents, _, _ in loaded):
-        _require_path(getattr(args, "audio_vae", None), "audio_vae")
+        _require_path(args.audio_vae, "audio_vae")
     shared = H3SharedModels(device=device)
     for source, video_latents, audio_latents, frame_count, metadata in loaded:
         logger.info("Decoding MiniMax-H3 latents from %s", source)
@@ -1617,6 +1610,8 @@ def setup_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = setup_parser().parse_args()
+    # not a command-line option: the per-line --o name of the multi-prompt modes, set by
+    # apply_overrides; defined here so every namespace reaching the output helpers has it
     args.output_name = None
     if args.prompt:
         args.prompt = args.prompt.replace("\\n", "\n")

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -6,7 +6,6 @@ import logging
 import re
 import time
 from collections.abc import Mapping, Sequence
-from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -35,6 +34,7 @@ from musubi_tuner.minimax_h3.generation_inputs import (
 )
 from musubi_tuner.minimax_h3.media import (
     H3_AUDIO_SPEC,
+    TARGET_FPS,
     audio_latent_frames,
     parse_inline_references,
     reject_one_frame_audio_references,
@@ -139,10 +139,8 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
                 frame_count,
             )
         video_latent_frames(frame_count)
-        duration = frame_count / 24.0
-        allow_experimental = bool(
-            getattr(args, "h3_allow_experimental_sample_duration", False) or sample.get("allow_experimental_duration", False)
-        )
+        duration = frame_count / TARGET_FPS
+        allow_experimental = bool(args.h3_allow_experimental_sample_duration or sample.get("allow_experimental_duration", False))
         if not allow_experimental and not 5.0 <= duration <= 15.0:
             raise ValueError(
                 f"MiniMax-H3 sample duration {duration:.3f}s is outside the released 5-15s range; "
@@ -166,6 +164,7 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
     reference_jsonl = sample.get("reference_jsonl")
     ref_specs = sample.get("ref")
     reference_index = int(sample.get("reference_index", 0))
+    ref_base_directory = None
     if ref_specs is not None:
         if not isinstance(ref_specs, list) or not all(isinstance(spec, str) and spec.strip() for spec in ref_specs):
             raise ValueError("MiniMax-H3 training sample --ref entries must be non-empty strings")
@@ -215,7 +214,7 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
                 raise ValueError("MiniMax-H3 Ref2VA training sample with --ref requires a prompt")
             if reference_index:
                 raise ValueError("MiniMax-H3 reference_index selects a reference_jsonl record and does not apply to --ref")
-            sample["ref_base_directory"] = str(prompt_directory)
+            ref_base_directory = str(prompt_directory)
             # validate the specs (existence, probes, count limits) before the heavyweight
             # sampling models are loaded; load_generation_record re-parses them later
             parse_inline_references(ref_specs, prompt_directory)
@@ -231,6 +230,8 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
                 raise ValueError("MiniMax-H3 reference_index must be nonnegative")
 
     seed = sample.get("seed")
+    # the normalized sample carries every field the generation-input helpers read (they are
+    # shared with minimax_h3_generate_video.py, whose argparse namespace defines them all)
     sample.update(
         task=args.task,
         prompt=prompt,
@@ -239,10 +240,12 @@ def _normalize_h3_sample_parameter(args: argparse.Namespace, parameter: dict[str
         condition_image=condition_images,
         reference_jsonl=reference_jsonl,
         ref=ref_specs,
+        ref_base_directory=ref_base_directory,
         reference_index=reference_index,
         width=width,
         height=height,
         frame_count=frame_count,
+        output_fps=TARGET_FPS,  # training samples run on the native timeline
         sample_steps=sample_steps,
         seed=None if seed is None else int(seed),
     )
@@ -808,6 +811,9 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         # guidance-loss uncond probe (CPU hidden rows + tags), loaded when
         # --h3_guidance_loss_scale is active
         self._guidance_uncond: tuple[torch.Tensor, torch.Tensor] | None = None
+        # effective base quantization, known once load_transformer has seen the checkpoint
+        # (pre-quantized ConvRot INT8 files are detected there, independent of --convrot_int8)
+        self._convrot_int8_active: bool | None = None
 
     @property
     def architecture(self) -> str:
@@ -823,11 +829,11 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         self._control_training = False
         self.default_guidance_scale = 1.0
         self.default_discrete_flow_shift = 1.0
-        if getattr(args, "task", None) not in {"t2va", "fl2va", "ref2va"}:
+        if args.task not in {"t2va", "fl2va", "ref2va"}:
             raise ValueError("MiniMax-H3 requires --task t2va, fl2va, or ref2va")
-        if getattr(args, "one_frame", False):
+        if args.one_frame:
             if (
-                getattr(args, "h3_teacher_matching", False)
+                args.h3_teacher_matching
                 and normalize_teacher_conditions(args.h3_teacher_conditions) != TEACHER_CONDITIONS_SUBJECT_REF
             ):
                 raise ValueError("--h3_teacher_matching supports --one_frame with --h3_teacher_conditions subject_ref only")
@@ -846,27 +852,21 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         upper = 1000.0 if args.max_timestep is None else float(args.max_timestep)
         if not 0.0 <= lower <= upper <= 1000.0:
             raise ValueError("MiniMax-H3 min_timestep/max_timestep must define a range inside [0,1000]")
-        for name in ("h3_shift_video", "h3_shift_audio"):
-            value = float(getattr(args, name))
-            if not 0.01 <= value <= 100.0:
+        for name, value in (("h3_shift_video", args.h3_shift_video), ("h3_shift_audio", args.h3_shift_audio)):
+            if not 0.01 <= float(value) <= 100.0:
                 raise ValueError(f"--{name} must be in [0.01,100.0], got {value}")
-        for name in ("h3_visual_cond_clean", "h3_audio_cond_clean"):
-            value = float(getattr(args, name))
-            if not 0.0 <= value <= 1.0:
+        for name, value in (("h3_visual_cond_clean", args.h3_visual_cond_clean), ("h3_audio_cond_clean", args.h3_audio_cond_clean)):
+            if not 0.0 <= float(value) <= 1.0:
                 raise ValueError(f"--{name} must be in [0.0,1.0], got {value}")
         if args.audio_loss_weight < 0:
             raise ValueError(f"--audio_loss_weight must be nonnegative, got {args.audio_loss_weight}")
         if args.blocks_to_swap is not None and args.blocks_to_swap > 48:
             raise ValueError("--blocks_to_swap for MiniMax-H3 must be <= 48")
-        if getattr(args, "fp8_base", False) or getattr(args, "fp8_scaled", False):
+        if args.fp8_base or args.fp8_scaled:
             raise ValueError("MiniMax-H3 does not support fp8 transformer bases; use --convrot_int8 for a quantized base")
-        if getattr(args, "dit_dtype", None) not in {None, "bfloat16", "bf16"}:
+        if args.dit_dtype not in {None, "bfloat16", "bf16"}:
             raise ValueError("MiniMax-H3 R1 requires --dit_dtype bfloat16")
-        if (
-            getattr(args, "block_swap_h2d_only", False)
-            and bool(args.blocks_to_swap)
-            and not getattr(args, "gradient_checkpointing", False)
-        ):
+        if args.block_swap_h2d_only and bool(args.blocks_to_swap) and not args.gradient_checkpointing:
             raise ValueError("MiniMax-H3 --block_swap_h2d_only training requires --gradient_checkpointing")
 
         focus_prob = float(args.h3_timestep_focus_prob)
@@ -889,13 +889,17 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         guidance_scale = float(args.h3_guidance_loss_scale)
         if guidance_scale < 0.0:
             raise ValueError(f"--h3_guidance_loss_scale must be nonnegative, got {guidance_scale}")
-        for name in ("h3_teacher_loss_dc_weight", "h3_teacher_loss_mag_weight", "h3_teacher_preservation_weight"):
-            value = float(getattr(args, name))
+        for name, value in (
+            ("h3_teacher_loss_dc_weight", args.h3_teacher_loss_dc_weight),
+            ("h3_teacher_loss_mag_weight", args.h3_teacher_loss_mag_weight),
+            ("h3_teacher_preservation_weight", args.h3_teacher_preservation_weight),
+        ):
+            value = float(value)
             if value < 0.0:
                 raise ValueError(f"--{name} must be nonnegative, got {value}")
-            if value != 1.0 and not getattr(args, "h3_teacher_matching", False):
+            if value != 1.0 and not args.h3_teacher_matching:
                 raise ValueError(f"--{name} shapes the teacher-matching loss and requires --h3_teacher_matching")
-        if getattr(args, "h3_teacher_matching", False):
+        if args.h3_teacher_matching:
             if args.task != "t2va":
                 raise ValueError("MiniMax-H3 --h3_teacher_matching trains a T2VA student and requires --task t2va")
             if guidance_scale > 0.0:
@@ -907,7 +911,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             sigma_max = float(args.h3_teacher_condition_sigma_max)
             if not 0.0 <= sigma_max <= 1.0:
                 raise ValueError(f"--h3_teacher_condition_sigma_max must be in [0.0,1.0], got {sigma_max}")
-            sigma_min = float(getattr(args, "h3_teacher_condition_sigma_min", 0.0))
+            sigma_min = float(args.h3_teacher_condition_sigma_min)
             if not 0.0 <= sigma_min <= sigma_max:
                 raise ValueError(
                     f"--h3_teacher_condition_sigma_min must be in [0.0, --h3_teacher_condition_sigma_max], got {sigma_min}"
@@ -993,7 +997,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 )
             if torch.device(accelerator.device).type != "cuda":
                 raise ValueError("--convrot_int8_bwd int8 requires a CUDA training device")
-        if is_convrot_int8 and getattr(args, "base_weights", None):
+        if is_convrot_int8 and args.base_weights:
             raise ValueError("MiniMax-H3 --base_weights cannot be merged into a ConvRot INT8 transformer base")
 
     def process_sample_prompts(self, args, accelerator, sample_prompts):
@@ -1007,8 +1011,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         del vae_dtype  # the H3 video/audio VAE dtypes are fixed per stage
         if not args.sample_prompts:
             return None, None
-        for label in ("video_vae", "audio_vae", "text_encoder"):
-            _require_sampling_path(getattr(args, label, None), label)
+        for label, value in (("video_vae", args.video_vae), ("audio_vae", args.audio_vae), ("text_encoder", args.text_encoder)):
+            _require_sampling_path(value, label)
         sample_prompts = args.sample_prompts
         logger.info("Preparing MiniMax-H3 joint AV training samples from %s", sample_prompts)
         parameters = [_normalize_h3_sample_parameter(args, item) for item in load_prompts(sample_prompts)]
@@ -1023,16 +1027,16 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             args.text_encoder,
             device=device,
             dtype=torch.bfloat16,
-            disable_mmap=getattr(args, "disable_numpy_memmap", False),
-            nvfp4_scaled_mm=getattr(args, "nvfp4_scaled_mm", False),
-            blocks_to_swap=getattr(args, "text_encoder_blocks_to_swap", 0),
-            attn_mode=getattr(args, "text_encoder_attn_mode", None),
+            disable_mmap=args.disable_numpy_memmap,
+            nvfp4_scaled_mm=args.nvfp4_scaled_mm,
+            blocks_to_swap=args.text_encoder_blocks_to_swap,
+            attn_mode=args.text_encoder_attn_mode,
         )
         text_encoder.eval().requires_grad_(False)
         try:
             for parameter in parameters:
                 request = SimpleNamespace(**parameter)
-                record = load_generation_record(request)
+                record = load_generation_record(request, ref_base_directory=parameter["ref_base_directory"])
                 if parameter["frame_count"] == 1:
                     reject_one_frame_audio_references(record)
                 raw_visuals, text_visuals = decode_generation_visuals(request, record, decoder)
@@ -1054,7 +1058,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             args.video_vae,
             device=video_vae_device,
             dtype=VIDEO_VAE_ENCODE_DTYPE if has_visual_conditions else VIDEO_VAE_DECODE_DTYPE,
-            disable_mmap=getattr(args, "disable_numpy_memmap", False),
+            disable_mmap=args.disable_numpy_memmap,
         )
         video_vae.eval().requires_grad_(False)
         try:
@@ -1100,7 +1104,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             args.audio_vae,
             device=device if has_audio_conditions else torch.device("cpu"),
             dtype=torch.float32,
-            disable_mmap=getattr(args, "disable_numpy_memmap", False),
+            disable_mmap=args.disable_numpy_memmap,
         )
         audio_vae.eval().requires_grad_(False)
         try:
@@ -1257,7 +1261,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 total=sample_steps,
                 desc=f"MiniMax-H3 sample {sample_parameter.get('enum', 0)}",
                 unit="step",
-                disable=not getattr(accelerator, "is_local_main_process", True),
+                disable=not accelerator.is_local_main_process,
             ) as progress:
                 sample = sample_joint_av(
                     transformer,
@@ -1365,21 +1369,21 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             "ss_minimax_h3_audio_loss_weight": args.audio_loss_weight,
             "ss_minimax_h3_video_only": args.video_only,
             "ss_minimax_h3_target_modules": "attn.qkv_proj,attn.out_proj,mlp.fc1,mlp.fc2",
-            "ss_minimax_h3_convrot_int8": getattr(self, "_convrot_int8_active", args.convrot_int8),
+            "ss_minimax_h3_convrot_int8": args.convrot_int8 if self._convrot_int8_active is None else self._convrot_int8_active,
             "ss_minimax_h3_latent_cache_version": "2",
             "ss_minimax_h3_text_cache_version": "1",
         }
-        if getattr(args, "one_frame", False):
+        if args.one_frame:
             metadata["ss_minimax_h3_one_frame"] = True
         if float(args.h3_guidance_loss_scale) > 0.0:
             metadata["ss_minimax_h3_guidance_loss_scale"] = args.h3_guidance_loss_scale
             metadata["ss_minimax_h3_guidance_loss_scale_audio"] = self._guidance_audio_scale(args)
             metadata["ss_minimax_h3_guidance_loss_sigma_min"] = args.h3_guidance_loss_sigma_min
-        if getattr(args, "h3_teacher_matching", False):
+        if args.h3_teacher_matching:
             metadata["ss_minimax_h3_teacher_matching"] = True
             metadata["ss_minimax_h3_teacher_conditions"] = normalize_teacher_conditions(args.h3_teacher_conditions)
             metadata["ss_minimax_h3_teacher_condition_sigma_max"] = args.h3_teacher_condition_sigma_max
-            metadata["ss_minimax_h3_teacher_condition_sigma_min"] = getattr(args, "h3_teacher_condition_sigma_min", 0.0)
+            metadata["ss_minimax_h3_teacher_condition_sigma_min"] = args.h3_teacher_condition_sigma_min
             metadata["ss_minimax_h3_teacher_loss"] = "decomposed_mag_dir"
             metadata["ss_minimax_h3_teacher_loss_mag_weight"] = args.h3_teacher_loss_mag_weight
             metadata["ss_minimax_h3_teacher_loss_dc_weight"] = args.h3_teacher_loss_dc_weight
@@ -1411,7 +1415,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             dtype=torch.bfloat16,
             attn_mode=attn_mode,
             split_attn=split_attn,
-            disable_mmap=getattr(args, "disable_numpy_memmap", False),
+            disable_mmap=args.disable_numpy_memmap,
             convrot_int8=args.convrot_int8,
             convrot_int8_bwd=args.convrot_int8_bwd,
             # quantization runs on the accelerator device even when the weights load to CPU
@@ -1469,7 +1473,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         text_hidden_states = runtime.text_hidden_states.to(device=accelerator.device, dtype=network_dtype)
         noisy_model_input = noisy_model_input.to(accelerator.device)
         noisy_audio_input = noisy_audio_input.to(accelerator.device)
-        autocast = accelerator.autocast if hasattr(accelerator, "autocast") else nullcontext
 
         video_target = latents - noise
         audio_target = audio_latents - audio_noise
@@ -1498,7 +1501,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                     network_dtype,
                 )
                 guidance_log.update(gap_log)
-        if getattr(args, "h3_teacher_matching", False):
+        if args.h3_teacher_matching:
             video_target, audio_target, teacher_log = self._apply_teacher_matching_targets(
                 args,
                 accelerator,
@@ -1522,7 +1525,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             noisy_model_input.requires_grad_(True)
             noisy_audio_input.requires_grad_(True)
             text_hidden_states.requires_grad_(True)
-        with autocast():
+        with accelerator.autocast():
             prediction = transformer(
                 video_latents=noisy_model_input,
                 audio_latents=noisy_audio_input,
@@ -1536,7 +1539,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 visual_condition_clean=args.h3_visual_cond_clean,
                 audio_condition_clean=args.h3_audio_cond_clean,
             )
-        if getattr(args, "h3_teacher_matching", False):
+        if args.h3_teacher_matching:
             # direction/magnitude decomposition of the student-teacher residual (observation
             # only): MSE mixes both, but content errors are direction-flavored while
             # burn/wash-out drift is magnitude-flavored, so the split (binned by
@@ -1616,8 +1619,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             condition_roles=uncond_condition_roles or None,
             time_overrides=runtime.layout.time_overrides,
         )
-        autocast = accelerator.autocast if hasattr(accelerator, "autocast") else nullcontext
-        with torch.no_grad(), autocast():
+        with torch.no_grad(), accelerator.autocast():
             uncond = transformer(
                 video_latents=noisy_model_input,
                 audio_latents=noisy_audio_input,
@@ -1698,16 +1700,11 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             raise RuntimeError("MiniMax-H3 teacher matching batch plan is missing the teacher layout")
         if network is None:
             raise RuntimeError("MiniMax-H3 teacher matching requires the LoRA network to disable it for the teacher forward")
-        unwrap = getattr(accelerator, "unwrap_model", None)
-        base_network = unwrap(network) if callable(unwrap) else network
-        if not hasattr(base_network, "set_enabled"):
-            raise RuntimeError(
-                "MiniMax-H3 teacher matching requires a network exposing set_enabled (e.g. networks.lora_minimax_h3)"
-            )
+        base_network = accelerator.unwrap_model(network)
         # the lower gate is the mirror of the upper one: near sigma 0 the noised target itself
         # reveals x_0, so every teacher's prediction collapses toward the raw velocity (the
         # complete-information de-amplification channel entering from below)
-        sigma_min = float(getattr(args, "h3_teacher_condition_sigma_min", 0.0))
+        sigma_min = float(args.h3_teacher_condition_sigma_min)
         conditioned = sigma_min <= float(base_sigma) <= float(args.h3_teacher_condition_sigma_max)
         if conditioned:
             teacher_text = runtime.teacher_text_hidden_states
@@ -1720,12 +1717,11 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             teacher_layout = runtime.layout
             teacher_visual_conditions = ()
             teacher_audio_conditions = ()
-        autocast = accelerator.autocast if hasattr(accelerator, "autocast") else nullcontext
         # the teacher forward runs before the grad forward so the block-swap offloader keeps
         # its forward->backward alternation and no autograd graph is live yet
         base_network.set_enabled(False)
         try:
-            with torch.no_grad(), autocast():
+            with torch.no_grad(), accelerator.autocast():
                 teacher = transformer(
                     video_latents=noisy_model_input,
                     audio_latents=noisy_audio_input,
@@ -1769,16 +1765,9 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         global_step: int,
     ) -> tuple[torch.Tensor, dict[str, float]]:
         del sample_resources
-        teacher_conditions = (
-            normalize_teacher_conditions(args.h3_teacher_conditions) if getattr(args, "h3_teacher_matching", False) else None
-        )
+        teacher_conditions = normalize_teacher_conditions(args.h3_teacher_conditions) if args.h3_teacher_matching else None
         # _runtime_batch_plan rejects batches larger than one item (batch_size=1 rule)
-        runtime = _runtime_batch_plan(
-            batch,
-            latents,
-            teacher_conditions=teacher_conditions,
-            one_frame=bool(getattr(args, "one_frame", False)),
-        )
+        runtime = _runtime_batch_plan(batch, latents, teacher_conditions=teacher_conditions, one_frame=bool(args.one_frame))
         self._audio_items_seen += int(runtime.audio_present.numel())
         self._audio_supervised_seen += int(runtime.audio_present.sum().item())
         if runtime.layout.task != args.task:
@@ -1791,10 +1780,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             raise ValueError("MiniMax-H3 R1 requires exactly one timestep value for its single-item batch")
         base = self.sample_timesteps(args, 1, pool, latents, device)[0]
         base = _apply_timestep_focus(
-            base,
-            float(getattr(args, "h3_timestep_focus_min", 0.4)),
-            float(getattr(args, "h3_timestep_focus_max", 0.8)),
-            float(getattr(args, "h3_timestep_focus_prob", 0.0)),
+            base, float(args.h3_timestep_focus_min), float(args.h3_timestep_focus_max), float(args.h3_timestep_focus_prob)
         )
         sigma_video = _shift_noise_amount(base, args.h3_shift_video)
         sigma_audio = _shift_noise_amount(base, args.h3_shift_audio)
@@ -1852,12 +1838,12 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         global_step: int,
     ) -> tuple[torch.Tensor, dict[str, float]]:
         del timesteps, noise_scheduler, dit_dtype, global_step
-        teacher_matching = bool(getattr(args, "h3_teacher_matching", False))
+        teacher_matching = bool(args.h3_teacher_matching)
         guidance_log = output.extra.get("guidance_log") or {}
         conditioned_flag = guidance_log.get("teacher/conditioned")
         conditioned = bool(conditioned_flag.item() > 0.5) if isinstance(conditioned_flag, torch.Tensor) else True
-        dc_weight = float(getattr(args, "h3_teacher_loss_dc_weight", 1.0))
-        mag_weight = float(getattr(args, "h3_teacher_loss_mag_weight", 1.0))
+        dc_weight = float(args.h3_teacher_loss_dc_weight)
+        mag_weight = float(args.h3_teacher_loss_mag_weight)
 
         def flow_loss(pred: torch.Tensor, target: torch.Tensor, *, attenuate_dc: bool) -> torch.Tensor:
             if not teacher_matching:
@@ -1900,12 +1886,12 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             # preservation-anchor step: user weight on top of the automatic focus compensation,
             # so raising the timestep focus does not silently weaken the drift protection.
             # loss/video and loss/audio are logged unweighted to keep sigma-binned reads comparable
-            multiplier = float(getattr(args, "h3_teacher_preservation_weight", 1.0)) * _preservation_density_compensation(
+            multiplier = float(args.h3_teacher_preservation_weight) * _preservation_density_compensation(
                 float(args.h3_teacher_condition_sigma_max),
-                float(getattr(args, "h3_timestep_focus_min", 0.4)),
-                float(getattr(args, "h3_timestep_focus_max", 0.8)),
-                float(getattr(args, "h3_timestep_focus_prob", 0.0)),
-                float(getattr(args, "h3_teacher_condition_sigma_min", 0.0)),
+                float(args.h3_timestep_focus_min),
+                float(args.h3_timestep_focus_max),
+                float(args.h3_timestep_focus_prob),
+                float(args.h3_teacher_condition_sigma_min),
             )
             if multiplier != 1.0:
                 total_loss = total_loss * multiplier

--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -45,6 +45,7 @@ def _load_training_module(monkeypatch):
         monkeypatch,
         "musubi_tuner.minimax_h3.media",
         H3_AUDIO_SPEC=object(),
+        TARGET_FPS=24,
         audio_latent_frames=noop,
         parse_inline_references=noop,
         reject_one_frame_audio_references=noop,
@@ -238,15 +239,15 @@ def test_generation_selects_merge_for_bf16_and_attachment_for_int8(monkeypatch):
     int8 = SimpleNamespace(is_convrot_int8=True)
 
     # plain BF16 base: one-time destructive CPU merge
-    args = SimpleNamespace(lora_weight=["adapter.safetensors"], convrot_int8=False)
+    args = SimpleNamespace(lora_weight=["adapter.safetensors"], convrot_int8=False, lora_runtime_attach=False)
     assert generate._configure_lora_weights(bf16, args, device, prequantized=False) == []
     # pre-quantized INT8 base (auto-detected): runtime additive branches
     assert generate._configure_lora_weights(int8, args, device, prequantized=True) is attached
     # BF16 base + --convrot_int8: merged during the streaming load, nothing to do here
-    dynamic_args = SimpleNamespace(lora_weight=["adapter.safetensors"], convrot_int8=True)
+    dynamic_args = SimpleNamespace(lora_weight=["adapter.safetensors"], convrot_int8=True, lora_runtime_attach=False)
     assert generate._configure_lora_weights(int8, dynamic_args, device, prequantized=False) == []
     # no LoRA: nothing happens on any route
-    no_lora = SimpleNamespace(lora_weight=None, convrot_int8=False)
+    no_lora = SimpleNamespace(lora_weight=None, convrot_int8=False, lora_runtime_attach=False)
     assert generate._configure_lora_weights(bf16, no_lora, device, prequantized=False) == []
     # --lora_runtime_attach overrides both merge routes with runtime branches (the merge
     # rounds small-magnitude LoRAs -- e.g. teacher matching -- out of the BF16 weights)

--- a/tests/test_minimax_h3_generation_modes.py
+++ b/tests/test_minimax_h3_generation_modes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import logging
 import sys
 from pathlib import Path
@@ -20,6 +21,17 @@ from musubi_tuner.minimax_h3_generate_video import (
 )
 
 
+def _parser_defaults() -> dict[str, object]:
+    # the script reads plain argparse attributes, so the fake args start from the real parser
+    # defaults and only spell out the values the tests choose
+    parser = generate.setup_parser()
+    return {
+        action.dest: action.default
+        for action in parser._actions
+        if action.dest != "help" and action.default is not argparse.SUPPRESS
+    }
+
+
 def _session_args(tmp_path, *, task="t2va", **overrides):
     paths = {}
     for name in ("dit", "video_vae", "audio_vae", "text_encoder"):
@@ -27,12 +39,14 @@ def _session_args(tmp_path, *, task="t2va", **overrides):
         path.touch()
         paths[name] = str(path)
     values = {
+        **_parser_defaults(),
         **paths,
         "task": task,
         "prompt": "a test prompt",
         "text_cache": None,
         "first_frame": None,
         "last_frame": None,
+        "condition_image": None,
         "reference_jsonl": None,
         "reference_index": 0,
         "ref": None,

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -27,6 +28,7 @@ from musubi_tuner.minimax_h3.sampling import write_image
 from musubi_tuner.minimax_h3_generate_video import (
     _one_frame_time_overrides,
     load_cached_text_conditioning,
+    setup_parser,
     validate_generation_args,
 )
 
@@ -287,6 +289,17 @@ def test_joint_output_uses_a_replaceable_mux_boundary(tmp_path):
     }
 
 
+def _parser_defaults() -> dict[str, object]:
+    # the script reads plain argparse attributes, so the fake args start from the real parser
+    # defaults and only spell out the values the tests choose
+    parser = setup_parser()
+    return {
+        action.dest: action.default
+        for action in parser._actions
+        if action.dest != "help" and action.default is not argparse.SUPPRESS
+    }
+
+
 def _generation_args(tmp_path, *, task="t2va", **overrides):
     paths = {}
     for name in ("dit", "video_vae", "audio_vae", "text_encoder"):
@@ -294,6 +307,7 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         path.touch()
         paths[name] = str(path)
     values = {
+        **_parser_defaults(),
         **paths,
         "task": task,
         "prompt": "a test prompt",
@@ -314,6 +328,8 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         "seed": 1,
         "output": str(tmp_path / "output.mp4"),
         "output_type": "video",
+        "output_name": None,
+        "condition_image": None,
         "blocks_to_swap": 0,
         "h3_shift_video": 12.0,
         "h3_shift_audio": 3.0,
@@ -385,10 +401,10 @@ def test_load_generation_record_builds_inline_ref_records_without_a_jsonl(tmp_pa
             task="ref2va",
             prompt="a cat sings",
             ref=["refs/face.png", "refs/style.webp"],
-            ref_base_directory=str(tmp_path),
             reference_jsonl=None,
             reference_index=0,
-        )
+        ),
+        ref_base_directory=str(tmp_path),
     )
 
     assert record.caption == "a cat sings"

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -103,10 +103,15 @@ def test_h3_epoch_end_stays_silent_unless_audio_supervision_was_expected(caplog,
 
 class _Accelerator:
     device = torch.device("cpu")
+    is_local_main_process = True
 
     @staticmethod
     def autocast():
         return nullcontext()
+
+    @staticmethod
+    def unwrap_model(model):
+        return model
 
 
 class _RecordingTransformer:
@@ -125,11 +130,14 @@ class _RecordingTransformer:
 
 def _parser_defaults() -> dict[str, object]:
     parser = minimax_h3_setup_parser(setup_parser_common())
-    return {
+    defaults = {
         action.dest: action.default
         for action in parser._actions
         if action.dest != "help" and action.default is not argparse.SUPPRESS
     }
+    # set_defaults() entries without an option of their own (e.g. fp8_scaled) are not actions
+    defaults.update(parser._defaults)
+    return defaults
 
 
 # the trainer reads plain argparse attributes, so the fake args start from the real parser defaults:


### PR DESCRIPTION
First of the MiniMax-H3 cleanup series (root causes inherited from the original PR, tracked before the dev -> main merge).

## What

Removes every `getattr(args, name, default)` from the H3 trainer, generation script and `minimax_h3/generation_inputs.py` (74 sites), plus the same defensive pattern on non-args objects.

- All 74 attributes are defined by the script's own parser, so the fallbacks were unreachable copies of the argparse defaults (four copies of the timestep-focus values alone). They now read `args.<name>`; the name loops spell out `(name, value)` pairs instead of `getattr(args, name)`.
- Two plumbing fields are not parser options and are now defined explicitly:
  - `output_name` (generate): the per-line `--o` of the multi-prompt modes, set by `apply_overrides`; `main()` defines it on the namespace with a comment.
  - `ref_base_directory` (generation_inputs): only training-sample requests carried it, so `load_generation_record` takes it as an explicit keyword.
- The training sample dict fed to the shared generation-input helpers lacked `output_fps` / `ref_base_directory`; the normalized sample now carries every field those helpers read, so the helpers no longer branch on which caller they serve.
- Also gone: `hasattr(accelerator, "autocast")` (x3), `getattr(accelerator, "is_local_main_process" / "unwrap_model")`, `hasattr(network, "set_enabled")` (a `LoRANetwork` method), and the undeclared `self._convrot_int8_active` (initialized in `__init__`).

No behavior change on the command line.

## Tests

- `pytest tests -k minimax_h3`: 513 passed
- `ruff check` / `ruff format --check`: clean
- The generate-side test fakes are now seeded from the real parser defaults (as the trainer tests already were), so a new plain attribute read never needs a hand-written key; the trainer helper also picks up `set_defaults()` entries (`fp8_scaled`).

## Next in the series

layering (package importing from the cache CLI) -> cache scripts (dataset identity on `ItemInfo`) -> train/generate contract unification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEK1d1RFXGCoFfpiQDnRfR
