### PR TITLE
Honour enable_bucket and bucket_no_upscale when caching video latents

### DIFF
--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -775,8 +775,8 @@ class VideoDataset(BaseDataset):
         return metadata
 
     def retrieve_latent_cache_batches(self, num_workers: int):
-        buckset_selector = BucketSelector(self.resolution, architecture=self.architecture)
-        self.datasource.set_bucket_selector(buckset_selector)
+        bucket_selector = BucketSelector(self.resolution, self.enable_bucket, self.bucket_no_upscale, self.architecture)
+        self.datasource.set_bucket_selector(bucket_selector)
         if self.source_fps is not None:
             self.datasource.set_source_and_target_fps(self.source_fps, self.target_fps)
         else:
@@ -927,7 +927,7 @@ class VideoDataset(BaseDataset):
                 frame_size = (video[0].shape[1], video[0].shape[0])
 
                 # resize if necessary
-                bucket_reso = buckset_selector.get_bucket_resolution(frame_size)
+                bucket_reso = bucket_selector.get_bucket_resolution(frame_size)
                 video = [resize_image_to_bucket(frame, bucket_reso) for frame in video]
 
                 # resize control if necessary

--- a/tests/test_minimax_h3_dataset.py
+++ b/tests/test_minimax_h3_dataset.py
@@ -368,3 +368,52 @@ def test_h3_training_sample_preserves_valid_frame_count(tmp_path: Path, monkeypa
     )
 
     assert captured["frame_count"] == 56
+
+
+def test_video_latent_cache_honours_enable_bucket(tmp_path: Path):
+    """A video dataset with bucketing off must cache at its single configured bucket.
+
+    ImageDataset.retrieve_latent_cache_batches and both prepare_for_training pass
+    enable_bucket / bucket_no_upscale to BucketSelector; the video caching path used
+    to build its selector with the defaults instead. A block asking for one bucket
+    therefore had its latents cached at an area-derived one, while get_metadata()
+    recorded enable_bucket: false either way.
+    """
+    dataset = VideoDataset(
+        resolution=(1792, 768),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=False,
+        bucket_no_upscale=False,
+        target_frames=[5],
+        video_directory=str(tmp_path),
+        cache_directory=str(tmp_path),
+        architecture=ARCHITECTURE_MINIMAX_H3,
+    )
+
+    assert list(dataset.retrieve_latent_cache_batches(1)) == []
+
+    selector = dataset.datasource.bucket_selector
+    assert selector.bucket_resolutions == [(1792, 768)]
+    assert selector.get_bucket_resolution((3840, 1080)) == (1792, 768)
+
+
+def test_video_latent_cache_still_buckets_when_asked_to(tmp_path: Path):
+    """The other half of the contract: enable_bucket=True keeps the area search."""
+    dataset = VideoDataset(
+        resolution=(1792, 768),
+        caption_extension=".txt",
+        batch_size=1,
+        num_repeats=1,
+        enable_bucket=True,
+        bucket_no_upscale=False,
+        target_frames=[5],
+        video_directory=str(tmp_path),
+        cache_directory=str(tmp_path),
+        architecture=ARCHITECTURE_MINIMAX_H3,
+    )
+
+    assert list(dataset.retrieve_latent_cache_batches(1)) == []
+
+    assert len(dataset.datasource.bucket_selector.bucket_resolutions) > 1


### PR DESCRIPTION
## The problem

`VideoDataset.retrieve_latent_cache_batches` builds its `BucketSelector` with the defaults, dropping the dataset's own settings:

```python
buckset_selector = BucketSelector(self.resolution, architecture=self.architecture)
```

The three other call sites pass them — `ImageDataset.retrieve_latent_cache_batches` (411), and `prepare_for_training` for both image (557) and video (961) datasets:

```python
bucket_selector = BucketSelector(self.resolution, self.enable_bucket, self.bucket_no_upscale, self.architecture)
```

So a video dataset configured with `enable_bucket = false` has its **latents cached at area-derived buckets**, while training groups those same items by the single configured `resolution`, and `get_metadata()` records `enable_bucket: false` regardless. `dataset_config.md` documents `enable_bucket` / `bucket_no_upscale` as common to both dataset kinds, with no video carve-out.

Nothing raises. At `batch_size = 1` the shapes never have to agree, so the run trains at a geometry the config did not ask for and `ss_datasets` records the requested one. The misspelled local is probably why it was never revisited.

## Why it matters in practice

Pinning one resolution per aspect ratio — one `[[datasets]]` block per aspect, `enable_bucket = false`, `resolution = [W, H]` — is a natural way to train a model like MiniMax-H3 that generates at a fixed short side across a range of aspects.

Over a sweep of 224k source sizes against that setup, the cached geometry matched the requested one **99.9%** of the time — but diverged whenever the requested aspect differed from the source aspect, which is precisely the case a single fixed bucket exists to handle (a source wider than the aspect you want to train, so the fixed bucket should crop it). There the shorter side landed on **736 or 704** instead of the requested 768. The 0.1% of matching-aspect misses were near-square sources off by one 32-step.

## The change

Three lines: pass `self.enable_bucket` and `self.bucket_no_upscale`, and fix the `buckset_selector` spelling while touching them.

## Tests

Two tests in `tests/test_minimax_h3_dataset.py`, both over an empty `tmp_path` video directory so nothing has to be decoded:

- `test_video_latent_cache_honours_enable_bucket` — with `enable_bucket=False` the selector holds exactly the one configured bucket, and a 3840x1080 frame resolves to it. **This fails on `dev` today.**
- `test_video_latent_cache_still_buckets_when_asked_to` — with `enable_bucket=True` the area search is still built, so the default path is unchanged.

`tests/test_minimax_h3_dataset.py` (31), `test_minimax_h3_cache_contract.py`, `test_audio_dataset_seam.py` and `test_datasource_item_extras.py` (113 together) all pass.

## Compatibility

This changes behaviour for video datasets that left `enable_bucket` at its default of `false` and relied on the caching path bucketing anyway. Those runs will now cache at the single `[resolution, resolution]` bucket — which is what the config asked for, what the metadata already claimed, and what an image dataset with the same setting has always done. Anyone wanting the previous behaviour sets `enable_bucket = true`, which is what the docs' examples already show.
