### PR TITLE
Add support for Krea 2 Turbo LoRA for sampling

### DIFF
--- a/docs/krea2.md
+++ b/docs/krea2.md
@@ -292,6 +292,8 @@ A fox in the snow.  --w 1024 --h 1024 --s 8 --l 1 --d 0
 
 > **`--turbo_dit` cannot be combined with `--blocks_to_swap`.** Turbo sampling swaps the base weights in place, which is only safe without the block-swap offloader. If you use block swap, omit `--turbo_dit` and sample on the RAW model instead.
 
+**Alternative: `--turbo_lora`.** If you only have Krea's official Turbo release in LoRA-delta form (rather than a merged Turbo checkpoint), pass `--turbo_lora path/to/turbo_lora.safetensors` instead of `--turbo_dit`. Unlike `--turbo_dit`, this never touches the RAW base weights at all: the Turbo LoRA is composed live as a second, independent LoRA hook on top of RAW, active at the same time as the LoRA being trained (both apply simultaneously, `base + trainee_delta + turbo_delta` -- no merge, no weight swap). `--turbo_lora_multiplier` (default `1.0`) scales its delta. The Turbo LoRA is built once (lazily, on the first sample step) and then just enabled/disabled around each sample pass -- no per-step disk I/O. The same Turbo schedule applies (fixed `mu = 1.15`, CFG off, low step count -- see the sample prompt guidance above). `--turbo_lora` is mutually exclusive with `--turbo_dit` (combining a Turbo LoRA with an already-distilled Turbo checkpoint isn't a meaningful workflow). Unlike `--turbo_dit`, `--turbo_lora` is **not** restricted against `--blocks_to_swap`, `--convrot_int8`, or `--nvfp4` -- because it never touches base weights, it is expected to compose the same way the trainee's own LoRA already does under those settings (untested in practice; report an issue if you hit a problem). `--turbo_lora` is **not** supported together with `--compile`. `--turbo_dit_cache` has no effect on `--turbo_lora` -- it only applies to `--turbo_dit`'s memory-mode choice.
+
 <details>
 <summary>日本語</summary>
 
@@ -307,6 +309,8 @@ A fox in the snow.  --w 1024 --h 1024 --s 8 --l 1 --d 0
 - **`--turbo_dit_cache`（常駐）**: Turboの重みを起動時に一度量子化してCPU RAMに常駐させ、サンプルごとにスワップインします。**高速**ですが、実行中ずっと **DiTサイズの約1倍** のCPU RAMを追加で使用します。
 
 > **`--turbo_dit`は`--blocks_to_swap`と併用できません。** Turboサンプリングはベースの重みをその場で入れ替えるため、block swapのオフローダーがない場合にのみ安全です。block swapを使う場合は`--turbo_dit`を省略し、RAWモデルでサンプリングしてください。
+
+**代替手段: `--turbo_lora`。** マージ済みのTurboチェックポイントではなく、KreaのTurbo公式リリースがLoRA差分形式でしか手元にない場合は、`--turbo_dit`の代わりに`--turbo_lora path/to/turbo_lora.safetensors`を指定します。`--turbo_dit`と異なり、RAWのbase重みには一切触れません。Turbo LoRAは、学習中のLoRAと同時に適用される、独立した2つ目のLoRAフックとしてRAWの上にライブ合成されます（`base + trainee_delta + turbo_delta`、マージも重みの入れ替えもありません）。`--turbo_lora_multiplier`（デフォルト`1.0`）でそのdeltaの強さを調整できます。Turbo LoRAは（最初のサンプルステップで）一度だけ遅延構築され、以降は各サンプルパスの前後で有効化/無効化されるだけです（ディスクI/Oは発生しません）。Turboのスケジュール（固定`mu = 1.15`、CFGオフ、少ないステップ数。上記のサンプルプロンプトの指定を参照）は同様に適用されます。`--turbo_lora`は`--turbo_dit`と併用できません（Turbo LoRAを既に蒸留済みのTurboチェックポイントと組み合わせるのは意味のあるワークフローではないためです）。`--turbo_dit`と異なり、`--turbo_lora`は`--blocks_to_swap`・`--convrot_int8`・`--nvfp4`との併用を制限していません——base重みに一切触れないため、これらの設定下でも学習中のLoRA自身と同様に動作すると想定しています（実運用での検証は未実施です。問題があれば報告してください）。`--turbo_lora`は`--compile`と併用できません。`--turbo_dit_cache`は`--turbo_lora`には影響しません（`--turbo_dit`のメモリモード選択にのみ適用されます）。
 
 </details>
 

--- a/docs/krea2.md
+++ b/docs/krea2.md
@@ -292,7 +292,15 @@ A fox in the snow.  --w 1024 --h 1024 --s 8 --l 1 --d 0
 
 > **`--turbo_dit` cannot be combined with `--blocks_to_swap`.** Turbo sampling swaps the base weights in place, which is only safe without the block-swap offloader. If you use block swap, omit `--turbo_dit` and sample on the RAW model instead.
 
-**Alternative: `--turbo_lora`.** If you only have Krea's official Turbo release in LoRA-delta form (rather than a merged Turbo checkpoint), pass `--turbo_lora path/to/turbo_lora.safetensors` instead of `--turbo_dit`. Unlike `--turbo_dit`, this never touches the RAW base weights at all: the Turbo LoRA is composed live as a second, independent LoRA hook on top of RAW, active at the same time as the LoRA being trained (both apply simultaneously, `base + trainee_delta + turbo_delta` -- no merge, no weight swap). `--turbo_lora_multiplier` (default `1.0`) scales its delta. The Turbo LoRA is built once (lazily, on the first sample step) and then just enabled/disabled around each sample pass -- no per-step disk I/O. The same Turbo schedule applies (fixed `mu = 1.15`, CFG off, low step count -- see the sample prompt guidance above). `--turbo_lora` is mutually exclusive with `--turbo_dit` (combining a Turbo LoRA with an already-distilled Turbo checkpoint isn't a meaningful workflow). Unlike `--turbo_dit`, `--turbo_lora` is **not** restricted against `--blocks_to_swap`, `--convrot_int8`, or `--nvfp4` -- because it never touches base weights, it is expected to compose the same way the trainee's own LoRA already does under those settings (untested in practice; report an issue if you hit a problem). `--turbo_lora` is **not** supported together with `--compile`. `--turbo_dit_cache` has no effect on `--turbo_lora` -- it only applies to `--turbo_dit`'s memory-mode choice.
+**Alternative: `--turbo_lora`.** Pass `--turbo_lora path/to/turbo_lora.safetensors` instead of
+`--turbo_dit` to compose a Turbo LoRA live on top of RAW (`base + trainee_delta + turbo_delta`)
+rather than swapping in a full Turbo checkpoint. `--turbo_lora_multiplier` (default `1.0`)
+scales its delta. Built once at startup; toggled on/off around each sample pass. Mutually
+exclusive with `--turbo_dit`. `--turbo_dit_cache` has no effect on it.
+
+This LoRA is a rank-extracted delta between the released raw and turbo checkpoints, not an
+official Krea artifact — it approximates the turbo weights, which is why the Turbo schedule
+(fixed `mu = 1.15`, CFG off, low step count) still applies.
 
 <details>
 <summary>日本語</summary>
@@ -310,7 +318,15 @@ A fox in the snow.  --w 1024 --h 1024 --s 8 --l 1 --d 0
 
 > **`--turbo_dit`は`--blocks_to_swap`と併用できません。** Turboサンプリングはベースの重みをその場で入れ替えるため、block swapのオフローダーがない場合にのみ安全です。block swapを使う場合は`--turbo_dit`を省略し、RAWモデルでサンプリングしてください。
 
-**代替手段: `--turbo_lora`。** マージ済みのTurboチェックポイントではなく、KreaのTurbo公式リリースがLoRA差分形式でしか手元にない場合は、`--turbo_dit`の代わりに`--turbo_lora path/to/turbo_lora.safetensors`を指定します。`--turbo_dit`と異なり、RAWのbase重みには一切触れません。Turbo LoRAは、学習中のLoRAと同時に適用される、独立した2つ目のLoRAフックとしてRAWの上にライブ合成されます（`base + trainee_delta + turbo_delta`、マージも重みの入れ替えもありません）。`--turbo_lora_multiplier`（デフォルト`1.0`）でそのdeltaの強さを調整できます。Turbo LoRAは（最初のサンプルステップで）一度だけ遅延構築され、以降は各サンプルパスの前後で有効化/無効化されるだけです（ディスクI/Oは発生しません）。Turboのスケジュール（固定`mu = 1.15`、CFGオフ、少ないステップ数。上記のサンプルプロンプトの指定を参照）は同様に適用されます。`--turbo_lora`は`--turbo_dit`と併用できません（Turbo LoRAを既に蒸留済みのTurboチェックポイントと組み合わせるのは意味のあるワークフローではないためです）。`--turbo_dit`と異なり、`--turbo_lora`は`--blocks_to_swap`・`--convrot_int8`・`--nvfp4`との併用を制限していません——base重みに一切触れないため、これらの設定下でも学習中のLoRA自身と同様に動作すると想定しています（実運用での検証は未実施です。問題があれば報告してください）。`--turbo_lora`は`--compile`と併用できません。`--turbo_dit_cache`は`--turbo_lora`には影響しません（`--turbo_dit`のメモリモード選択にのみ適用されます）。
+**代替手段: `--turbo_lora`。** `--turbo_dit`の代わりに`--turbo_lora path/to/turbo_lora.safetensors`
+を指定すると、フルのTurboチェックポイントを入れ替える代わりに、RAWの上でTurbo LoRAをライブ合成します
+（`base + trainee_delta + turbo_delta`）。`--turbo_lora_multiplier`（デフォルト`1.0`）でdeltaの強さを
+調整できます。起動時に一度だけ構築され、各サンプルパスの前後で有効/無効を切り替えます。`--turbo_dit`
+とは併用できません。`--turbo_dit_cache`はこれには影響しません。
+
+このLoRAは公開されているraw/turboチェックポイント間から抽出したランク近似deltaであり、Krea公式のLoRA
+ではありません——turboの重みを近似しているため、Turboのスケジュール（固定`mu = 1.15`、CFGオフ、少ない
+ステップ数）がそのまま適用されます。
 
 </details>
 

--- a/docs/krea2.md
+++ b/docs/krea2.md
@@ -296,7 +296,7 @@ A fox in the snow.  --w 1024 --h 1024 --s 8 --l 1 --d 0
 `--turbo_dit` to compose a Turbo LoRA live on top of RAW (`base + trainee_delta + turbo_delta`)
 rather than swapping in a full Turbo checkpoint. `--turbo_lora_multiplier` (default `1.0`)
 scales its delta. Built once at startup; toggled on/off around each sample pass. Mutually
-exclusive with `--turbo_dit`. `--turbo_dit_cache` has no effect on it.
+exclusive with `--turbo_dit`. Cannot be combined with `--turbo_dit_cache` (that flag requires `--turbo_dit`).
 
 This LoRA is a rank-extracted delta between the released raw and turbo checkpoints, not an
 official Krea artifact — it approximates the turbo weights, which is why the Turbo schedule
@@ -322,7 +322,7 @@ official Krea artifact — it approximates the turbo weights, which is why the T
 を指定すると、フルのTurboチェックポイントを入れ替える代わりに、RAWの上でTurbo LoRAをライブ合成します
 （`base + trainee_delta + turbo_delta`）。`--turbo_lora_multiplier`（デフォルト`1.0`）でdeltaの強さを
 調整できます。起動時に一度だけ構築され、各サンプルパスの前後で有効/無効を切り替えます。`--turbo_dit`
-とは併用できません。`--turbo_dit_cache`はこれには影響しません。
+とは併用できません。`--turbo_dit_cache`（`--turbo_dit`が必須のオプション）との併用もできません。
 
 このLoRAは公開されているraw/turboチェックポイント間から抽出したランク近似deltaであり、Krea公式のLoRA
 ではありません——turboの重みを近似しているため、Turboのスケジュール（固定`mu = 1.15`、CFGオフ、少ない

--- a/src/musubi_tuner/krea2_train_network.py
+++ b/src/musubi_tuner/krea2_train_network.py
@@ -54,9 +54,7 @@ class Krea2NetworkTrainer(NetworkTrainer):
         # so a single snapshot stays valid for the whole run).
         self._turbo_stash = None
         self._raw_stash = None
-        # --turbo_lora sampling composes a second, frozen LoRANetwork live on top of RAW,
-        # alongside the trainee network (see _ensure_turbo_lora_network) -- never a weight
-        # swap. Built once, lazily, on the first sample step; None until then.
+        # --turbo_lora: second, frozen LoRANetwork composed on RAW (see _build_turbo_lora_network).
         self._turbo_lora_network = None
 
     # region model specific
@@ -89,46 +87,26 @@ class Krea2NetworkTrainer(NetworkTrainer):
         if args.convrot_int8_bwd == "int8" and not args.convrot_int8:
             raise ValueError("--convrot_int8_bwd int8 requires --convrot_int8.")
         # RAW-train / Turbo-sample: the recommended K2 LoRA workflow is to train on the RAW
-        # checkpoint and run inference on the distilled Turbo. --turbo_dit makes sample
-        # generation during training swap the base weights to Turbo (LoRA, hooked on the live
-        # Linears, applies on top automatically) and use the Turbo sampling schedule.
+        # checkpoint and run inference on the distilled Turbo. --turbo_dit (a full separate
+        # Turbo checkpoint) swaps the base weights to Turbo for sample generation (the trainee
+        # LoRA stays hooked and applies on top automatically). --turbo_lora instead composes a
+        # second, frozen LoRA network live on top of RAW, alongside the trainee LoRA -- built
+        # eagerly in _build_network -- and never touches the base weights at all, so it is not
+        # bound by --turbo_dit's block-swap restriction below (only mutual exclusion with
+        # --turbo_dit itself, checked next).
+        turbo_lora = getattr(args, "turbo_lora", None)
+        if args.turbo_dit and turbo_lora:
+            raise ValueError("--turbo_dit and --turbo_lora are mutually exclusive: choose one turbo source for sample generation.")
         if args.turbo_dit_cache and not args.turbo_dit:
             raise ValueError("--turbo_dit_cache (M1, resident Turbo weights) requires --turbo_dit.")
-        # Turbo sample generation swaps the base weights from outside the model, which is unsafe
-        # under block swap: the offloader (esp. --block_swap_h2d_only's LoRAStreamOffloader) keeps
-        # its own CPU master and streams it to the GPU, so an external weight swap does NOT reach
-        # the weights the forward actually uses -> RAW/Turbo mix (bf16: loss drift; fp8: pure noise
-        # from RAW weight x Turbo scale_weight). Restrict Turbo sampling to the block-swap-disabled
-        # case (it is an optional, VRAM-permitting convenience); with block swap, sample on RAW.
+        # --turbo_dit swaps base weights from outside the model; the block-swap offloader's own
+        # CPU master never sees that swap, producing a RAW/Turbo weight mix. --turbo_lora never
+        # swaps weights (only composes a LoRA hook), so it is not restricted here.
         if args.turbo_dit and args.blocks_to_swap:
             raise ValueError(
                 "--turbo_dit (Turbo sample generation) is not supported together with --blocks_to_swap: "
                 "the block-swap offloader manages the base weights and an external swap would mix RAW/Turbo. "
                 "Use Turbo sampling without block swap (VRAM permitting), or omit --turbo_dit to sample on RAW."
-            )
-        turbo_lora = getattr(args, "turbo_lora", None)
-        # --turbo_lora composes a second, frozen LoRA network live on top of RAW, alongside the
-        # trainee LoRA (see _ensure_turbo_lora_network), and never touches the base weights, so
-        # it is not bound by --turbo_dit's block-swap restriction above -- only mutual exclusion
-        # with --turbo_dit itself (combining the two turbo sources is not a meaningful workflow).
-        if args.turbo_dit and turbo_lora:
-            raise ValueError("--turbo_dit and --turbo_lora are mutually exclusive: choose one turbo source for sample generation.")
-        # --turbo_lora's LoRANetwork is built lazily on the first sample step (see
-        # _ensure_turbo_lora_network), i.e. after compile_transformer has already run (compile
-        # happens well before the training/sampling loop). torch.compile wraps each block in an
-        # OptimizedModule, so post-compile module paths gain an "_orig_mod" segment; every
-        # lora_name the lazily-built Turbo LoRA network derives against the live (compiled) model
-        # would then mismatch the modules_dim keys loaded from the (uncompiled-name) checkpoint,
-        # and LoRANetwork.apply_to raises "No LoRA modules found" -- crashing training mid-flight
-        # at the first sample step rather than at startup. --turbo_dit does not have this problem:
-        # _named_live_tensors already strips "_orig_mod" for its weight-swap path, but --turbo_lora
-        # has no equivalent workaround yet, so reject the combination up front instead.
-        if turbo_lora and args.compile:
-            raise ValueError(
-                "--turbo_lora is not supported together with --compile: the Turbo LoRA network is built lazily "
-                "on the first sample step, after torch.compile has already renamed module paths (adding "
-                "'_orig_mod'), so its LoRA module names would not match the checkpoint's uncompiled names. "
-                "Omit --compile, or sample Turbo via --turbo_dit instead."
             )
         if (args.turbo_dit or turbo_lora) and not args.sample_prompts:
             logger.warning("--turbo_dit/--turbo_lora is set but --sample_prompts is not; Turbo is only used for sample generation.")
@@ -342,31 +320,28 @@ class Krea2NetworkTrainer(NetworkTrainer):
         for k, t in self._named_live_tensors(model).items():
             t.data = src[k]
 
-    def _ensure_turbo_lora_network(self, args: argparse.Namespace, accelerator: Accelerator, model):
-        """Build (once) and return the Turbo LoRA network, composed live on top of RAW.
-
-        Loads ``args.turbo_lora``'s weights, builds a second ``LoRANetwork`` from them (Krea 2
-        only ships one LoRA network module, ``lora_krea2``, so it is used directly regardless of
-        the trainee's own ``--network_module``), and ``apply_to()``s it onto ``model``. Because
-        ``LoRAModule.apply_to()`` wraps ``org_module.forward`` rather than merging weights, this
-        chains additively on top of whatever is already hooked (the trainee network) -- no base
-        weight is ever read or written. Frozen (``requires_grad_(False)``) since it is never
-        trained, and starts disabled: the caller enables/disables it per sample step.
-        """
-        if self._turbo_lora_network is not None:
-            return self._turbo_lora_network
+    def _build_turbo_lora_network(self, args: argparse.Namespace, accelerator: Accelerator, model):
+        """Build and apply the Turbo LoRA network (frozen, disabled) live on top of RAW."""
         logger.info(f"Krea 2: loading Turbo LoRA for sampling from {args.turbo_lora}")
         weights_sd = load_file(args.turbo_lora)
         turbo_network = lora_krea2.create_arch_network_from_weights(
             getattr(args, "turbo_lora_multiplier", 1.0), weights_sd, unet=model, for_inference=True
         )
         turbo_network.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+        # strict=False: the current Turbo LoRA extraction carries non-essential keys; revisit
+        # once that extraction is investigated.
         turbo_network.load_weights(args.turbo_lora)
         turbo_network.requires_grad_(False)
         turbo_network.to(accelerator.device)
         turbo_network.set_enabled(False)
         self._turbo_lora_network = turbo_network
         return turbo_network
+
+    def _build_network(self, args, accelerator, transformer, vae, weight_dtype):
+        network = super()._build_network(args, accelerator, transformer, vae, weight_dtype)
+        if network is not None and getattr(args, "turbo_lora", None):
+            self._build_turbo_lora_network(args, accelerator, transformer)
+        return network
 
     def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
         if args.turbo_dit:
@@ -404,12 +379,8 @@ class Krea2NetworkTrainer(NetworkTrainer):
                 gc.collect()
                 clean_memory_on_device(accelerator.device)
         elif getattr(args, "turbo_lora", None):
-            # Compose the Turbo LoRA live on top of RAW, alongside the trainee LoRA -- no
-            # weight is ever swapped or merged.
-            model = accelerator.unwrap_model(transformer)
-            turbo_network = self._ensure_turbo_lora_network(args, accelerator, model)
             logger.info("Krea 2: enabling Turbo LoRA for sampling")
-            turbo_network.set_enabled(True)
+            self._turbo_lora_network.set_enabled(True)
 
     def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
         if args.turbo_dit:

--- a/src/musubi_tuner/krea2_train_network.py
+++ b/src/musubi_tuner/krea2_train_network.py
@@ -224,8 +224,10 @@ class Krea2NetworkTrainer(NetworkTrainer):
         # mu interpolation endpoints (krea2 sample defaults minres=256, maxres=1280).
         x1 = (256 // align) ** 2
         x2 = (1280 // align) ** 2
-        # The distilled Turbo checkpoint was trained at a fixed mu=1.15; the RAW checkpoint
-        # uses resolution-aware mu interpolation. When sampling on Turbo (--turbo_dit), pin mu.
+        # The distilled Turbo checkpoint was trained at a fixed mu=1.15; the RAW checkpoint uses
+        # resolution-aware mu interpolation. --turbo_dit swaps in that checkpoint directly;
+        # --turbo_lora is a rank-extracted delta between the released raw/turbo checkpoints, so
+        # it approximates the same fixed-mu weights. Pin mu for either.
         turbo_mu = 1.15 if (args.turbo_dit or getattr(args, "turbo_lora", None)) else None
         ts = krea2_sampling.timesteps(img.shape[1], sample_steps, x1, x2, y1=0.5, y2=1.15, mu=turbo_mu)
 
@@ -580,6 +582,19 @@ def krea2_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
         help="M1 memory mode for --turbo_dit: keep the (fp8-quantized at startup) Turbo weights resident in "
         "CPU RAM and ping-pong-swap them in (~1x extra CPU, faster). Default (M2) streams Turbo from disk each "
         "sample step (re-quantizing if fp8) for ~0x steady CPU at the cost of per-validation load time.",
+    )
+    parser.add_argument(
+        "--turbo_lora",
+        type=str,
+        default=None,
+        help="Turbo LoRA safetensors path: composed live on top of RAW, alongside the LoRA "
+        "being trained. Alternative to --turbo_dit (mutually exclusive with it). See docs/krea2.md.",
+    )
+    parser.add_argument(
+        "--turbo_lora_multiplier",
+        type=float,
+        default=1.0,
+        help="Multiplier for the Turbo LoRA's delta.",
     )
     return parser
 

--- a/src/musubi_tuner/krea2_train_network.py
+++ b/src/musubi_tuner/krea2_train_network.py
@@ -18,6 +18,7 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from accelerate import Accelerator
+from safetensors.torch import load_file
 from tqdm import tqdm
 from einops import rearrange, repeat
 
@@ -32,6 +33,7 @@ from musubi_tuner.hv_train_network import (
 )
 from musubi_tuner.krea2 import krea2_utils
 from musubi_tuner.krea2 import krea2_sampling
+from musubi_tuner.networks import lora_krea2
 from musubi_tuner.qwen_image import qwen_image_utils
 from musubi_tuner.utils import model_utils
 
@@ -52,6 +54,10 @@ class Krea2NetworkTrainer(NetworkTrainer):
         # so a single snapshot stays valid for the whole run).
         self._turbo_stash = None
         self._raw_stash = None
+        # --turbo_lora sampling composes a second, frozen LoRANetwork live on top of RAW,
+        # alongside the trainee network (see _ensure_turbo_lora_network) -- never a weight
+        # swap. Built once, lazily, on the first sample step; None until then.
+        self._turbo_lora_network = None
 
     # region model specific
 
@@ -218,7 +224,7 @@ class Krea2NetworkTrainer(NetworkTrainer):
         x2 = (1280 // align) ** 2
         # The distilled Turbo checkpoint was trained at a fixed mu=1.15; the RAW checkpoint
         # uses resolution-aware mu interpolation. When sampling on Turbo (--turbo_dit), pin mu.
-        turbo_mu = 1.15 if args.turbo_dit else None
+        turbo_mu = 1.15 if (args.turbo_dit or getattr(args, "turbo_lora", None)) else None
         ts = krea2_sampling.timesteps(img.shape[1], sample_steps, x1, x2, y1=0.5, y2=1.15, mu=turbo_mu)
 
         for tcurr, tprev in tqdm(zip(ts[:-1], ts[1:]), total=len(ts) - 1, desc="Denoising steps"):
@@ -312,64 +318,101 @@ class Krea2NetworkTrainer(NetworkTrainer):
         for k, t in self._named_live_tensors(model).items():
             t.data = src[k]
 
+    def _ensure_turbo_lora_network(self, args: argparse.Namespace, accelerator: Accelerator, model):
+        """Build (once) and return the Turbo LoRA network, composed live on top of RAW.
+
+        Loads ``args.turbo_lora``'s weights, builds a second ``LoRANetwork`` from them (Krea 2
+        only ships one LoRA network module, ``lora_krea2``, so it is used directly regardless of
+        the trainee's own ``--network_module``), and ``apply_to()``s it onto ``model``. Because
+        ``LoRAModule.apply_to()`` wraps ``org_module.forward`` rather than merging weights, this
+        chains additively on top of whatever is already hooked (the trainee network) -- no base
+        weight is ever read or written. Frozen (``requires_grad_(False)``) since it is never
+        trained, and starts disabled: the caller enables/disables it per sample step.
+        """
+        if self._turbo_lora_network is not None:
+            return self._turbo_lora_network
+        logger.info(f"Krea 2: loading Turbo LoRA for sampling from {args.turbo_lora}")
+        weights_sd = load_file(args.turbo_lora)
+        turbo_network = lora_krea2.create_arch_network_from_weights(
+            getattr(args, "turbo_lora_multiplier", 1.0), weights_sd, unet=model, for_inference=True
+        )
+        turbo_network.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+        turbo_network.load_weights(args.turbo_lora)
+        turbo_network.requires_grad_(False)
+        turbo_network.to(accelerator.device)
+        turbo_network.set_enabled(False)
+        self._turbo_lora_network = turbo_network
+        return turbo_network
+
     def on_before_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
-        # Swap RAW -> Turbo base weights for sample generation (LoRA stays hooked and applies on top).
-        if not args.turbo_dit:
-            return
-        model = accelerator.unwrap_model(transformer)
-        if args.turbo_dit_cache:
-            # M1: build the resident (fp8-quantized at startup) Turbo stash once and snapshot the
-            # RAW base once, then copy Turbo into the live weights (storage preserved, see
-            # _overwrite_weights). The snapshot must be taken before the first overwrite.
-            if self._turbo_stash is None:
-                logger.info(f"Krea 2: caching Turbo weights for sampling (M1) from {args.turbo_dit}")
-                self._turbo_stash = krea2_utils.load_krea2_dit_state_dict(
-                    args.turbo_dit, fp8_scaled=args.fp8_scaled, calc_device=accelerator.device, result_device="cpu"
+        if args.turbo_dit:
+            # Swap RAW -> Turbo base weights for sample generation (LoRA stays hooked and
+            # applies on top automatically).
+            model = accelerator.unwrap_model(transformer)
+            if args.turbo_dit_cache:
+                # M1: build the resident (fp8-quantized at startup) Turbo stash once and snapshot
+                # the RAW base once, then copy Turbo into the live weights (storage preserved,
+                # see _overwrite_weights). The snapshot must be taken before the first overwrite.
+                if self._turbo_stash is None:
+                    logger.info(f"Krea 2: caching Turbo weights for sampling (M1) from {args.turbo_dit}")
+                    self._turbo_stash = krea2_utils.load_krea2_dit_state_dict(
+                        args.turbo_dit, fp8_scaled=args.fp8_scaled, calc_device=accelerator.device, result_device="cpu"
+                    )
+                if self._raw_stash is None:
+                    logger.info("Krea 2: snapshotting RAW weights for restore (M1)")
+                    self._raw_stash = self._snapshot_weights(model)
+                logger.info("Krea 2: swapping in Turbo weights for sampling (M1)")
+                self._overwrite_weights(model, self._turbo_stash)
+            else:
+                # M2: free the RAW base weights, then load the Turbo weights (re-quantized if
+                # fp8) straight onto the GPU and reassign them. Freeing first keeps the GPU at
+                # ~1x the model size; loading directly to the GPU keeps the CPU peak at ~1
+                # tensor (no full intermediate CPU dict). Safe to reassign here because
+                # --turbo_dit forbids block swap.
+                logger.info(f"Krea 2: loading Turbo weights for sampling (M2, GPU-direct) from {args.turbo_dit}")
+                self._free_base_weights(model)
+                clean_memory_on_device(accelerator.device)
+                turbo_sd = krea2_utils.load_krea2_dit_state_dict(
+                    args.turbo_dit, fp8_scaled=args.fp8_scaled, calc_device=accelerator.device, result_device=accelerator.device
                 )
-            if self._raw_stash is None:
-                logger.info("Krea 2: snapshotting RAW weights for restore (M1)")
-                self._raw_stash = self._snapshot_weights(model)
-            logger.info("Krea 2: swapping in Turbo weights for sampling (M1)")
-            self._overwrite_weights(model, self._turbo_stash)
-        else:
-            # M2: free the RAW base weights, then load the Turbo weights (re-quantized if fp8)
-            # straight onto the GPU and reassign them. Freeing first keeps the GPU at ~1x the
-            # model size; loading directly to the GPU keeps the CPU peak at ~1 tensor (no full
-            # intermediate CPU dict). Safe to reassign here because --turbo_dit forbids block swap.
-            logger.info(f"Krea 2: loading Turbo weights for sampling (M2, GPU-direct) from {args.turbo_dit}")
-            self._free_base_weights(model)
-            clean_memory_on_device(accelerator.device)
-            turbo_sd = krea2_utils.load_krea2_dit_state_dict(
-                args.turbo_dit, fp8_scaled=args.fp8_scaled, calc_device=accelerator.device, result_device=accelerator.device
-            )
-            self._assign_weights(model, turbo_sd)
-            del turbo_sd
-            gc.collect()
-            clean_memory_on_device(accelerator.device)
+                self._assign_weights(model, turbo_sd)
+                del turbo_sd
+                gc.collect()
+                clean_memory_on_device(accelerator.device)
+        elif getattr(args, "turbo_lora", None):
+            # Compose the Turbo LoRA live on top of RAW, alongside the trainee LoRA -- no
+            # weight is ever swapped or merged.
+            model = accelerator.unwrap_model(transformer)
+            turbo_network = self._ensure_turbo_lora_network(args, accelerator, model)
+            logger.info("Krea 2: enabling Turbo LoRA for sampling")
+            turbo_network.set_enabled(True)
 
     def on_after_sample_images(self, accelerator, args, epoch, steps, vae, transformer, network, sample_parameters, dit_dtype):
-        # Restore RAW base weights after sampling.
-        if not args.turbo_dit:
-            return
-        model = accelerator.unwrap_model(transformer)
-        if args.turbo_dit_cache:
-            logger.info("Krea 2: restoring RAW weights after sampling (M1)")
-            self._overwrite_weights(model, self._raw_stash)  # copy RAW back in place (storage preserved)
-        else:
-            # M2: free the Turbo base weights, then reload RAW (re-quantized if fp8) straight
-            # onto the GPU and reassign — same GPU-direct, CPU-peak-~1-tensor path as swap-in.
-            # RAW is frozen during training, so reloading it from disk reproduces it exactly.
-            logger.info(f"Krea 2: restoring RAW weights after sampling (M2, GPU-direct) from {args.dit}")
-            self._free_base_weights(model)
-            clean_memory_on_device(accelerator.device)
-            raw_sd = krea2_utils.load_krea2_dit_state_dict(
-                args.dit, fp8_scaled=args.fp8_scaled, calc_device=accelerator.device, result_device=accelerator.device
-            )
-            self._assign_weights(model, raw_sd)
-            del raw_sd
-            gc.collect()
-            clean_memory_on_device(accelerator.device)
-        logger.info("Krea 2: RAW weights restored")
+        if args.turbo_dit:
+            # Restore RAW base weights after sampling.
+            model = accelerator.unwrap_model(transformer)
+            if args.turbo_dit_cache:
+                logger.info("Krea 2: restoring RAW weights after sampling (M1)")
+                self._overwrite_weights(model, self._raw_stash)  # copy RAW back in place (storage preserved)
+            else:
+                # M2: free the Turbo base weights, then reload RAW (re-quantized if fp8) straight
+                # onto the GPU and reassign -- same GPU-direct, CPU-peak-~1-tensor path as
+                # swap-in. RAW is frozen during training, so reloading it from disk reproduces
+                # it exactly.
+                logger.info(f"Krea 2: restoring RAW weights after sampling (M2, GPU-direct) from {args.dit}")
+                self._free_base_weights(model)
+                clean_memory_on_device(accelerator.device)
+                raw_sd = krea2_utils.load_krea2_dit_state_dict(
+                    args.dit, fp8_scaled=args.fp8_scaled, calc_device=accelerator.device, result_device=accelerator.device
+                )
+                self._assign_weights(model, raw_sd)
+                del raw_sd
+                gc.collect()
+                clean_memory_on_device(accelerator.device)
+            logger.info("Krea 2: RAW weights restored")
+        elif getattr(args, "turbo_lora", None):
+            logger.info("Krea 2: disabling Turbo LoRA after sampling")
+            self._turbo_lora_network.set_enabled(False)
 
     # endregion RAW-train / Turbo-sample
 

--- a/src/musubi_tuner/krea2_train_network.py
+++ b/src/musubi_tuner/krea2_train_network.py
@@ -106,8 +106,32 @@ class Krea2NetworkTrainer(NetworkTrainer):
                 "the block-swap offloader manages the base weights and an external swap would mix RAW/Turbo. "
                 "Use Turbo sampling without block swap (VRAM permitting), or omit --turbo_dit to sample on RAW."
             )
-        if args.turbo_dit and not args.sample_prompts:
-            logger.warning("--turbo_dit is set but --sample_prompts is not; Turbo is only used for sample generation.")
+        turbo_lora = getattr(args, "turbo_lora", None)
+        # --turbo_lora composes a second, frozen LoRA network live on top of RAW, alongside the
+        # trainee LoRA (see _ensure_turbo_lora_network), and never touches the base weights, so
+        # it is not bound by --turbo_dit's block-swap restriction above -- only mutual exclusion
+        # with --turbo_dit itself (combining the two turbo sources is not a meaningful workflow).
+        if args.turbo_dit and turbo_lora:
+            raise ValueError("--turbo_dit and --turbo_lora are mutually exclusive: choose one turbo source for sample generation.")
+        # --turbo_lora's LoRANetwork is built lazily on the first sample step (see
+        # _ensure_turbo_lora_network), i.e. after compile_transformer has already run (compile
+        # happens well before the training/sampling loop). torch.compile wraps each block in an
+        # OptimizedModule, so post-compile module paths gain an "_orig_mod" segment; every
+        # lora_name the lazily-built Turbo LoRA network derives against the live (compiled) model
+        # would then mismatch the modules_dim keys loaded from the (uncompiled-name) checkpoint,
+        # and LoRANetwork.apply_to raises "No LoRA modules found" -- crashing training mid-flight
+        # at the first sample step rather than at startup. --turbo_dit does not have this problem:
+        # _named_live_tensors already strips "_orig_mod" for its weight-swap path, but --turbo_lora
+        # has no equivalent workaround yet, so reject the combination up front instead.
+        if turbo_lora and args.compile:
+            raise ValueError(
+                "--turbo_lora is not supported together with --compile: the Turbo LoRA network is built lazily "
+                "on the first sample step, after torch.compile has already renamed module paths (adding "
+                "'_orig_mod'), so its LoRA module names would not match the checkpoint's uncompiled names. "
+                "Omit --compile, or sample Turbo via --turbo_dit instead."
+            )
+        if (args.turbo_dit or turbo_lora) and not args.sample_prompts:
+            logger.warning("--turbo_dit/--turbo_lora is set but --sample_prompts is not; Turbo is only used for sample generation.")
 
     def process_sample_prompts(
         self,

--- a/tests/test_krea2_turbo_lora.py
+++ b/tests/test_krea2_turbo_lora.py
@@ -2,8 +2,44 @@
 RAW weights, alongside the LoRA being trained. Never merges into or mutates base weights."""
 
 import pytest
+import torch
 
 from types import SimpleNamespace
+
+from musubi_tuner.krea2.krea2_mmdit import SingleMMDiTConfig, SingleStreamDiT
+
+
+@pytest.fixture
+def tiny_k2_config():
+    """Minimal K2 config for fast CPU tests -- not real weights.
+
+    features=32, heads=2 -> headdim=16 -> axes=[4,6,6] (sum=16, all even),
+    the constraint SingleStreamDiT.__init__ asserts on.
+    """
+    return SingleMMDiTConfig(
+        features=32,
+        tdim=32,
+        txtdim=32,
+        heads=2,
+        multiplier=1,
+        layers=3,
+        patch=2,
+        channels=4,
+        bias=False,
+        theta=1e3,
+        kvheads=None,
+        txtlayers=1,
+        txtheads=2,
+        txtkvheads=2,
+    )
+
+
+@pytest.fixture
+def tiny_k2_model(tiny_k2_config):
+    torch.manual_seed(0)
+    model = SingleStreamDiT(tiny_k2_config, attn_mode="torch")
+    model.eval()
+    return model
 
 
 def _trainer_args(**overrides):
@@ -80,7 +116,6 @@ def test_trainer_warns_turbo_lora_without_sample_prompts(caplog):
     assert "turbo_dit" in caplog.text.lower() or "turbo_lora" in caplog.text.lower()
 
 
-import torch
 from safetensors.torch import save_file
 
 

--- a/tests/test_krea2_turbo_lora.py
+++ b/tests/test_krea2_turbo_lora.py
@@ -80,11 +80,6 @@ def test_trainer_warns_turbo_lora_without_sample_prompts(caplog):
     assert "turbo_dit" in caplog.text.lower() or "turbo_lora" in caplog.text.lower()
 
 
-def test_trainer_rejects_turbo_lora_with_compile():
-    with pytest.raises(ValueError, match="compile"):
-        _handle_args(_trainer_args(turbo_lora="turbo_lora.safetensors", compile=True, sample_prompts="p.txt"))
-
-
 import torch
 from safetensors.torch import save_file
 
@@ -96,7 +91,7 @@ class _FakeAccelerator:
         return m
 
 
-def test_ensure_turbo_lora_network_builds_once_and_starts_disabled(tiny_k2_model, tmp_path):
+def test_build_turbo_lora_network_starts_disabled_and_frozen(tiny_k2_model, tmp_path):
     from musubi_tuner.krea2_train_network import Krea2NetworkTrainer
     from musubi_tuner.networks import lora_krea2
 
@@ -111,12 +106,10 @@ def test_ensure_turbo_lora_network_builds_once_and_starts_disabled(tiny_k2_model
     args = _trainer_args(turbo_lora=str(lora_path), turbo_lora_multiplier=1.0)
     accelerator = _FakeAccelerator()
 
-    network1 = trainer._ensure_turbo_lora_network(args, accelerator, model)
-    assert all(not lora.enabled for lora in network1.unet_loras)
-    assert all(not p.requires_grad for p in network1.parameters())
-
-    network2 = trainer._ensure_turbo_lora_network(args, accelerator, model)
-    assert network1 is network2  # built once, cached
+    network = trainer._build_turbo_lora_network(args, accelerator, model)
+    assert network is trainer._turbo_lora_network
+    assert all(not lora.enabled for lora in network.unet_loras)
+    assert all(not p.requires_grad for p in network.parameters())
 
 
 def test_turbo_lora_composes_additively_with_trainee_lora(tiny_k2_model, tmp_path):
@@ -155,7 +148,7 @@ def test_turbo_lora_composes_additively_with_trainee_lora(tiny_k2_model, tmp_pat
     args = _trainer_args(turbo_lora=str(lora_path), turbo_lora_multiplier=1.0)
     accelerator = _FakeAccelerator()
 
-    turbo_network = trainer._ensure_turbo_lora_network(args, accelerator, model)
+    turbo_network = trainer._build_turbo_lora_network(args, accelerator, model)
     assert torch.equal(linear_module(x), trainee_out)  # still disabled: no change yet
 
     turbo_network.set_enabled(True)
@@ -180,6 +173,7 @@ def test_on_before_after_sample_images_toggle_turbo_lora(tiny_k2_model, tmp_path
     trainer = Krea2NetworkTrainer()
     args = _trainer_args(turbo_lora=str(lora_path), turbo_dit=None, sample_prompts="p.txt")
     accelerator = _FakeAccelerator()
+    trainer._build_turbo_lora_network(args, accelerator, model)
 
     trainer.on_before_sample_images(accelerator, args, 0, 0, None, model, trainee, [], torch.float32)
     assert trainer._turbo_lora_network is not None
@@ -187,6 +181,53 @@ def test_on_before_after_sample_images_toggle_turbo_lora(tiny_k2_model, tmp_path
 
     trainer.on_after_sample_images(accelerator, args, 0, 0, None, model, trainee, [], torch.float32)
     assert all(not lora.enabled for lora in trainer._turbo_lora_network.unet_loras)
+
+
+def test_build_network_eagerly_builds_turbo_lora(tiny_k2_model, tmp_path, monkeypatch):
+    from musubi_tuner.krea2_train_network import Krea2NetworkTrainer
+    from musubi_tuner.networks import lora_krea2
+    from musubi_tuner.training.trainer_base import NetworkTrainer
+
+    model = tiny_k2_model
+    trainee = lora_krea2.create_arch_network(1.0, 4, 4, None, None, model)
+    trainee.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+    lora_path = tmp_path / "turbo_lora.safetensors"
+    save_file(trainee.state_dict(), str(lora_path))
+
+    monkeypatch.setattr(
+        NetworkTrainer, "_build_network", lambda self, args, accelerator, transformer, vae, weight_dtype: trainee
+    )
+
+    trainer = Krea2NetworkTrainer()
+    args = _trainer_args(turbo_lora=str(lora_path), compile=True)
+    accelerator = _FakeAccelerator()
+
+    result = trainer._build_network(args, accelerator, model, None, torch.float32)
+
+    assert result is trainee
+    assert trainer._turbo_lora_network is not None
+    assert all(not lora.enabled for lora in trainer._turbo_lora_network.unet_loras)
+    for lora in trainer._turbo_lora_network.unet_loras:
+        assert "_orig_mod" not in lora.lora_name
+
+
+def test_build_network_skips_turbo_lora_when_not_set(tiny_k2_model, monkeypatch):
+    from musubi_tuner.krea2_train_network import Krea2NetworkTrainer
+    from musubi_tuner.training.trainer_base import NetworkTrainer
+
+    model = tiny_k2_model
+    monkeypatch.setattr(
+        NetworkTrainer, "_build_network", lambda self, args, accelerator, transformer, vae, weight_dtype: "stub-network"
+    )
+
+    trainer = Krea2NetworkTrainer()
+    args = _trainer_args(turbo_lora=None)
+    accelerator = _FakeAccelerator()
+
+    result = trainer._build_network(args, accelerator, model, None, torch.float32)
+
+    assert result == "stub-network"
+    assert trainer._turbo_lora_network is None
 
 
 def test_do_inference_turbo_mu_pinned_for_turbo_lora():

--- a/tests/test_krea2_turbo_lora.py
+++ b/tests/test_krea2_turbo_lora.py
@@ -19,6 +19,7 @@ def _trainer_args(**overrides):
         turbo_lora_multiplier=1.0,
         blocks_to_swap=0,
         sample_prompts=None,
+        compile=False,
     )
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -77,6 +78,11 @@ def test_trainer_accepts_turbo_lora_alone():
 def test_trainer_warns_turbo_lora_without_sample_prompts(caplog):
     _handle_args(_trainer_args(turbo_lora="turbo_lora.safetensors", sample_prompts=None))
     assert "turbo_dit" in caplog.text.lower() or "turbo_lora" in caplog.text.lower()
+
+
+def test_trainer_rejects_turbo_lora_with_compile():
+    with pytest.raises(ValueError, match="compile"):
+        _handle_args(_trainer_args(turbo_lora="turbo_lora.safetensors", compile=True, sample_prompts="p.txt"))
 
 
 import torch

--- a/tests/test_krea2_turbo_lora.py
+++ b/tests/test_krea2_turbo_lora.py
@@ -1,0 +1,192 @@
+"""Tests for --turbo_lora: a Turbo LoRA composed live (as a second LoRA hook) on top of
+RAW weights, alongside the LoRA being trained. Never merges into or mutates base weights."""
+
+import pytest
+
+from types import SimpleNamespace
+
+
+def _trainer_args(**overrides):
+    base = dict(
+        fp8_base=False,
+        fp8_scaled=False,
+        convrot_int8=False,
+        convrot_int8_bwd="bf16",
+        nvfp4=False,
+        turbo_dit=None,
+        turbo_dit_cache=False,
+        turbo_lora=None,
+        turbo_lora_multiplier=1.0,
+        blocks_to_swap=0,
+        sample_prompts=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _handle_args(args):
+    from musubi_tuner.krea2_train_network import Krea2NetworkTrainer
+
+    Krea2NetworkTrainer().handle_model_specific_args(args)
+
+
+def test_parser_has_turbo_lora_flags():
+    import argparse
+
+    from musubi_tuner.krea2_train_network import krea2_setup_parser
+
+    parser = argparse.ArgumentParser()
+    krea2_setup_parser(parser)
+    args = parser.parse_args([])
+    assert args.turbo_lora is None
+    assert args.turbo_lora_multiplier == 1.0
+
+
+def test_trainer_rejects_turbo_dit_and_turbo_lora_together():
+    with pytest.raises(ValueError, match="turbo_dit.*turbo_lora|turbo_lora.*turbo_dit"):
+        _handle_args(_trainer_args(turbo_dit="turbo.safetensors", turbo_lora="turbo_lora.safetensors"))
+
+
+def test_trainer_rejects_turbo_dit_cache_without_turbo_dit():
+    with pytest.raises(ValueError, match="turbo_dit_cache"):
+        _handle_args(_trainer_args(turbo_dit_cache=True, turbo_lora="turbo_lora.safetensors"))
+
+
+def test_trainer_rejects_turbo_dit_cache_with_neither_turbo_source():
+    with pytest.raises(ValueError, match="turbo_dit_cache"):
+        _handle_args(_trainer_args(turbo_dit_cache=True))
+
+
+def test_trainer_accepts_turbo_lora_with_blocks_to_swap():
+    _handle_args(_trainer_args(turbo_lora="turbo_lora.safetensors", blocks_to_swap=4, sample_prompts="p.txt"))
+
+
+def test_trainer_accepts_turbo_lora_with_convrot_int8():
+    _handle_args(_trainer_args(turbo_lora="turbo_lora.safetensors", convrot_int8=True, sample_prompts="p.txt"))
+
+
+def test_trainer_still_rejects_turbo_dit_with_blocks_to_swap():
+    with pytest.raises(ValueError, match="blocks_to_swap"):
+        _handle_args(_trainer_args(turbo_dit="turbo.safetensors", blocks_to_swap=4))
+
+
+def test_trainer_accepts_turbo_lora_alone():
+    _handle_args(_trainer_args(turbo_lora="turbo_lora.safetensors", sample_prompts="p.txt"))
+
+
+def test_trainer_warns_turbo_lora_without_sample_prompts(caplog):
+    _handle_args(_trainer_args(turbo_lora="turbo_lora.safetensors", sample_prompts=None))
+    assert "turbo_dit" in caplog.text.lower() or "turbo_lora" in caplog.text.lower()
+
+
+import torch
+from safetensors.torch import save_file
+
+
+class _FakeAccelerator:
+    device = torch.device("cpu")
+
+    def unwrap_model(self, m):
+        return m
+
+
+def test_ensure_turbo_lora_network_builds_once_and_starts_disabled(tiny_k2_model, tmp_path):
+    from musubi_tuner.krea2_train_network import Krea2NetworkTrainer
+    from musubi_tuner.networks import lora_krea2
+
+    model = tiny_k2_model
+    trainee = lora_krea2.create_arch_network(1.0, 4, 4, None, None, model)
+    trainee.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+
+    lora_path = tmp_path / "turbo_lora.safetensors"
+    save_file(trainee.state_dict(), str(lora_path))  # any valid LoRA sd; values don't matter here
+
+    trainer = Krea2NetworkTrainer()
+    args = _trainer_args(turbo_lora=str(lora_path), turbo_lora_multiplier=1.0)
+    accelerator = _FakeAccelerator()
+
+    network1 = trainer._ensure_turbo_lora_network(args, accelerator, model)
+    assert all(not lora.enabled for lora in network1.unet_loras)
+    assert all(not p.requires_grad for p in network1.parameters())
+
+    network2 = trainer._ensure_turbo_lora_network(args, accelerator, model)
+    assert network1 is network2  # built once, cached
+
+
+def test_turbo_lora_composes_additively_with_trainee_lora(tiny_k2_model, tmp_path):
+    from musubi_tuner.krea2_train_network import Krea2NetworkTrainer
+    from musubi_tuner.networks import lora_krea2
+
+    torch.manual_seed(0)
+    model = tiny_k2_model
+
+    # Trainee LoRA: real network, apply_to() the model, then hand-set one module's weights
+    # to a known nonzero delta so its contribution is detectable.
+    trainee = lora_krea2.create_arch_network(1.0, 4, 4, None, None, model)
+    lora0 = trainee.unet_loras[0]
+    linear_module = lora0.org_module  # captured before apply_to() deletes this attribute
+    in_features = linear_module.in_features
+    trainee.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+    lora0.lora_down.weight.data.fill_(0.1)
+    lora0.lora_up.weight.data.fill_(0.1)
+
+    x = torch.randn(2, in_features)
+    trainee_out = linear_module(x)
+
+    # Turbo LoRA: only one key (matching lora0's name), different nonzero values, so it wraps
+    # the exact same underlying Linear as a second, independent hook.
+    down2 = torch.full((4, in_features), 0.2)
+    up2 = torch.full((linear_module.out_features, 4), 0.2)
+    turbo_sd = {
+        f"{lora0.lora_name}.lora_down.weight": down2,
+        f"{lora0.lora_name}.lora_up.weight": up2,
+        f"{lora0.lora_name}.alpha": torch.tensor(4.0),
+    }
+    lora_path = tmp_path / "turbo_lora.safetensors"
+    save_file(turbo_sd, str(lora_path))
+
+    trainer = Krea2NetworkTrainer()
+    args = _trainer_args(turbo_lora=str(lora_path), turbo_lora_multiplier=1.0)
+    accelerator = _FakeAccelerator()
+
+    turbo_network = trainer._ensure_turbo_lora_network(args, accelerator, model)
+    assert torch.equal(linear_module(x), trainee_out)  # still disabled: no change yet
+
+    turbo_network.set_enabled(True)
+    composed_out = linear_module(x)
+    expected_turbo_delta = (up2.float() @ down2.float() @ x.float().T).T  # alpha == rank -> scale 1.0
+    assert torch.allclose(composed_out, trainee_out + expected_turbo_delta, atol=1e-4)
+
+    turbo_network.set_enabled(False)
+    assert torch.equal(linear_module(x), trainee_out)  # back to trainee-only
+
+
+def test_on_before_after_sample_images_toggle_turbo_lora(tiny_k2_model, tmp_path):
+    from musubi_tuner.krea2_train_network import Krea2NetworkTrainer
+    from musubi_tuner.networks import lora_krea2
+
+    model = tiny_k2_model
+    trainee = lora_krea2.create_arch_network(1.0, 4, 4, None, None, model)
+    trainee.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+    lora_path = tmp_path / "turbo_lora.safetensors"
+    save_file(trainee.state_dict(), str(lora_path))
+
+    trainer = Krea2NetworkTrainer()
+    args = _trainer_args(turbo_lora=str(lora_path), turbo_dit=None, sample_prompts="p.txt")
+    accelerator = _FakeAccelerator()
+
+    trainer.on_before_sample_images(accelerator, args, 0, 0, None, model, trainee, [], torch.float32)
+    assert trainer._turbo_lora_network is not None
+    assert all(lora.enabled for lora in trainer._turbo_lora_network.unet_loras)
+
+    trainer.on_after_sample_images(accelerator, args, 0, 0, None, model, trainee, [], torch.float32)
+    assert all(not lora.enabled for lora in trainer._turbo_lora_network.unet_loras)
+
+
+def test_do_inference_turbo_mu_pinned_for_turbo_lora():
+    # turbo_mu selection is a single expression inside do_inference; exercise it directly
+    # via the same condition the implementation uses, since a full do_inference call needs a
+    # real model/VAE/text-encoder pipeline out of scope for this unit test.
+    args = _trainer_args(turbo_dit=None, turbo_lora="turbo_lora.safetensors")
+    turbo_mu = 1.15 if (args.turbo_dit or getattr(args, "turbo_lora", None)) else None
+    assert turbo_mu == 1.15


### PR DESCRIPTION
Instead of loading a separate turbo DiT model, we can load the Turbo LoRA and have it work in a chain with the training LoRA.

Turbo LoRA loads at the same time we would load the network weights so works with everything downstream, convrot int8, nvfp4, fp8, and torch compile.

Compatible Turbo LoRA https://huggingface.co/rockerBOO/krea-2-turbo-lora-r64-kohya/blob/main/krea2_turbo_lora_rank_64_bf16_kohya.safetensors