### PR TITLE
MiniMax-H3: find an item's dataset through ItemInfo.dataset_index instead of its cache path

### DIFF
--- a/src/musubi_tuner/cache_latents.py
+++ b/src/musubi_tuner/cache_latents.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import torch
@@ -284,9 +284,21 @@ def encode_and_save_batch(vae: AutoencoderKLCausal3D, batch: list[ItemInfo]):
         save_latent_cache(item, l)
 
 
-def encode_datasets(datasets: list[BaseDataset], encode: callable, args: argparse.Namespace, supports_alpha: bool = False):
-    """Common function to encode datasets. This function is called from multiple architecture scripts."""
+def encode_datasets(
+    datasets: list[BaseDataset],
+    encode: callable,
+    args: argparse.Namespace,
+    supports_alpha: bool = False,
+    cache_is_current: Optional[Callable[[ItemInfo], bool]] = None,
+):
+    """Common function to encode datasets. This function is called from multiple architecture scripts.
+
+    With --skip_existing, an item whose latent cache file exists is skipped; an architecture can
+    replace that test with `cache_is_current(item)` (e.g. to also compare cache metadata).
+    """
     num_workers = args.num_workers if args.num_workers is not None else max(1, os.cpu_count() - 1)
+    if cache_is_current is None:
+        cache_is_current = lambda item: os.path.exists(item.latent_cache_path)  # noqa: E731
     for i, dataset in enumerate(datasets):
         logger.info(f"Encoding dataset [{i}]")
         all_latent_cache_paths = []
@@ -304,7 +316,7 @@ def encode_datasets(datasets: list[BaseDataset], encode: callable, args: argpars
             all_latent_cache_paths.extend([item.latent_cache_path for item in batch])
 
             if args.skip_existing:
-                filtered_batch = [item for item in batch if not os.path.exists(item.latent_cache_path)]
+                filtered_batch = [item for item in batch if not cache_is_current(item)]
                 if len(filtered_batch) == 0:
                     continue
                 batch = filtered_batch

--- a/src/musubi_tuner/cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/cache_text_encoder_outputs.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 import torch
 from tqdm import tqdm
@@ -79,9 +79,13 @@ def process_text_encoder_batches(
     all_cache_paths_for_dataset: list[set],
     encode: callable,
     requires_content: Optional[bool] = False,
+    cache_is_current: Optional[Callable[[ItemInfo], bool]] = None,
 ):
     """
     Architecture independent processing of text encoder batches.
+
+    With skip_existing, an item whose cache file already exists is skipped; an architecture can
+    replace that test with `cache_is_current(item)` (e.g. to also compare cache metadata).
     """
 
     num_workers = num_workers if num_workers is not None else max(1, os.cpu_count() - 1)
@@ -103,9 +107,12 @@ def process_text_encoder_batches(
 
             # skip existing cache files
             if skip_existing:
-                filtered_batch = [
-                    item for item in batch if os.path.normpath(item.text_encoder_output_cache_path) not in all_cache_files
-                ]
+                if cache_is_current is None:
+                    filtered_batch = [
+                        item for item in batch if os.path.normpath(item.text_encoder_output_cache_path) not in all_cache_files
+                    ]
+                else:
+                    filtered_batch = [item for item in batch if not cache_is_current(item)]
                 # print(f"Filtered {len(batch) - len(filtered_batch)} existing cache files")
                 if len(filtered_batch) == 0:
                     continue

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -67,10 +67,12 @@ class ItemInfo:
         # np.ndarray for video, list[np.ndarray] for image with multiple controls
         self.control_content: Optional[Union[np.ndarray, list[np.ndarray]]] = None
 
-        # provenance: the index of the originating datasource record (image and video datasets)
-        # and, for video crops, the start frame of the crop in target-fps space
-        self.frame_pos: Optional[int] = None
+        # provenance: the index of the originating dataset in its DatasetGroup, the index of the
+        # originating datasource record (image and video datasets) and, for video crops, the
+        # start frame of the crop in target-fps space
+        self.dataset_index: Optional[int] = None
         self.datasource_index: Optional[int] = None
+        self.frame_pos: Optional[int] = None
 
         # audio (audio-capable architectures): waveform window [channels, samples] aligned to
         # the crop, and whether it came from real audio (False: silence placeholder)
@@ -141,6 +143,9 @@ class BaseDataset(torch.utils.data.Dataset):
         self.seed = None
         self.current_epoch = 0
         self.shared_epoch = None
+        # position in the owning DatasetGroup (stamped by the group), carried by every ItemInfo
+        # so cache scripts can find the dataset an item came from
+        self.dataset_index: Optional[int] = None
 
         if not self.enable_bucket:
             self.bucket_no_upscale = False
@@ -242,6 +247,7 @@ class BaseDataset(torch.utils.data.Dataset):
                 for future in completed_futures:
                     item_key, caption = future.result()
                     item_info = ItemInfo(item_key, caption, (0, 0), (0, 0))
+                    item_info.dataset_index = self.dataset_index
                     item_info.text_encoder_output_cache_path = self.get_text_encoder_output_cache_path(item_info)
                     data.append(item_info)
 
@@ -434,6 +440,7 @@ class ImageDataset(BaseDataset):
                     item_info = ItemInfo(
                         item_key, caption, original_size, bucket_reso, content=image if len(images) == 1 else images
                     )
+                    item_info.dataset_index = self.dataset_index
                     item_info.datasource_index = datasource_index
                     item_info.latent_cache_path = self.get_latent_cache_path(item_info)
 
@@ -873,8 +880,9 @@ class VideoDataset(BaseDataset):
                             item_info.text_encoder_output_cache_path = self.get_text_encoder_output_cache_path(item_info)
                         item_info.control_content = cropped_control  # None is allowed
                         item_info.fp_latent_window_size = self.fp_latent_window_size
-                        item_info.frame_pos = int(crop_pos)
+                        item_info.dataset_index = self.dataset_index
                         item_info.datasource_index = datasource_index
+                        item_info.frame_pos = int(crop_pos)
 
                         if self.audio_spec is not None:
                             sample_count = self.audio_spec.samples_per_crop(target_frame)
@@ -1023,7 +1031,8 @@ class DatasetGroup(torch.utils.data.ConcatDataset):
         super().__init__(datasets)
         self.datasets: list[Union[ImageDataset, VideoDataset]] = datasets
         self.num_train_items = 0
-        for dataset in self.datasets:
+        for index, dataset in enumerate(self.datasets):
+            dataset.dataset_index = index
             self.num_train_items += dataset.num_train_items
 
     def set_current_epoch(self, epoch):

--- a/src/musubi_tuner/minimax_h3/cache_plan.py
+++ b/src/musubi_tuner/minimax_h3/cache_plan.py
@@ -1,0 +1,172 @@
+"""How the MiniMax-H3 cache scripts see a dataset group.
+
+The shared cache drivers hand the architecture callbacks one batch of ``ItemInfo`` at a time,
+while MiniMax-H3 needs per-dataset context for every item: the H3 records built from the
+datasource (references, teacher captions), the target audio files behind the audio windows,
+and the control image paths behind the control pixels. ``plan_h3_datasets`` builds that
+context once per dataset, and the items find theirs through ``ItemInfo.dataset_index`` (the
+dataset's position in its ``DatasetGroup``) and ``ItemInfo.datasource_index`` (the record's
+position in the datasource). Image and video items are told apart the way every other
+architecture does it: image items carry no ``frame_count``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+from safetensors import safe_open
+
+from musubi_tuner.dataset.audio_utils import AudioSource
+from musubi_tuner.dataset.image_video_dataset import BaseDataset, ImageDataset, ItemInfo, VideoDataset
+from musubi_tuner.minimax_h3.media import H3Record, H3Task, h3_records_from_datasource
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class H3DatasetPlan:
+    index: int
+    is_image: bool
+    # aligned with the datasource indices (ItemInfo.datasource_index)
+    records: list[H3Record]
+    # video datasets: the target audio source of each record (None = silence placeholder);
+    # None when the dataset was built without an audio spec (text caching)
+    audio_sources: Optional[Sequence[Optional[AudioSource]]]
+    # image datasets: {image path: control image paths in index order}, for cache fingerprints
+    control_paths: Mapping[str, Sequence[str]]
+    # image datasets: control images without fp_1f_clean_indices are untimed Ref2VA references
+    controls_as_references: bool
+
+
+def validate_h3_dataset(dataset: BaseDataset) -> None:
+    # image datasets use control images as time-annotated fl2va conditions (validated in the
+    # dataset layer); the shared control-VIDEO fields stay unsupported
+    if isinstance(dataset, VideoDataset) and (dataset.control_directory is not None or dataset.has_control):
+        raise ValueError("MiniMax-H3 does not use the shared control-video fields")
+
+
+def validate_h3_image_dataset_task(dataset, task: H3Task, one_frame: bool, record_task: H3Task | None = None) -> None:
+    """The one-frame task matrix, shared by both cache scripts: plain images cache as t2va;
+    time-annotated control images (fp_1f_clean_indices) require fl2va; control images without
+    indices are untimed references and require the records to be built as ref2va (``record_task``,
+    the cache task itself or the subject-reference teacher's), like JSONL ``references``."""
+    record_task = task if record_task is None else record_task
+    if not one_frame:
+        raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
+    if dataset.fp_1f_clean_indices is not None:
+        if task != "fl2va":
+            raise ValueError(
+                "MiniMax-H3 image datasets with time-annotated control images (fp_1f_clean_indices) require --task fl2va"
+            )
+    elif dataset.has_control:
+        if record_task != "ref2va":
+            raise ValueError(
+                "MiniMax-H3 image datasets with control images and no fp_1f_clean_indices use them as untimed references:"
+                " cache with --task ref2va (or --teacher_conditions subject_ref), or add fp_1f_clean_indices for --task fl2va"
+            )
+    elif task == "fl2va":
+        raise ValueError(
+            "MiniMax-H3 --task fl2va requires image datasets with control images (plain image datasets cache with --task t2va)"
+        )
+
+
+def plan_h3_datasets(
+    datasets: Sequence[BaseDataset],
+    *,
+    task: H3Task,
+    one_frame: bool,
+    record_task: H3Task | None = None,
+) -> list[H3DatasetPlan]:
+    """One plan per dataset of a DatasetGroup, in group order (``ItemInfo.dataset_index``).
+
+    ``record_task`` is the task the records are parsed as when it differs from the cache task
+    (the subject-reference teacher reads Ref2VA references for a T2VA student).
+    """
+    record_task = task if record_task is None else record_task
+    plans = []
+    for index, dataset in enumerate(datasets):
+        if dataset.dataset_index != index:
+            raise ValueError(
+                f"MiniMax-H3 dataset {index} is not at its DatasetGroup position (dataset_index={dataset.dataset_index})"
+            )
+        validate_h3_dataset(dataset)
+        controls_as_references = False
+        control_paths: Mapping[str, Sequence[str]] = {}
+        audio_sources = None
+        if isinstance(dataset, ImageDataset):
+            validate_h3_image_dataset_task(dataset, task, one_frame, record_task)
+            control_paths = dataset.datasource.get_control_paths()
+            controls_as_references = dataset.fp_1f_clean_indices is None
+        elif isinstance(dataset, VideoDataset):
+            audio_sources = dataset.datasource.audio_sources
+        else:
+            raise ValueError("MiniMax-H3 caching accepts only image and video datasets")
+        records = h3_records_from_datasource(dataset.datasource, record_task, control_images_as_references=controls_as_references)
+        plans.append(
+            H3DatasetPlan(
+                index=index,
+                is_image=isinstance(dataset, ImageDataset),
+                records=records,
+                audio_sources=audio_sources,
+                control_paths=control_paths,
+                controls_as_references=controls_as_references,
+            )
+        )
+    return plans
+
+
+def item_plan(plans: Sequence[H3DatasetPlan], item: ItemInfo) -> H3DatasetPlan:
+    """The plan of the dataset an item came from."""
+    if item.dataset_index is None or not 0 <= item.dataset_index < len(plans):
+        raise ValueError(f"MiniMax-H3 cache item is missing its dataset provenance: {item.item_key}")
+    plan = plans[item.dataset_index]
+    if plan.is_image != (item.frame_count is None):
+        raise ValueError(f"MiniMax-H3 cache item does not match its dataset kind: {item.item_key}")
+    return plan
+
+
+def item_record(plan: H3DatasetPlan, item: ItemInfo) -> H3Record:
+    """The H3 record of an item (its datasource record with the H3-specific fields parsed)."""
+    return plan.records[item_record_index(item)]
+
+
+def item_audio_source(plan: H3DatasetPlan, item: ItemInfo) -> Optional[AudioSource]:
+    """The target audio file behind a video item's audio window, if any."""
+    if plan.audio_sources is None:
+        return None
+    return plan.audio_sources[item_record_index(item)]
+
+
+def item_record_index(item: ItemInfo) -> int:
+    if item.datasource_index is None:
+        raise ValueError(f"MiniMax-H3 cache item is missing its datasource provenance: {item.item_key}")
+    return item.datasource_index
+
+
+def item_crop_start(item: ItemInfo) -> int:
+    """The start frame of a video item's crop (target-fps space)."""
+    if item.frame_pos is None:
+        raise ValueError(f"MiniMax-H3 cache item is missing its crop provenance: {item.item_key}")
+    return item.frame_pos
+
+
+def item_control_paths(plan: H3DatasetPlan, item: ItemInfo, expected_count: int) -> list[Path]:
+    """The control image files behind a one-frame item's control pixels, resolved."""
+    control_paths = plan.control_paths.get(item.item_key)
+    if control_paths is None or len(control_paths) != expected_count:
+        raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control paths: {item.item_key}")
+    return [Path(path).resolve() for path in control_paths]
+
+
+def cache_metadata_matches(path: str | Path, expected: Mapping[str, str]) -> bool:
+    """Whether a cache file carries every expected metadata value (the --skip_existing staleness check)."""
+    try:
+        with safe_open(str(path), framework="pt", device="cpu") as handle:
+            actual = handle.metadata() or {}
+    except Exception as error:
+        logger.warning("Unable to read MiniMax-H3 cache metadata from %s: %s", path, error)
+        return False
+    return all(actual.get(key) == value for key, value in expected.items())

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -7,11 +7,9 @@ from dataclasses import dataclass
 from fractions import Fraction
 import json
 import logging
-import os
 from pathlib import Path
 
 import numpy as np
-from safetensors import safe_open
 import torch
 
 import musubi_tuner.cache_latents as cache_latents
@@ -24,8 +22,18 @@ from musubi_tuner.dataset.cache_io import (
     save_latent_cache_minimax_h3,
 )
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
-from musubi_tuner.dataset.image_video_dataset import ImageDataset, ItemInfo, VideoDataset
+from musubi_tuner.dataset.image_video_dataset import ItemInfo
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode, load_audio_vae
+from musubi_tuner.minimax_h3.cache_plan import (
+    H3DatasetPlan,
+    cache_metadata_matches,
+    item_audio_source,
+    item_control_paths,
+    item_crop_start,
+    item_plan,
+    item_record,
+    plan_h3_datasets,
+)
 from musubi_tuner.minimax_h3.checkpoint import fingerprint_checkpoint
 from musubi_tuner.minimax_h3.packing import ONE_FRAME_AUDIO_LATENT_FRAMES, ONE_FRAME_VIDEO_LATENT_FRAMES, one_frame_condition_role
 from musubi_tuner.minimax_h3.media import (
@@ -38,7 +46,6 @@ from musubi_tuner.minimax_h3.media import (
     TARGET_FPS,
     audio_latent_frames,
     fingerprint_file,
-    h3_records_from_datasource,
     module_device_dtype,
     prepare_pixels,
     reject_one_frame_audio_references,
@@ -162,16 +169,6 @@ def build_latent_metadata(
         if one_frame_control_indices is not None:
             metadata["one_frame_control_indices"] = ";".join(str(index) for index in one_frame_control_indices)
     return metadata
-
-
-def cache_metadata_matches(path: str | Path, expected: Mapping[str, str]) -> bool:
-    try:
-        with safe_open(str(path), framework="pt", device="cpu") as handle:
-            actual = handle.metadata() or {}
-    except Exception as error:
-        logger.warning("Unable to read MiniMax-H3 cache metadata from %s: %s", path, error)
-        return False
-    return all(actual.get(key) == value for key, value in expected.items())
 
 
 def build_latent_tensors(
@@ -454,58 +451,22 @@ def record_media_paths(record: H3Record) -> set[Path]:
     return paths
 
 
-def validate_h3_dataset(dataset: VideoDataset | ImageDataset) -> None:
-    # image datasets use control images as time-annotated fl2va conditions (validated in the
-    # dataset layer); the shared control-VIDEO fields stay unsupported
-    if isinstance(dataset, VideoDataset) and (dataset.control_directory is not None or dataset.has_control):
-        raise ValueError("MiniMax-H3 does not use the shared control-video fields")
+@dataclass(frozen=True)
+class _OneFrameCacheInputs:
+    record: H3Record
+    fingerprints: dict[Path, str]
+    control_frames: Sequence[np.ndarray] | None
+    control_indices: list[int] | None
+    target_index: int
+    metadata: dict[str, str]
 
 
-def validate_h3_image_dataset_task(dataset: ImageDataset, task: H3Task, one_frame: bool, record_task: H3Task | None = None) -> None:
-    """The one-frame task matrix, shared by both cache scripts: plain images cache as t2va;
-    time-annotated control images (fp_1f_clean_indices) require fl2va; control images without
-    indices are untimed references and require the records to be built as ref2va (``record_task``,
-    the cache task itself or the subject-reference teacher's), like JSONL ``references``."""
-    record_task = task if record_task is None else record_task
-    if not one_frame:
-        raise ValueError("MiniMax-H3 image datasets require --one_frame (experimental one-frame training)")
-    if dataset.fp_1f_clean_indices is not None:
-        if task != "fl2va":
-            raise ValueError(
-                "MiniMax-H3 image datasets with time-annotated control images (fp_1f_clean_indices) require --task fl2va"
-            )
-    elif dataset.has_control:
-        if record_task != "ref2va":
-            raise ValueError(
-                "MiniMax-H3 image datasets with control images and no fp_1f_clean_indices use them as untimed references:"
-                " cache with --task ref2va (or --teacher_conditions subject_ref), or add fp_1f_clean_indices for --task fl2va"
-            )
-    elif task == "fl2va":
-        raise ValueError(
-            "MiniMax-H3 --task fl2va requires image datasets with control images (plain image datasets cache with --task t2va)"
-        )
-
-
-def dataset_cache_dir_key(cache_directory: str) -> str:
-    return os.path.normpath(os.path.abspath(cache_directory))
-
-
-def item_cache_dir_key(item: ItemInfo) -> str:
-    return dataset_cache_dir_key(os.path.dirname(item.latent_cache_path))
-
-
-def item_datasource_index(item: ItemInfo) -> int:
-    """The index of the item's record in its datasource (and in the H3 records built from it)."""
-    if item.datasource_index is None:
-        raise ValueError(f"MiniMax-H3 cache item is missing datasource provenance: {item.item_key}")
-    return item.datasource_index
-
-
-def item_record_inputs(item: ItemInfo) -> tuple[int, int]:
-    """Returns (datasource_index, crop_start_frame) of a video item with presence validation."""
-    if item.frame_pos is None:
-        raise ValueError(f"MiniMax-H3 cache item is missing its crop provenance: {item.item_key}")
-    return item_datasource_index(item), item.frame_pos
+@dataclass(frozen=True)
+class _VideoCacheInputs:
+    record: H3Record
+    fingerprints: dict[Path, str]
+    crop_start: int
+    metadata: dict[str, str]
 
 
 def log_audio_presence_summary(presence_counts: Mapping[bool, int]) -> None:
@@ -563,36 +524,15 @@ def main() -> None:
     dataset_group = config_utils.generate_dataset_group_by_blueprint(blueprint.dataset_group, audio_spec=H3_AUDIO_SPEC)
     datasets = dataset_group.datasets
 
-    # H3 records per cache directory (image and video datasets alike), aligned with the datasource indices
-    records_by_dir: dict[str, list[H3Record]] = {}
-    audio_sources_by_dir: dict[str, list] = {}
-    image_dirs: set[str] = set()
-    control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
-    for dataset_index, dataset in enumerate(datasets):
-        validate_h3_dataset(dataset)
+    plans = plan_h3_datasets(datasets, task=args.task, one_frame=args.one_frame)
+    for dataset in datasets:
         if int(dataset.batch_size) != 1:
             logger.warning(
                 "MiniMax-H3 dataset %d has batch_size=%d in the dataset config; training requires batch_size=1 "
                 "(use gradient accumulation for a larger effective batch) and will stop on the first training batch",
-                dataset_index,
+                dataset.dataset_index,
                 int(dataset.batch_size),
             )
-        key = dataset_cache_dir_key(dataset.cache_directory)
-        if key in records_by_dir:
-            raise ValueError(f"MiniMax-H3 datasets cannot share a cache_directory: {key}")
-        controls_as_references = False
-        if isinstance(dataset, ImageDataset):
-            validate_h3_image_dataset_task(dataset, args.task, args.one_frame)
-            image_dirs.add(key)
-            control_paths_by_dir[key] = dataset.datasource.get_control_paths()
-            controls_as_references = dataset.fp_1f_clean_indices is None
-        elif isinstance(dataset, VideoDataset):
-            audio_sources_by_dir[key] = dataset.datasource.audio_sources
-        else:
-            raise ValueError("MiniMax-H3 latent caching accepts only image and video datasets")
-        records_by_dir[key] = h3_records_from_datasource(
-            dataset.datasource, args.task, control_images_as_references=controls_as_references
-        )
 
     if args.debug_mode is not None:
         cache_latents.show_datasets(
@@ -607,12 +547,14 @@ def main() -> None:
 
     video_vae_fingerprint = fingerprint_checkpoint(args.video_vae)
     audio_vae_fingerprint = fingerprint_checkpoint(args.audio_vae)
+    # every media file behind the records, fingerprinted before the models load so a missing
+    # file fails fast; control images are fingerprinted per item (they are per-dataset lookups)
     media_fingerprints: dict[Path, str] = {}
-    for key, records in records_by_dir.items():
-        for record in records:
+    for plan in plans:
+        for record in plan.records:
             for path in record_media_paths(record):
                 media_fingerprints[path] = fingerprint_file(path)
-        for source in audio_sources_by_dir.get(key, ()):
+        for source in plan.audio_sources or ():
             if source is not None:
                 media_fingerprints[source.path] = fingerprint_file(source.path)
 
@@ -627,22 +569,18 @@ def main() -> None:
     audio_vae = load_audio_vae(args.audio_vae, device=device, dtype=torch.float32, disable_mmap=args.disable_mmap)
 
     silence_audio_latent: torch.Tensor | None = None
-    if image_dirs:
+    if any(plan.is_image for plan in plans):
         # the silence placeholder is a constant per audio VAE, so encode it once for every item
         silence_audio_latent = encode_one_frame_silence_latent(audio_vae)
 
     decoder = PyAVH3MediaDecoder()
-    skip_matching_cache = args.skip_existing
-    args.skip_existing = False
     presence_counts: Counter[bool] = Counter()
     one_frame_item_count = 0
 
-    def encode_one_frame(item: ItemInfo, cache_dir_key: str) -> None:
-        nonlocal one_frame_item_count
-        one_frame_item_count += 1
-        record = records_by_dir[cache_dir_key][item_datasource_index(item)]
+    def one_frame_inputs(item: ItemInfo, plan: H3DatasetPlan) -> _OneFrameCacheInputs:
+        record = item_record(plan, item)
         # the target image and, for ref2va, the references the cache encodes form the identity
-        image_fingerprints = {path: media_fingerprints[path] for path in record_media_paths(record)}
+        fingerprints = {path: media_fingerprints[path] for path in record_media_paths(record)}
         control_frames = None
         control_indices = None
         if args.task == "fl2va":
@@ -651,96 +589,110 @@ def main() -> None:
             if not control_indices or control_frames is None or len(control_frames) != len(control_indices):
                 raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control images: {item.item_key}")
             control_indices = [int(index) for index in control_indices]
-            control_paths = control_paths_by_dir.get(cache_dir_key, {}).get(item.item_key)
-            if control_paths is None or len(control_paths) != len(control_indices):
-                raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control paths: {item.item_key}")
-            for control_path in control_paths:
-                resolved = Path(control_path).resolve()
-                image_fingerprints[resolved] = media_fingerprints.setdefault(resolved, fingerprint_file(resolved))
+            for control_path in item_control_paths(plan, item, len(control_indices)):
+                fingerprints[control_path] = media_fingerprints.setdefault(control_path, fingerprint_file(control_path))
         target_index = 0 if item.fp_1f_target_index is None else int(item.fp_1f_target_index)
-        expected_metadata = build_latent_metadata(
+        metadata = build_latent_metadata(
             task=args.task,
             crop_start_frame=0,
             cache_seed=args.cache_seed,
             video_vae_fingerprint=video_vae_fingerprint,
             audio_vae_fingerprint=audio_vae_fingerprint,
-            media_fingerprints=image_fingerprints,
+            media_fingerprints=fingerprints,
             one_frame_target_index=target_index,
             one_frame_control_indices=control_indices,
         )
-        if skip_matching_cache and Path(item.latent_cache_path).is_file():
-            if cache_metadata_matches(item.latent_cache_path, expected_metadata):
-                logger.info("Skipping matching MiniMax-H3 latent cache: %s", item.latent_cache_path)
-                return
-            logger.info("Rebuilding stale MiniMax-H3 latent cache: %s", item.latent_cache_path)
+        return _OneFrameCacheInputs(record, fingerprints, control_frames, control_indices, target_index, metadata)
+
+    def video_inputs(item: ItemInfo, plan: H3DatasetPlan) -> _VideoCacheInputs:
+        record = item_record(plan, item)
+        crop_start = item_crop_start(item)
+        if item.audio_content is None or item.audio_present is None:
+            raise ValueError(f"MiniMax-H3 cache item is missing its audio window: {item.item_key}")
+        fingerprints = {path: media_fingerprints[path] for path in record_media_paths(record)}
+        audio_source = item_audio_source(plan, item)
+        if audio_source is not None:
+            fingerprints[audio_source.path] = media_fingerprints[audio_source.path]
+        metadata = build_latent_metadata(
+            task=args.task,
+            crop_start_frame=crop_start,
+            cache_seed=args.cache_seed,
+            video_vae_fingerprint=video_vae_fingerprint,
+            audio_vae_fingerprint=audio_vae_fingerprint,
+            media_fingerprints=fingerprints,
+        )
+        return _VideoCacheInputs(record, fingerprints, crop_start, metadata)
+
+    def expected_metadata(item: ItemInfo) -> dict[str, str]:
+        plan = item_plan(plans, item)
+        if item.frame_count is None:
+            return one_frame_inputs(item, plan).metadata
+        return video_inputs(item, plan).metadata
+
+    def cache_is_current(item: ItemInfo) -> bool:
+        # --skip_existing: a cache counts as existing only when its identity metadata matches
+        if not Path(item.latent_cache_path).is_file():
+            return False
+        if cache_metadata_matches(item.latent_cache_path, expected_metadata(item)):
+            logger.info("Skipping matching MiniMax-H3 latent cache: %s", item.latent_cache_path)
+            return True
+        logger.info("Rebuilding stale MiniMax-H3 latent cache: %s", item.latent_cache_path)
+        return False
+
+    def encode_one_frame(item: ItemInfo, plan: H3DatasetPlan) -> None:
+        nonlocal one_frame_item_count
+        one_frame_item_count += 1
+        inputs = one_frame_inputs(item, plan)
         payload = build_one_frame_latent_tensors(
             image_frames=item.content,
-            target_index=target_index,
+            target_index=inputs.target_index,
             video_vae=video_vae,
             silence_audio_latent=silence_audio_latent,
             cache_seed=args.cache_seed,
-            item_key=str(record.video_path),
+            item_key=str(inputs.record.video_path),
             video_vae_fingerprint=video_vae_fingerprint,
             audio_vae_fingerprint=audio_vae_fingerprint,
-            media_fingerprints=image_fingerprints,
-            control_frames=control_frames,
-            control_indices=control_indices,
-            record=record,
+            media_fingerprints=inputs.fingerprints,
+            control_frames=inputs.control_frames,
+            control_indices=inputs.control_indices,
+            record=inputs.record,
             audio_vae=audio_vae,
             media_decoder=decoder,
         )
         logger.info("Saving MiniMax-H3 one-frame latent cache for %s to %s", item.item_key, item.latent_cache_path)
         save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
 
+    def encode_video(item: ItemInfo, plan: H3DatasetPlan) -> None:
+        inputs = video_inputs(item, plan)
+        presence_counts[item.audio_present] += 1
+        payload = build_latent_tensors(
+            record=inputs.record,
+            task=args.task,
+            target_frames=item.content,
+            target_waveform=item.audio_content,
+            audio_present=item.audio_present,
+            crop_start_frame=inputs.crop_start,
+            video_vae=video_vae,
+            audio_vae=audio_vae,
+            cache_seed=args.cache_seed,
+            media_decoder=decoder,
+            video_vae_fingerprint=video_vae_fingerprint,
+            audio_vae_fingerprint=audio_vae_fingerprint,
+            media_fingerprints=inputs.fingerprints,
+            allow_experimental_duration=args.allow_experimental_duration,
+        )
+        logger.info("Saving MiniMax-H3 latent cache for %s to %s", item.item_key, item.latent_cache_path)
+        save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
+
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:
-            key = item_cache_dir_key(item)
-            if key in image_dirs:
-                encode_one_frame(item, key)
-                continue
-            datasource_index, crop_start = item_record_inputs(item)
-            record = records_by_dir[key][datasource_index]
-            audio_source = audio_sources_by_dir[key][datasource_index]
-            if item.audio_content is None or item.audio_present is None:
-                raise ValueError(f"MiniMax-H3 cache item is missing its audio window: {item.item_key}")
-            presence_counts[item.audio_present] += 1
+            plan = item_plan(plans, item)
+            if item.frame_count is None:
+                encode_one_frame(item, plan)
+            else:
+                encode_video(item, plan)
 
-            record_fingerprints = {path: media_fingerprints[path] for path in record_media_paths(record)}
-            if audio_source is not None:
-                record_fingerprints[audio_source.path] = media_fingerprints[audio_source.path]
-            expected_metadata = build_latent_metadata(
-                task=args.task,
-                crop_start_frame=crop_start,
-                cache_seed=args.cache_seed,
-                video_vae_fingerprint=video_vae_fingerprint,
-                audio_vae_fingerprint=audio_vae_fingerprint,
-                media_fingerprints=record_fingerprints,
-            )
-            if skip_matching_cache and Path(item.latent_cache_path).is_file():
-                if cache_metadata_matches(item.latent_cache_path, expected_metadata):
-                    logger.info("Skipping matching MiniMax-H3 latent cache: %s", item.latent_cache_path)
-                    continue
-                logger.info("Rebuilding stale MiniMax-H3 latent cache: %s", item.latent_cache_path)
-            payload = build_latent_tensors(
-                record=record,
-                task=args.task,
-                target_frames=item.content,
-                target_waveform=item.audio_content,
-                audio_present=item.audio_present,
-                crop_start_frame=crop_start,
-                video_vae=video_vae,
-                audio_vae=audio_vae,
-                cache_seed=args.cache_seed,
-                media_decoder=decoder,
-                video_vae_fingerprint=video_vae_fingerprint,
-                audio_vae_fingerprint=audio_vae_fingerprint,
-                media_fingerprints=record_fingerprints,
-                allow_experimental_duration=args.allow_experimental_duration,
-            )
-            logger.info("Saving MiniMax-H3 latent cache for %s to %s", item.item_key, item.latent_cache_path)
-            save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
-
-    cache_latents.encode_datasets(datasets, encode, args)
+    cache_latents.encode_datasets(datasets, encode, args, cache_is_current=cache_is_current)
     if one_frame_item_count:
         logger.info(
             "MiniMax-H3 one-frame cache summary: %d image items (silence audio placeholder, excluded from audio supervision)",

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import logging
 from pathlib import Path
 
@@ -12,7 +12,7 @@ from musubi_tuner.dataset import config_utils
 from musubi_tuner.dataset.architectures import ARCHITECTURE_MINIMAX_H3
 from musubi_tuner.dataset.cache_io import save_text_encoder_output_cache_minimax_h3
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
-from musubi_tuner.dataset.image_video_dataset import ImageDataset, ItemInfo, VideoDataset
+from musubi_tuner.dataset.image_video_dataset import ItemInfo
 from musubi_tuner.minimax_h3.text_encoder import (
     H3Presentation,
     H3TextVisual,
@@ -42,20 +42,20 @@ from musubi_tuner.minimax_h3.media import (
     PyAVH3MediaDecoder,
     adapt_reference_canvas,
     fingerprint_file,
-    h3_records_from_datasource,
     reject_one_frame_audio_references,
     resize_frames,
     validate_subject_reference_record,
 )
-from musubi_tuner.minimax_h3.checkpoint import fingerprint_checkpoint
-from musubi_tuner.minimax_h3_cache_latents import (
+from musubi_tuner.minimax_h3.cache_plan import (
+    H3DatasetPlan,
     cache_metadata_matches,
-    dataset_cache_dir_key,
-    item_datasource_index,
-    item_record_inputs,
-    validate_h3_dataset,
-    validate_h3_image_dataset_task,
+    item_control_paths,
+    item_crop_start,
+    item_plan,
+    item_record,
+    plan_h3_datasets,
 )
+from musubi_tuner.minimax_h3.checkpoint import fingerprint_checkpoint
 from musubi_tuner.utils.model_utils import dtype_to_str
 
 
@@ -187,6 +187,21 @@ def _subject_ref_teacher_presentation(
     return build_presentation(replace(record, caption=caption), "ref2va", visuals)
 
 
+@dataclass(frozen=True)
+class _TextCacheInputs:
+    """Everything the text cache of one item is built from, prepared once per item."""
+
+    record: H3Record
+    crop_start: int
+    frame_count: int
+    reference_frame_cap: int
+    target_size: tuple[int, int]
+    presentation: H3Presentation
+    record_media_fingerprints: dict[Path, str]
+    teacher_presentation: H3Presentation | None = None
+    metadata: dict[str, str] | None = None
+
+
 def _text_cache_metadata(
     *,
     task: str,
@@ -313,48 +328,21 @@ def main() -> None:
     datasets = dataset_group.datasets
 
     decoder = PyAVH3MediaDecoder()
-    # H3 records per cache directory (image and video datasets alike), aligned with the datasource indices
-    records_by_dir: dict[str, list[H3Record]] = {}
-    image_dirs: set[str] = set()
-    control_paths_by_dir: dict[str, dict[str, list[str]]] = {}
-    for dataset in datasets:
-        validate_h3_dataset(dataset)
-        key = dataset_cache_dir_key(dataset.cache_directory)
-        if key in records_by_dir:
-            raise ValueError(f"MiniMax-H3 datasets cannot share a cache_directory: {key}")
-        controls_as_references = False
-        if isinstance(dataset, ImageDataset):
-            validate_h3_image_dataset_task(dataset, args.task, args.one_frame, record_task)
-            image_dirs.add(key)
-            control_paths_by_dir[key] = dataset.datasource.get_control_paths()
-            controls_as_references = dataset.fp_1f_clean_indices is None
-        elif not isinstance(dataset, VideoDataset):
-            raise ValueError("MiniMax-H3 text caching accepts only image and video datasets")
-        records_by_dir[key] = h3_records_from_datasource(
-            dataset.datasource, record_task, control_images_as_references=controls_as_references
-        )
+    plans = plan_h3_datasets(datasets, task=args.task, one_frame=args.one_frame, record_task=record_task)
     if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF:
         # fail on the data contract before any model is loaded
-        for records in records_by_dir.values():
-            for record in records:
+        for plan in plans:
+            for record in plan.records:
                 validate_subject_reference_record(record, record.context)
 
     all_cache_files, all_cache_paths = cache_text_encoder_outputs.prepare_cache_files_and_paths(datasets)
     # the presentations embed the FL2VA endpoints / the reference visuals (video and one-frame
     # ref2va or subject-reference teacher alike), so those files join the identity
     text_paths = {
-        path
-        for records in records_by_dir.values()
-        for record in records
-        for path in _text_media_paths(record, args.task, teacher_conditions)
+        path for plan in plans for record in plan.records for path in _text_media_paths(record, args.task, teacher_conditions)
     }
     # ... and one-frame fl2va presentations embed the control images
-    text_paths.update(
-        Path(path).resolve()
-        for control_paths in control_paths_by_dir.values()
-        for paths in control_paths.values()
-        for path in paths
-    )
+    text_paths.update(Path(path).resolve() for plan in plans for paths in plan.control_paths.values() for path in paths)
     media_fingerprints = {path: fingerprint_file(path) for path in text_paths}
 
     logger.info("Loading MiniMax-H3 Qwen3-VL processor")
@@ -394,124 +382,145 @@ def main() -> None:
         )
 
     decoded_reference_cache = {}
-    skip_matching_cache = args.skip_existing
+    # the presentations and identity metadata of the items seen so far, keyed by cache path:
+    # the --skip_existing check builds them first and the encoder consumes them right after
+    prepared_items: dict[str, _TextCacheInputs] = {}
+
+    def one_frame_inputs(item: ItemInfo, plan: H3DatasetPlan) -> _TextCacheInputs:
+        # one-frame image item: the caption as a T2VA presentation, an FL2VA presentation
+        # embedding the bucket-resized control images, or a Ref2VA presentation embedding the
+        # item's references; all time indices live in the latent cache, never in the text rows
+        record = item_record(plan, item)
+        visuals = {}
+        record_media_fingerprints = {}
+        target = torch.as_tensor(item.content)
+        if target.ndim != 3:
+            raise ValueError(f"MiniMax-H3 one-frame target must be [H,W,C], got {tuple(target.shape)}")
+        target_size = (int(target.shape[1]), int(target.shape[0]))
+        if record.references:
+            # ref2va targets or subject-reference teachers (the records are parsed as Ref2VA)
+            reject_one_frame_audio_references(record)
+        if args.task == "ref2va":
+            # the same canvas policy as the latent cache: images capped to the target
+            # area, videos to the released 15 s span with 2 fps text sampling
+            visuals = _reference_visuals(record, ONE_FRAME_REFERENCE_FRAME_CAP, target_size, decoder, decoded_reference_cache)
+            record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
+        elif args.task == "fl2va":
+            controls = item.control_content
+            control_indices = item.fp_1f_clean_indices
+            if not control_indices or controls is None or len(controls) != len(control_indices):
+                raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control images: {item.item_key}")
+            for index, control in enumerate(controls):
+                # the dataset keeps RGBA controls as-is; drop alpha the same way the
+                # latent path does (prepare_pixels), the processor accepts only RGB
+                visuals[one_frame_condition_role(index)] = H3TextVisual(torch.as_tensor(control)[..., :3].unsqueeze(0))
+            record_media_fingerprints = {
+                control_path: media_fingerprints[control_path]
+                for control_path in item_control_paths(plan, item, len(control_indices))
+            }
+        # the student rows never carry the subject-reference teacher's references
+        student_record = replace(record, references=()) if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF else record
+        return _TextCacheInputs(
+            record=record,
+            crop_start=0,
+            frame_count=1,
+            reference_frame_cap=ONE_FRAME_REFERENCE_FRAME_CAP,
+            target_size=target_size,
+            presentation=build_presentation(student_record, args.task, visuals),
+            record_media_fingerprints=record_media_fingerprints,
+        )
+
+    def video_inputs(item: ItemInfo, plan: H3DatasetPlan) -> _TextCacheInputs:
+        record = item_record(plan, item)
+        target_frames = torch.as_tensor(item.content)
+        target_size = (int(target_frames.shape[2]), int(target_frames.shape[1]))
+        student_record = replace(record, references=()) if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF else record
+        visuals = _build_visuals(student_record, args.task, item, decoder, decoded_reference_cache)
+        return _TextCacheInputs(
+            record=record,
+            crop_start=item_crop_start(item),
+            frame_count=item.frame_count,
+            reference_frame_cap=item.frame_count,
+            target_size=target_size,
+            presentation=build_presentation(student_record, args.task, visuals),
+            record_media_fingerprints={path: media_fingerprints[path] for path in _text_media_paths(record, args.task)},
+        )
+
+    def prepare(item: ItemInfo) -> _TextCacheInputs:
+        inputs = prepared_items.get(item.text_encoder_output_cache_path)
+        if inputs is not None:
+            return inputs
+        plan = item_plan(plans, item)
+        inputs = one_frame_inputs(item, plan) if item.frame_count is None else video_inputs(item, plan)
+        record = inputs.record
+        presentation_identity = presentation_fingerprint(
+            inputs.presentation, inputs.record_media_fingerprints, frame_count=inputs.frame_count
+        )
+        teacher_presentation = None
+        teacher_presentation_identity = None
+        if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF:
+            # the student rows stay a plain T2VA presentation; the teacher rows are the
+            # Ref2VA presentation with the item's own reference pictures (subject references)
+            teacher_presentation = _subject_ref_teacher_presentation(
+                record,
+                reference_frame_cap=inputs.reference_frame_cap,
+                target_size=inputs.target_size,
+                still_image=inputs.frame_count == 1,
+                decoder=decoder,
+                decoded_reference_cache=decoded_reference_cache,
+            )
+            teacher_presentation_identity = presentation_fingerprint(
+                teacher_presentation,
+                {path: media_fingerprints[path] for path in _text_media_paths(record, args.task, teacher_conditions)},
+                frame_count=inputs.frame_count,
+            )
+        elif teacher_conditions == TEACHER_CONDITIONS_REF:
+            # the student rows stay a plain T2VA presentation; the teacher rows are the
+            # Ref2VA presentation with the training crop itself as the copy-source reference
+            teacher_presentation = _ref_teacher_presentation(record, item)
+        elif teacher_conditions:
+            # the student rows stay a plain T2VA presentation; the teacher rows are the
+            # FL2VA presentation of the same record (first/last frames of the crop window)
+            teacher_visuals = _build_visuals(record, "fl2va", item, decoder, decoded_reference_cache)
+            teacher_presentation = build_presentation(record, "fl2va", teacher_visuals)
+        if teacher_presentation is not None and teacher_presentation_identity is None:
+            teacher_presentation_identity = presentation_fingerprint(
+                teacher_presentation,
+                {record.video_path: media_fingerprints[record.video_path]},
+                frame_count=item.frame_count,
+            )
+        metadata = _text_cache_metadata(
+            task=args.task,
+            crop_start=inputs.crop_start,
+            processor_identity=processor_identity,
+            text_encoder_identity=text_encoder_identity,
+            presentation_identity=presentation_identity,
+            cache_dtype=args.text_cache_dtype,
+            teacher_conditions=teacher_conditions,
+            teacher_presentation_identity=teacher_presentation_identity,
+        )
+        inputs = replace(inputs, teacher_presentation=teacher_presentation, metadata=metadata)
+        prepared_items[item.text_encoder_output_cache_path] = inputs
+        return inputs
+
+    def cache_is_current(item: ItemInfo) -> bool:
+        # --skip_existing: a cache counts as existing only when its identity metadata matches
+        if not Path(item.text_encoder_output_cache_path).is_file():
+            return False
+        if cache_metadata_matches(item.text_encoder_output_cache_path, prepare(item).metadata):
+            logger.info("Skipping matching MiniMax-H3 text cache: %s", item.text_encoder_output_cache_path)
+            prepared_items.pop(item.text_encoder_output_cache_path)  # the decoded visuals are not needed
+            return True
+        logger.info("Rebuilding stale MiniMax-H3 text cache: %s", item.text_encoder_output_cache_path)
+        return False
 
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:
-            cache_dir_key = dataset_cache_dir_key(str(Path(item.text_encoder_output_cache_path).parent))
-            records = records_by_dir[cache_dir_key]
-            if cache_dir_key in image_dirs:
-                # one-frame image item: the caption as a T2VA presentation, an FL2VA
-                # presentation embedding the bucket-resized control images, or a Ref2VA
-                # presentation embedding the item's references; all time indices live in the
-                # latent cache, never in the text rows
-                record = records[item_datasource_index(item)]
-                crop_start = 0
-                frame_count = 1
-                visuals = {}
-                record_media_fingerprints = {}
-                target = torch.as_tensor(item.content)
-                if target.ndim != 3:
-                    raise ValueError(f"MiniMax-H3 one-frame target must be [H,W,C], got {tuple(target.shape)}")
-                target_size = (int(target.shape[1]), int(target.shape[0]))
-                if record.references:
-                    # ref2va targets or subject-reference teachers (the records are parsed as Ref2VA)
-                    reject_one_frame_audio_references(record)
-                if args.task == "ref2va":
-                    # the same canvas policy as the latent cache: images capped to the target
-                    # area, videos to the released 15 s span with 2 fps text sampling
-                    visuals = _reference_visuals(
-                        record,
-                        ONE_FRAME_REFERENCE_FRAME_CAP,
-                        target_size,
-                        decoder,
-                        decoded_reference_cache,
-                    )
-                    record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
-                elif args.task == "fl2va":
-                    controls = item.control_content
-                    control_indices = item.fp_1f_clean_indices
-                    if not control_indices or controls is None or len(controls) != len(control_indices):
-                        raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control images: {item.item_key}")
-                    for index, control in enumerate(controls):
-                        # the dataset keeps RGBA controls as-is; drop alpha the same way the
-                        # latent path does (prepare_pixels), the processor accepts only RGB
-                        visuals[one_frame_condition_role(index)] = H3TextVisual(torch.as_tensor(control)[..., :3].unsqueeze(0))
-                    control_paths = control_paths_by_dir.get(cache_dir_key, {}).get(item.item_key)
-                    if control_paths is None or len(control_paths) != len(control_indices):
-                        raise ValueError(f"MiniMax-H3 fl2va one-frame item is missing its control paths: {item.item_key}")
-                    record_media_fingerprints = {
-                        Path(control_path).resolve(): media_fingerprints[Path(control_path).resolve()]
-                        for control_path in control_paths
-                    }
-                # the student rows never carry the subject-reference teacher's references
-                student_record = replace(record, references=()) if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF else record
-                presentation = build_presentation(student_record, args.task, visuals)
-                reference_frame_cap = ONE_FRAME_REFERENCE_FRAME_CAP
-            else:
-                datasource_index, crop_start = item_record_inputs(item)
-                record = records[datasource_index]
-                frame_count = item.frame_count
-                reference_frame_cap = item.frame_count
-                target_frames = torch.as_tensor(item.content)
-                target_size = (int(target_frames.shape[2]), int(target_frames.shape[1]))
-                student_record = replace(record, references=()) if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF else record
-                visuals = _build_visuals(student_record, args.task, item, decoder, decoded_reference_cache)
-                presentation = build_presentation(student_record, args.task, visuals)
-                record_media_fingerprints = {path: media_fingerprints[path] for path in _text_media_paths(record, args.task)}
-            presentation_identity = presentation_fingerprint(
-                presentation,
-                record_media_fingerprints,
-                frame_count=frame_count,
-            )
-            teacher_presentation = None
-            teacher_presentation_identity = None
-            if teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF:
-                # the student rows stay a plain T2VA presentation; the teacher rows are the
-                # Ref2VA presentation with the item's own reference pictures (subject references)
-                teacher_presentation = _subject_ref_teacher_presentation(
-                    record,
-                    reference_frame_cap=reference_frame_cap,
-                    target_size=target_size,
-                    still_image=frame_count == 1,
-                    decoder=decoder,
-                    decoded_reference_cache=decoded_reference_cache,
-                )
-                teacher_presentation_identity = presentation_fingerprint(
-                    teacher_presentation,
-                    {path: media_fingerprints[path] for path in _text_media_paths(record, args.task, teacher_conditions)},
-                    frame_count=frame_count,
-                )
-            elif teacher_conditions == TEACHER_CONDITIONS_REF:
-                # the student rows stay a plain T2VA presentation; the teacher rows are the
-                # Ref2VA presentation with the training crop itself as the copy-source reference
-                teacher_presentation = _ref_teacher_presentation(record, item)
-            elif teacher_conditions:
-                # the student rows stay a plain T2VA presentation; the teacher rows are the
-                # FL2VA presentation of the same record (first/last frames of the crop window)
-                teacher_visuals = _build_visuals(record, "fl2va", item, decoder, decoded_reference_cache)
-                teacher_presentation = build_presentation(record, "fl2va", teacher_visuals)
-            if teacher_presentation is not None and teacher_presentation_identity is None:
-                teacher_presentation_identity = presentation_fingerprint(
-                    teacher_presentation,
-                    {record.video_path: media_fingerprints[record.video_path]},
-                    frame_count=item.frame_count,
-                )
-            metadata = _text_cache_metadata(
-                task=args.task,
-                crop_start=crop_start,
-                processor_identity=processor_identity,
-                text_encoder_identity=text_encoder_identity,
-                presentation_identity=presentation_identity,
-                cache_dtype=args.text_cache_dtype,
-                teacher_conditions=teacher_conditions,
-                teacher_presentation_identity=teacher_presentation_identity,
-            )
-            if skip_matching_cache and Path(item.text_encoder_output_cache_path).is_file():
-                if cache_metadata_matches(item.text_encoder_output_cache_path, metadata):
-                    logger.info("Skipping matching MiniMax-H3 text cache: %s", item.text_encoder_output_cache_path)
-                    continue
-                logger.info("Rebuilding stale MiniMax-H3 text cache: %s", item.text_encoder_output_cache_path)
+            inputs = prepare(item)
+            prepared_items.pop(item.text_encoder_output_cache_path, None)
+            presentation = inputs.presentation
+            teacher_presentation = inputs.teacher_presentation
+            metadata = inputs.metadata
 
             hidden_states, token_tags = encode_h3_presentation(processor, text_encoder, presentation)
             hidden_states = hidden_states.to(_cache_dtype(args.text_cache_dtype))
@@ -543,15 +552,18 @@ def main() -> None:
             )
             save_text_encoder_output_cache_minimax_h3(item, tensors, metadata)
 
+    # the text caches are per crop (the FL2VA presentations embed the crop endpoints), so every
+    # task walks the latent batches; a per-record text cache for t2va/ref2va is a follow-up
     cache_text_encoder_outputs.process_text_encoder_batches(
         args.num_workers,
-        False,
+        args.skip_existing,
         args.batch_size,
         datasets,
         all_cache_files,
         all_cache_paths,
         encode,
         requires_content=True,
+        cache_is_current=cache_is_current,
     )
     cache_text_encoder_outputs.post_process_cache_files(datasets, all_cache_files, all_cache_paths, args.keep_cache)
 

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -24,10 +24,10 @@ from musubi_tuner.minimax_h3.media import (
     video_latent_frames,
     waveform_samples,
 )
+from musubi_tuner.minimax_h3.cache_plan import cache_metadata_matches
 from musubi_tuner.minimax_h3_cache_latents import (
     build_latent_tensors,
     build_one_frame_latent_tensors,
-    cache_metadata_matches,
     encode_one_frame_silence_latent,
     log_audio_presence_summary,
     record_media_paths,
@@ -1517,7 +1517,7 @@ def test_h3_jsonl_control_paths_become_references_unless_the_record_has_its_own(
 def test_h3_image_dataset_task_matrix(has_control, indices, task, record_task, message):
     from types import SimpleNamespace
 
-    from musubi_tuner.minimax_h3_cache_latents import validate_h3_image_dataset_task
+    from musubi_tuner.minimax_h3.cache_plan import validate_h3_image_dataset_task
 
     dataset = SimpleNamespace(has_control=has_control, fp_1f_clean_indices=indices)
     if message is None:

--- a/tests/test_minimax_h3_cache_plan.py
+++ b/tests/test_minimax_h3_cache_plan.py
@@ -1,0 +1,208 @@
+"""Dataset provenance for the MiniMax-H3 cache scripts: items carry the index of the dataset
+they came from (stamped by the DatasetGroup), the per-dataset cache plan is looked up through
+it, and the shared cache drivers let an architecture decide what "existing cache" means."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from musubi_tuner import cache_latents, cache_text_encoder_outputs
+from musubi_tuner.dataset.architectures import ARCHITECTURE_MINIMAX_H3
+from musubi_tuner.dataset.image_video_dataset import DatasetGroup, ItemInfo, VideoDataset
+from musubi_tuner.minimax_h3.cache_plan import (
+    H3DatasetPlan,
+    item_control_paths,
+    item_crop_start,
+    item_plan,
+    item_record,
+    plan_h3_datasets,
+)
+from musubi_tuner.minimax_h3.media import H3Record
+
+
+class _FakeVideoDatasource:
+    has_control = False
+    audio_sources = None
+
+    def set_bucket_selector(self, bucket_selector):
+        pass
+
+    def set_source_and_target_fps(self, source_fps, target_fps):
+        pass
+
+    def __iter__(self):
+        frame = np.zeros((64, 64, 3), dtype=np.uint8)
+        fetch = lambda: ("clip.mp4", [frame.copy() for _ in range(5)], "caption", None)  # noqa: E731
+        fetch.datasource_index = 0
+        yield fetch
+
+
+def _video_dataset(directory: Path) -> VideoDataset:
+    directory.mkdir(exist_ok=True)
+    dataset = VideoDataset(
+        resolution=(64, 64),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=True,
+        bucket_no_upscale=False,
+        target_frames=[5],
+        video_directory=str(directory),
+        cache_directory=str(directory),
+        architecture=ARCHITECTURE_MINIMAX_H3,
+    )
+    dataset.datasource = _FakeVideoDatasource()
+    return dataset
+
+
+def test_dataset_group_stamps_the_dataset_index_that_items_carry(tmp_path: Path):
+    datasets = [_video_dataset(tmp_path / "a"), _video_dataset(tmp_path / "b")]
+    assert [dataset.dataset_index for dataset in datasets] == [None, None]
+
+    DatasetGroup(datasets)
+
+    assert [dataset.dataset_index for dataset in datasets] == [0, 1]
+    _, items = next(iter(datasets[1].retrieve_latent_cache_batches(num_workers=1)))
+    assert items[0].dataset_index == 1
+    assert items[0].datasource_index == 0
+    assert items[0].frame_pos == 0
+
+
+def test_plan_requires_datasets_in_group_order(tmp_path: Path):
+    dataset = _video_dataset(tmp_path / "a")
+    with pytest.raises(ValueError, match="DatasetGroup position"):
+        plan_h3_datasets([dataset], task="t2va", one_frame=False)
+
+
+def _plan(*, is_image: bool, records=(), control_paths=None) -> H3DatasetPlan:
+    return H3DatasetPlan(
+        index=0,
+        is_image=is_image,
+        records=list(records),
+        audio_sources=None,
+        control_paths=control_paths or {},
+        controls_as_references=False,
+    )
+
+
+def test_item_plan_checks_provenance_and_dataset_kind():
+    plans = [_plan(is_image=False)]
+    video_item = ItemInfo("clip.mp4", "caption", (64, 64), (64, 64), frame_count=5)
+    with pytest.raises(ValueError, match="dataset provenance"):
+        item_plan(plans, video_item)
+
+    video_item.dataset_index = 0
+    assert item_plan(plans, video_item) is plans[0]
+    video_item.dataset_index = 1
+    with pytest.raises(ValueError, match="dataset provenance"):
+        item_plan(plans, video_item)
+
+    # an image item (no frame_count) cannot come from a video dataset plan
+    image_item = ItemInfo("image.png", "caption", (64, 64), (64, 64))
+    image_item.dataset_index = 0
+    with pytest.raises(ValueError, match="dataset kind"):
+        item_plan(plans, image_item)
+    assert item_plan([_plan(is_image=True)], image_item).is_image
+
+
+def test_item_accessors_require_the_record_crop_and_control_provenance(tmp_path: Path):
+    record = H3Record(video_path=tmp_path / "clip.mp4", caption="caption", references=())
+    plan = _plan(is_image=False, records=[record])
+    item = ItemInfo("clip.mp4", "caption", (64, 64), (64, 64), frame_count=5)
+
+    with pytest.raises(ValueError, match="datasource provenance"):
+        item_record(plan, item)
+    with pytest.raises(ValueError, match="crop provenance"):
+        item_crop_start(item)
+    item.datasource_index = 0
+    item.frame_pos = 17
+    assert item_record(plan, item) is record
+    assert item_crop_start(item) == 17
+
+    image_plan = _plan(is_image=True, control_paths={"image.png": ["a.png", "b.png"]})
+    image_item = ItemInfo("image.png", "caption", (64, 64), (64, 64))
+    assert item_control_paths(image_plan, image_item, 2) == [Path("a.png").resolve(), Path("b.png").resolve()]
+    with pytest.raises(ValueError, match="control paths"):
+        item_control_paths(image_plan, image_item, 1)
+    with pytest.raises(ValueError, match="control paths"):
+        item_control_paths(image_plan, ItemInfo("other.png", "caption", (64, 64), (64, 64)), 2)
+
+
+class _FakeCacheDataset:
+    """The slice of BaseDataset the shared cache drivers touch."""
+
+    def __init__(self, items: list[ItemInfo]):
+        self.items = items
+
+    def retrieve_latent_cache_batches(self, num_workers):
+        yield (64, 64), list(self.items)
+
+    def retrieve_text_encoder_output_cache_batches(self, num_workers):
+        yield list(self.items)
+
+    def get_all_latent_cache_files(self):
+        return []
+
+
+def _cache_items(tmp_path: Path) -> list[ItemInfo]:
+    items = []
+    for name in ("current", "stale"):
+        item = ItemInfo(name, "caption", (64, 64), (64, 64), content=np.zeros((64, 64, 3), dtype=np.uint8))
+        item.latent_cache_path = str(tmp_path / f"{name}_mmh3.safetensors")
+        item.text_encoder_output_cache_path = str(tmp_path / f"{name}_mmh3_te.safetensors")
+        items.append(item)
+    return items
+
+
+def test_latent_driver_skips_items_whose_cache_the_architecture_deems_current(tmp_path: Path):
+    items = _cache_items(tmp_path)
+    for item in items:
+        Path(item.latent_cache_path).touch()  # both files exist; only the metadata check tells them apart
+    args = SimpleNamespace(skip_existing=True, num_workers=1, batch_size=None, keep_cache=True)
+    encoded = []
+
+    cache_latents.encode_datasets(
+        [_FakeCacheDataset(items)],
+        lambda batch: encoded.extend(item.item_key for item in batch),
+        args,
+        cache_is_current=lambda item: item.item_key == "current",
+    )
+    assert encoded == ["stale"]
+
+    # the default test stays "the cache file exists"
+    encoded.clear()
+    Path(items[1].latent_cache_path).unlink()
+    cache_latents.encode_datasets([_FakeCacheDataset(items)], lambda batch: encoded.extend(item.item_key for item in batch), args)
+    assert encoded == ["stale"]
+
+
+def test_text_driver_skips_items_whose_cache_the_architecture_deems_current(tmp_path: Path):
+    items = _cache_items(tmp_path)
+    existing = {Path(item.text_encoder_output_cache_path).as_posix() for item in items}
+    encoded = []
+
+    def run(**kwargs):
+        encoded.clear()
+        cache_text_encoder_outputs.process_text_encoder_batches(
+            1,
+            True,
+            None,
+            [_FakeCacheDataset(items)],
+            [{str(Path(path)) for path in existing}],
+            [set()],
+            lambda batch: encoded.extend(item.item_key for item in batch),
+            **kwargs,
+        )
+        return list(encoded)
+
+    assert run(cache_is_current=lambda item: item.item_key == "current") == ["stale"]
+    # the default test stays set membership of the existing cache files
+    assert run() == []


### PR DESCRIPTION
Third of the MiniMax-H3 cleanup series (after #1097, #1098): the dataset-identity root cause of the cache scripts.

## What

The H3 cache scripts identified the dataset an item came from by normalizing the parent directory of its cache path and looking it up in four parallel dicts keyed by that string, with `isinstance(dataset, ImageDataset/VideoDataset)` ladders deciding the per-item route. The text-encoder script derived the key from a *different* path (the text cache's parent) and imported the whole machinery from the latent cache CLI. Nothing else in the repository looks a dataset up by path or dispatches on the dataset class.

- **`ItemInfo.dataset_index`** (shared dataset layer): the position of the originating dataset in its `DatasetGroup`. The group stamps `BaseDataset.dataset_index`; the three `ItemInfo` producers copy it. Together with `datasource_index` and `frame_pos` this is the full provenance of a cache item, usable by any architecture that needs per-dataset context at cache time.
- **`minimax_h3/cache_plan.py`**: one `H3DatasetPlan` per dataset (records, audio sources, control paths, kind) built up front, items resolved through `dataset_index`. Both cache scripts import it from the package, so the text-encoder script no longer depends on the latent cache script (the last import in that direction). Image and video items are told apart by `ItemInfo.frame_count is None`, as in every other architecture; the dataset-kind `isinstance` survives only inside the plan builder.
- **`cache_is_current(item)` seam** on the shared cache drivers (`cache_latents.encode_datasets`, `cache_text_encoder_outputs.process_text_encoder_batches`) for `--skip_existing`; the default stays "the cache file exists". The H3 scripts pass their metadata comparison instead of disabling the driver's skip by mutating `args.skip_existing`.
- The per-item cache inputs (record, fingerprints, expected metadata, presentations) are computed once by a helper shared between the skip check and the encoder. The text script memoizes its prepared presentations per item and drops them once consumed or skipped.

No cache format or metadata change; existing caches stay valid and `--skip_existing` decisions are unchanged.

Still open, on purpose:
- The text-encoder script still walks the latent batches (`requires_content=True`) because the text caches are per crop (the FL2VA presentations embed the crop endpoints). A per-record text cache for t2va/ref2va is a follow-up.
- The safetensors key vocabulary that `dataset/cache_io.py` re-parses with regexes (key minting outside `cache_io`) is the next PR.

## Tests

- New `tests/test_minimax_h3_cache_plan.py`: `DatasetGroup` stamps `dataset_index` and items carry it; plan/provenance errors; both shared drivers honor `cache_is_current` and keep their default behavior.
- Full suite: 674 passed; `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEK1d1RFXGCoFfpiQDnRfR
