### PR TITLE
Krea 2: wire activation CPU offloading into gradient checkpointing

### DIFF
--- a/docs/krea2.md
+++ b/docs/krea2.md
@@ -183,14 +183,14 @@ Because the default already targets everything, both `exclude_patterns` and `inc
 
 - `--fp8_base` and `--fp8_scaled` reduce DiT memory usage. **Both must be specified together** (plain fp8 without scaled is rejected, because it would cast the norms to fp8 and break the model). fp8 is applied to the 28 main blocks only; the text-fusion transformer stays bf16.
 - `--blocks_to_swap N` offloads some of the main blocks to CPU. The maximum is **26** (28 blocks − 2).
-- `--gradient_checkpointing` is available for memory savings. See [HunyuanVideo documentation](./hunyuan_video.md#memory-optimization) for details.
+- `--gradient_checkpointing` and `--gradient_checkpointing_cpu_offload` are available for memory savings. See [HunyuanVideo documentation](./hunyuan_video.md#memory-optimization) for details.
 
 <details>
 <summary>日本語</summary>
 
 - `--fp8_base`と`--fp8_scaled`でDiTのメモリ使用量を削減します。**両方を同時に指定する必要があります**（scaledなしのplain fp8は、normをfp8にキャストしてモデルを壊すため拒否されます）。fp8は28個のメインブロックのみに適用され、text-fusion transformerはbf16のまま保持されます。
 - `--blocks_to_swap N`で一部のメインブロックをCPUにオフロードします。最大値は **26**（28ブロック − 2）です。
-- メモリ節約のために`--gradient_checkpointing`が利用可能です。詳細は[HunyuanVideoドキュメント](./hunyuan_video.md#memory-optimization)を参照してください。
+- メモリ節約のために`--gradient_checkpointing`と`--gradient_checkpointing_cpu_offload`が利用可能です。詳細は[HunyuanVideoドキュメント](./hunyuan_video.md#memory-optimization)を参照してください。
 
 </details>
 

--- a/src/musubi_tuner/krea2/krea2_mmdit.py
+++ b/src/musubi_tuner/krea2/krea2_mmdit.py
@@ -344,15 +344,17 @@ class SingleStreamDiT(nn.Module):
 
         # musubi training hooks
         self.gradient_checkpointing = False
+        self.activation_cpu_offloading = False
         self.blocks_to_swap = 0
         self.offloader = None
 
     def enable_gradient_checkpointing(self, cpu_offload: bool = False):
-        # cpu_offload is accepted for interface parity; not implemented for K2 yet.
         self.gradient_checkpointing = True
+        self.activation_cpu_offloading = cpu_offload
 
     def disable_gradient_checkpointing(self):
         self.gradient_checkpointing = False
+        self.activation_cpu_offloading = False
 
     # Block swap (CPU offloading of the main SingleStreamBlocks). Mirrors the other
     # musubi architectures: the trainer calls enable_block_swap + move_to_device_except_swap_blocks

--- a/src/musubi_tuner/krea2/krea2_mmdit.py
+++ b/src/musubi_tuner/krea2/krea2_mmdit.py
@@ -19,6 +19,7 @@ from torch import Tensor
 
 from musubi_tuner.modules.attention import AttentionParams, attention as common_attention
 from musubi_tuner.modules.custom_offloading_utils import BlockSwapConfig, create_offloader
+from musubi_tuner.utils.model_utils import create_cpu_offloading_wrapper
 
 
 def rope(pos: Tensor, dim: int, theta: float = 1e4, ntk: float = 1.0) -> Tensor:
@@ -441,12 +442,18 @@ class SingleStreamDiT(nn.Module):
                 self.offloader.wait_for_block(index)
 
             if self.gradient_checkpointing and self.training:
-                combined = torch.utils.checkpoint.checkpoint(block, combined, tvec, freqs, attn_params, use_reentrant=False)
+                forward_fn = block
+                if self.activation_cpu_offloading:
+                    forward_fn = create_cpu_offloading_wrapper(forward_fn, img.device)
+                combined = torch.utils.checkpoint.checkpoint(forward_fn, combined, tvec, freqs, attn_params, use_reentrant=False)
             else:
                 combined = block(combined, tvec, freqs, attn_params)
 
             if self.blocks_to_swap:
                 self.offloader.submit_move_blocks_forward(self.blocks, index)
+
+        if combined.device != img.device:
+            combined = combined.to(img.device)
 
         final = self.last(combined, t)
         output = final[:, :imglen, :]  # image tokens are the leading slice now

--- a/src/musubi_tuner/krea2/krea2_mmdit.py
+++ b/src/musubi_tuner/krea2/krea2_mmdit.py
@@ -444,6 +444,9 @@ class SingleStreamDiT(nn.Module):
             if self.gradient_checkpointing and self.training:
                 forward_fn = block
                 if self.activation_cpu_offloading:
+                    # create_cpu_offloading_wrapper only recurses into tensors/list/tuple/dict; attn_params (a
+                    # dataclass) passes through untouched -- if AttentionParams ever becomes a NamedTuple this
+                    # would silently break.
                     forward_fn = create_cpu_offloading_wrapper(forward_fn, img.device)
                 combined = torch.utils.checkpoint.checkpoint(forward_fn, combined, tvec, freqs, attn_params, use_reentrant=False)
             else:

--- a/tests/test_krea2_gradient_checkpointing.py
+++ b/tests/test_krea2_gradient_checkpointing.py
@@ -1,0 +1,83 @@
+"""Tests for SingleStreamDiT's gradient-checkpointing activation CPU offload.
+
+Krea 2 accepted --gradient_checkpointing_cpu_offload for interface parity with every other
+architecture in this codebase but silently dropped it (see
+docs/superpowers/specs/2026-09-08-krea2-gradient-checkpointing-cpu-offload-design.md for the
+real-hardware OOM this caused). These tests cover the interface toggle, that plain checkpointing
+still works once the flag exists, and that the CPU-offload round-trip doesn't strand output on
+the wrong device or corrupt gradients.
+"""
+
+import pytest
+import torch
+
+from musubi_tuner.krea2.krea2_mmdit import SingleMMDiTConfig, SingleStreamDiT
+from musubi_tuner.krea2 import krea2_sampling
+
+
+def _tiny_model() -> SingleStreamDiT:
+    cfg = SingleMMDiTConfig(
+        features=32,
+        tdim=32,
+        txtdim=32,
+        heads=2,
+        multiplier=1,
+        layers=2,
+        patch=2,
+        channels=4,
+        bias=False,
+        theta=1e3,
+        kvheads=None,
+        txtlayers=1,
+        txtheads=2,
+        txtkvheads=2,
+    )
+    return SingleStreamDiT(cfg, attn_mode="torch")
+
+
+def _forward_inputs(model: SingleStreamDiT, device: torch.device, batch: int = 1):
+    """Builds a valid (img, context, t, pos, mask) call for model.forward on the given device,
+    using krea2_sampling.prepare the same way krea2_train_network.py's own sampling path does."""
+    torch.manual_seed(0)
+    patch = model.config.patch
+    lat_h, lat_w = 8, 8  # multiple of patch=2, small for a fast test
+    noise = torch.randn(batch, model.config.channels, lat_h, lat_w, device=device)
+    txt_len = 3
+    # Context is 4D: (batch, txt_len, num_txt_layers, txtdim). The text encoder output stacks
+    # hidden states from num_txt_layers, which the text fusion transformer then projects to 1.
+    num_txt_layers = 1  # matches model.config.txtlayers
+    context = torch.randn(batch, txt_len, num_txt_layers, model.config.txtdim, device=device)
+    txtmask = torch.ones(batch, txt_len, device=device, dtype=torch.bool)
+    img_tokens, pos, mask = krea2_sampling.prepare(noise, txt_len, patch, txtmask)
+    t = torch.rand(batch, device=device)
+    return img_tokens, context, t, pos, mask
+
+
+def test_gradient_checkpointing_interface_toggles_both_flags():
+    model = _tiny_model()
+
+    model.enable_gradient_checkpointing(cpu_offload=True)
+    assert model.gradient_checkpointing is True
+    assert model.activation_cpu_offloading is True
+
+    model.disable_gradient_checkpointing()
+    assert model.gradient_checkpointing is False
+    assert model.activation_cpu_offloading is False
+
+
+def test_checkpointed_forward_and_backward_still_work_without_offload():
+    """Regression guard: plain checkpointing (cpu_offload left at its False default) must be
+    unaffected by adding the activation_cpu_offloading attribute."""
+    model = _tiny_model()
+    model.train()
+    model.enable_gradient_checkpointing()  # cpu_offload defaults to False
+    assert model.activation_cpu_offloading is False
+
+    img, context, t, pos, mask = _forward_inputs(model, device=torch.device("cpu"))
+    output = model(img=img, context=context, t=t, pos=pos, mask=mask)
+    assert torch.isfinite(output).all()
+
+    output.square().mean().backward()
+    grad = model.blocks[0].attn.wq.weight.grad
+    assert grad is not None
+    assert torch.isfinite(grad).all()

--- a/tests/test_krea2_gradient_checkpointing.py
+++ b/tests/test_krea2_gradient_checkpointing.py
@@ -1,11 +1,10 @@
 """Tests for SingleStreamDiT's gradient-checkpointing activation CPU offload.
 
 Krea 2 accepted --gradient_checkpointing_cpu_offload for interface parity with every other
-architecture in this codebase but silently dropped it (see
-docs/superpowers/specs/2026-09-08-krea2-gradient-checkpointing-cpu-offload-design.md for the
-real-hardware OOM this caused). These tests cover the interface toggle, that plain checkpointing
-still works once the flag exists, and that the CPU-offload round-trip doesn't strand output on
-the wrong device or corrupt gradients.
+architecture in this codebase but silently dropped it, causing linear per-step GPU memory growth
+during long gradient-enabled rollouts. These tests cover the interface toggle, that plain
+checkpointing still works once the flag exists, and that the CPU-offload round-trip doesn't
+strand output on the wrong device or corrupt gradients.
 """
 
 import pytest
@@ -80,4 +79,24 @@ def test_checkpointed_forward_and_backward_still_work_without_offload():
     output.square().mean().backward()
     grad = model.blocks[0].attn.wq.weight.grad
     assert grad is not None
+    assert torch.isfinite(grad).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="activation CPU offloading requires CUDA")
+def test_activation_cpu_offloading_round_trip_preserves_device_and_gradients():
+    device = torch.device("cuda")
+    model = _tiny_model().to(device)
+    model.train()
+    model.enable_gradient_checkpointing(cpu_offload=True)
+
+    img, context, t, pos, mask = _forward_inputs(model, device=device)
+    output = model(img=img, context=context, t=t, pos=pos, mask=mask)
+
+    assert output.device.type == "cuda"
+    assert torch.isfinite(output).all()
+
+    output.square().mean().backward()
+    grad = model.blocks[0].attn.wq.weight.grad
+    assert grad is not None
+    assert grad.device.type == "cuda"
     assert torch.isfinite(grad).all()

--- a/tests/test_krea2_gradient_checkpointing.py
+++ b/tests/test_krea2_gradient_checkpointing.py
@@ -7,11 +7,14 @@ checkpointing still works once the flag exists, and that the CPU-offload round-t
 strand output on the wrong device or corrupt gradients.
 """
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
+from musubi_tuner.krea2 import krea2_mmdit, krea2_sampling
 from musubi_tuner.krea2.krea2_mmdit import SingleMMDiTConfig, SingleStreamDiT
-from musubi_tuner.krea2 import krea2_sampling
+from musubi_tuner.utils.model_utils import create_cpu_offloading_wrapper as real_create_cpu_offloading_wrapper
 
 
 def _tiny_model() -> SingleStreamDiT:
@@ -100,3 +103,32 @@ def test_activation_cpu_offloading_round_trip_preserves_device_and_gradients():
     assert grad is not None
     assert grad.device.type == "cuda"
     assert torch.isfinite(grad).all()
+
+
+def test_cpu_offloading_wrapper_is_actually_invoked_per_block():
+    """Proves the offload wrapper is really wired into the block loop, not just that the flag
+    is set. A spy on create_cpu_offloading_wrapper (delegating to the real implementation) must
+    be called once per block with device=img.device when the flag is on, and not at all when off.
+    This is what catches a reverted/no-op wiring that the other tests can't distinguish."""
+    model = _tiny_model()
+    model.train()
+    device = torch.device("cpu")
+
+    with patch.object(krea2_mmdit, "create_cpu_offloading_wrapper", wraps=real_create_cpu_offloading_wrapper) as spy:
+        model.enable_gradient_checkpointing(cpu_offload=True)
+        img, context, t, pos, mask = _forward_inputs(model, device=device)
+        output = model(img=img, context=context, t=t, pos=pos, mask=mask)
+        assert torch.isfinite(output).all()
+
+    assert spy.call_count == len(model.blocks)
+    for call in spy.call_args_list:
+        called_device = call.args[1] if len(call.args) > 1 else call.kwargs["device"]
+        assert called_device == img.device
+
+    with patch.object(krea2_mmdit, "create_cpu_offloading_wrapper", wraps=real_create_cpu_offloading_wrapper) as spy:
+        model.enable_gradient_checkpointing(cpu_offload=False)
+        img, context, t, pos, mask = _forward_inputs(model, device=device)
+        output = model(img=img, context=context, t=t, pos=pos, mask=mask)
+        assert torch.isfinite(output).all()
+
+    assert spy.call_count == 0


### PR DESCRIPTION
## Summary
- Track an `activation_cpu_offloading` flag on Krea 2's `SingleStreamDiT`
- Wrap the checkpointed block forward with a CPU-offloading wrapper when the flag is enabled, moving activations back to the compute device before the final layer
- Add a mutation-sensitive test covering the offload wiring

## Test plan
- [x] `pytest tests/test_krea2_gradient_checkpointing.py -q` passes