### PR TITLE
MiniMax-H3: let dataset/cache_io.py mint the cache keys from typed inputs

### DIFF
--- a/src/musubi_tuner/dataset/cache_io.py
+++ b/src/musubi_tuner/dataset/cache_io.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import os
 from typing import Optional, TYPE_CHECKING, Union
 
@@ -20,6 +21,8 @@ from musubi_tuner.dataset.architectures import (
     ARCHITECTURE_WAN_FULL,
     ARCHITECTURE_Z_IMAGE_FULL,
 )
+from musubi_tuner.minimax_h3 import packing as h3_packing
+from musubi_tuner.minimax_h3 import text_encoder as h3_text_encoder
 from musubi_tuner.utils import safetensors_utils
 from musubi_tuner.utils.model_utils import dtype_to_str, remove_dtype_suffix
 
@@ -549,148 +552,123 @@ def save_text_encoder_output_cache_hidream_o1(
     save_text_encoder_output_cache_common(item_info, sd, ARCHITECTURE_HIDREAM_O1_FULL, merge_existing=False)
 
 
-def _h3_dtype_matches(tensor: torch.Tensor, dtype_name: str) -> bool:
-    return dtype_to_str(tensor.dtype) == dtype_name
+def _h3_video_latent_key(role: str, latent: torch.Tensor, label: str) -> str:
+    """`latents[_<role>]_FxHxW_<dtype>` of a [24,F,H,W] MiniMax-H3 video latent (role "" = the target)."""
+    channels = h3_packing.VIDEO_CHANNELS
+    if latent.ndim != 4 or latent.shape[0] != channels:
+        raise ValueError(f"MiniMax-H3 {label} latent must be [{channels},F,H,W], got {tuple(latent.shape)}")
+    _, F, H, W = latent.shape
+    return f"latents_{role + '_' if role else ''}{F}x{H}x{W}_{dtype_to_str(latent.dtype)}"
+
+
+def _h3_audio_latent_key(role: str, latent: torch.Tensor, label: str) -> str:
+    """`latents_<role>_32x2xA_<dtype>` of a [32,2,A] MiniMax-H3 audio latent (role "audio" = the target)."""
+    channels, stereo = h3_packing.AUDIO_CHANNELS, h3_packing.STEREO_CHANNELS
+    if latent.ndim != 3 or tuple(latent.shape[:2]) != (channels, stereo):
+        raise ValueError(f"MiniMax-H3 {label} latent [{channels},{stereo},A] required, got {tuple(latent.shape)}")
+    return f"latents_{role}_{channels}x{stereo}x{latent.shape[2]}_{dtype_to_str(latent.dtype)}"
 
 
 def save_latent_cache_minimax_h3(
     item_info: ItemInfo,
-    tensors: dict[str, torch.Tensor],
+    *,
+    target_video: torch.Tensor,
+    target_audio: torch.Tensor,
+    audio_present: bool,
+    visual_conditions: Optional[Mapping[str, torch.Tensor]] = None,
+    audio_conditions: Optional[Mapping[str, torch.Tensor]] = None,
+    one_frame_target_index: Optional[int] = None,
+    one_frame_control_indices: Optional[Sequence[int]] = None,
     metadata: Optional[dict[str, str]] = None,
 ):
-    import re
+    """MiniMax-H3 architecture: a joint audio-video target plus optional condition latents.
 
-    target_pattern = re.compile(r"^latents_(\d+)x(\d+)x(\d+)_(.+)$")
-    audio_pattern = re.compile(r"^latents_audio_32x2x(\d+)_(.+)$")
-    visual_condition_pattern = re.compile(r"^latents_(?:first|last|cond_\d{3}|ref_\d{3}_(?:image|video))_(\d+)x(\d+)x(\d+)_(.+)$")
-    audio_condition_pattern = re.compile(r"^latents_ref_\d{3}_audio_32x2x(\d+)_(.+)$")
+    `target_video` is [24,F,H,W] and `target_audio` [32,2,A]; `audio_present` records whether the
+    audio is real (see AUDIO_PRESENT_KEY). The conditions are keyed by their role in the
+    packed layout (`first`/`last`, `cond_{i}`, `ref_{i}_{image|video|audio}`, see
+    minimax_h3/packing.py): video-shaped ones in `visual_conditions`, the reference audio rows
+    in `audio_conditions`. One-frame (image) caches also carry the target's pixel-frame index and,
+    for FL2VA controls, the condition indices (ONE_FRAME_*_KEY). Every tensor lands under
+    `latents[_<role>]_<shape>_<dtype>`, which the bucket collator folds back to `latents[_<role>]`.
+    """
+    sd = {
+        _h3_video_latent_key("", target_video, "target video"): target_video,
+        _h3_audio_latent_key("audio", target_audio, "target audio"): target_audio,
+    }
+    for role, latent in (visual_conditions or {}).items():
+        if h3_packing.parse_condition_role(role).is_audio:
+            raise ValueError(f"MiniMax-H3 condition role {role} carries audio rows, not a visual latent")
+        sd[_h3_video_latent_key(role, latent, f"visual condition {role}")] = latent
+    for role, latent in (audio_conditions or {}).items():
+        if not h3_packing.parse_condition_role(role).is_audio:
+            raise ValueError(f"MiniMax-H3 condition role {role} carries a visual latent, not audio rows")
+        sd[_h3_audio_latent_key(role, latent, f"audio condition {role}")] = latent
+    sd = {key: tensor.detach().cpu().contiguous() for key, tensor in sd.items()}
 
-    target_count = 0
-    audio_count = 0
-    normalized = {}
-    for key, tensor in tensors.items():
-        if not isinstance(tensor, torch.Tensor):
-            raise ValueError(f"MiniMax-H3 cache value must be a tensor: {key}")
-        if key == AUDIO_PRESENT_KEY:
-            normalized[key] = tensor.detach().cpu().contiguous()
-            continue
-        if key == ONE_FRAME_TARGET_INDEX_KEY:
-            if tensor.shape != torch.Size([]) or tensor.dtype != torch.int64 or tensor.item() < 0:
-                raise ValueError(f"MiniMax-H3 {ONE_FRAME_TARGET_INDEX_KEY} must be a nonnegative scalar int64 tensor")
-            normalized[key] = tensor.detach().cpu().contiguous()
-            continue
-        if key == ONE_FRAME_CONTROL_INDICES_KEY:
-            if tensor.ndim != 1 or tensor.shape[0] < 1 or tensor.dtype != torch.int64 or bool((tensor < 0).any()):
-                raise ValueError(f"MiniMax-H3 {ONE_FRAME_CONTROL_INDICES_KEY} must be a nonnegative int64 [K] tensor with K >= 1")
-            normalized[key] = tensor.detach().cpu().contiguous()
-            continue
-
-        match = target_pattern.fullmatch(key)
-        if match is not None:
-            frames, height, width = (int(match.group(index)) for index in range(1, 4))
-            if tensor.shape != (24, frames, height, width):
-                raise ValueError(f"MiniMax-H3 target video latent must be [24,F,H,W], got {tuple(tensor.shape)}")
-            if not _h3_dtype_matches(tensor, match.group(4)):
-                raise ValueError(f"MiniMax-H3 cache key dtype does not match tensor: {key}")
-            target_count += 1
-        else:
-            match = audio_pattern.fullmatch(key)
-            if match is not None:
-                audio_frames = int(match.group(1))
-                if tensor.shape != (32, 2, audio_frames):
-                    raise ValueError(f"MiniMax-H3 audio latent [32,2,A] required, got {tuple(tensor.shape)}")
-                if not _h3_dtype_matches(tensor, match.group(2)):
-                    raise ValueError(f"MiniMax-H3 cache key dtype does not match tensor: {key}")
-                audio_count += 1
-            else:
-                match = visual_condition_pattern.fullmatch(key)
-                if match is not None:
-                    frames, height, width = (int(match.group(index)) for index in range(1, 4))
-                    if tensor.shape != (24, frames, height, width):
-                        raise ValueError(f"MiniMax-H3 visual condition latent must be [24,F,H,W], got {tuple(tensor.shape)}")
-                    if not _h3_dtype_matches(tensor, match.group(4)):
-                        raise ValueError(f"MiniMax-H3 cache key dtype does not match tensor: {key}")
-                else:
-                    match = audio_condition_pattern.fullmatch(key)
-                    if match is None:
-                        raise ValueError(f"Unsupported MiniMax-H3 latent cache key: {key}")
-                    audio_frames = int(match.group(1))
-                    if tensor.shape != (32, 2, audio_frames):
-                        raise ValueError(f"MiniMax-H3 audio latent [32,2,A] required, got {tuple(tensor.shape)}")
-                    if not _h3_dtype_matches(tensor, match.group(2)):
-                        raise ValueError(f"MiniMax-H3 cache key dtype does not match tensor: {key}")
-        normalized[key] = tensor.detach().cpu().contiguous()
-
-    if target_count != 1:
-        raise ValueError(f"MiniMax-H3 cache requires exactly one target video latent, found {target_count}")
-    if audio_count != 1:
-        raise ValueError(f"MiniMax-H3 cache requires exactly one target audio latent, found {audio_count}")
-    validate_audio_present_entry(normalized)
-    save_latent_cache_common(item_info, normalized, ARCHITECTURE_MINIMAX_H3_FULL, metadata)
+    append_audio_present_entry(sd, audio_present)
+    if one_frame_control_indices is not None and one_frame_target_index is None:
+        raise ValueError("MiniMax-H3 one-frame control indices require the one-frame target index")
+    if one_frame_target_index is not None:
+        append_one_frame_target_index_entry(sd, one_frame_target_index)
+    if one_frame_control_indices is not None:
+        append_one_frame_control_indices_entry(sd, list(one_frame_control_indices))
+    save_latent_cache_common(item_info, sd, ARCHITECTURE_MINIMAX_H3_FULL, metadata)
 
 
-# (teacher kind, key prefix) of the teacher text rows a MiniMax-H3 text cache may carry next to
-# the student rows; the writer accepts at most one kind per cache
-MINIMAX_H3_TEACHER_TEXT_PREFIXES = (
-    ("first,last", "varlen_mmh3_teacher"),
-    ("ref", "varlen_mmh3_teacher_ref"),
-    ("subject_ref", "varlen_mmh3_teacher_subject_ref"),
-)
+# key stem of the teacher text rows a MiniMax-H3 text cache may carry next to the student rows,
+# per teacher kind: each kind uses distinct keys so the trainer hard-fails on a cache/flag mode
+# mismatch instead of silently misreading the rows
+MINIMAX_H3_TEACHER_TEXT_PREFIXES = {
+    "first,last": "varlen_mmh3_teacher",
+    "ref": "varlen_mmh3_teacher_ref",
+    "subject_ref": "varlen_mmh3_teacher_subject_ref",
+}
+
+
+def _h3_text_rows(prefix: str, hidden_states: torch.Tensor, token_tags: torch.Tensor, label: str) -> dict[str, torch.Tensor]:
+    """`<prefix>_hidden_states_<dtype>` ([L,5120]) and `<prefix>_token_tags_int64` ([L], 0/1) of one presentation."""
+    width, max_rows = h3_text_encoder.TEXT_WIDTH, h3_text_encoder.MAX_TEXT_ROWS
+    if hidden_states.ndim != 2 or hidden_states.shape[1] != width:
+        raise ValueError(f"MiniMax-H3 {label} hidden states must be [L,{width}], got {tuple(hidden_states.shape)}")
+    if hidden_states.shape[0] > max_rows:
+        raise ValueError(f"MiniMax-H3 {label} exceeds {max_rows} rows: {hidden_states.shape[0]}")
+    if token_tags.dtype != torch.int64 or token_tags.shape != (hidden_states.shape[0],):
+        raise ValueError(f"MiniMax-H3 {label} token tags must be int64 [L]")
+    if not torch.all((token_tags == 0) | (token_tags == 1)):
+        raise ValueError(f"MiniMax-H3 {label} token tags may contain only 0 and 1")
+    return {
+        f"{prefix}_hidden_states_{dtype_to_str(hidden_states.dtype)}": hidden_states.detach().cpu().contiguous(),
+        f"{prefix}_token_tags_int64": token_tags.detach().cpu().contiguous(),
+    }
 
 
 def save_text_encoder_output_cache_minimax_h3(
     item_info: ItemInfo,
-    tensors: dict[str, torch.Tensor],
+    *,
+    hidden_states: torch.Tensor,
+    token_tags: torch.Tensor,
+    teacher_kind: Optional[str] = None,
+    teacher_hidden_states: Optional[torch.Tensor] = None,
+    teacher_token_tags: Optional[torch.Tensor] = None,
     metadata: Optional[dict[str, str]] = None,
 ):
-    # the teacher prefixes must be split off before matching the student prefix, because
-    # "varlen_mmh3_teacher[_<kind>]_hidden_states_*" does not share the student prefix; each
-    # teacher kind (FL2VA "first,last", Ref2VA "ref", subject-reference "subject_ref") uses
-    # distinct keys so the trainer can hard-fail on a cache/flag mode mismatch instead of
-    # silently misreading the rows. A cache carries the student rows plus at most one kind.
-    student_hidden_keys = [key for key in tensors if key.startswith("varlen_mmh3_hidden_states_")]
-    if len(student_hidden_keys) != 1:
-        raise ValueError(f"MiniMax-H3 text cache requires exactly one hidden-state tensor, found {len(student_hidden_keys)}")
-    tags_key = "varlen_mmh3_token_tags_int64"
+    """MiniMax-H3 architecture: the student presentation's Qwen3-VL rows plus, for teacher matching,
+    the rows of one teacher presentation (`teacher_kind` in MINIMAX_H3_TEACHER_TEXT_PREFIXES).
 
-    pairs = [(student_hidden_keys[0], "varlen_mmh3_hidden_states_", tags_key)]
-    expected_keys = {student_hidden_keys[0], tags_key}
-    teacher_kinds_present = []
-    for kind, prefix in MINIMAX_H3_TEACHER_TEXT_PREFIXES:
-        hidden_prefix = f"{prefix}_hidden_states_"
-        kind_tags_key = f"{prefix}_token_tags_int64"
-        hidden_keys = [key for key in tensors if key.startswith(hidden_prefix)]
-        if not hidden_keys and kind_tags_key not in tensors:
-            continue
-        if len(hidden_keys) != 1 or kind_tags_key not in tensors:
-            raise ValueError("MiniMax-H3 teacher text rows require exactly one hidden-state tensor and its token tags")
-        teacher_kinds_present.append(kind)
-        pairs.append((hidden_keys[0], hidden_prefix, kind_tags_key))
-        expected_keys |= {hidden_keys[0], kind_tags_key}
-    if len(teacher_kinds_present) > 1:
-        raise ValueError(f"MiniMax-H3 text cache cannot mix {' and '.join(teacher_kinds_present)} teacher rows")
-    if set(tensors) != expected_keys:
-        raise ValueError(f"MiniMax-H3 text cache requires exactly the keys {sorted(expected_keys)}")
-
-    normalized = {}
-    for hidden_key, hidden_prefix, pair_tags_key in pairs:
-        hidden_states = tensors[hidden_key]
-        token_tags = tensors[pair_tags_key]
-        if hidden_states.ndim != 2 or hidden_states.shape[1] != 5120:
-            raise ValueError(f"MiniMax-H3 hidden states must be [L,5120], got {tuple(hidden_states.shape)}")
-        if not _h3_dtype_matches(hidden_states, hidden_key.removeprefix(hidden_prefix)):
-            raise ValueError(f"MiniMax-H3 hidden-state key dtype does not match tensor: {hidden_key}")
-        if hidden_states.shape[0] > 32768:
-            raise ValueError(f"MiniMax-H3 text cache exceeds 32768 rows: {hidden_states.shape[0]}")
-        if token_tags.dtype != torch.int64 or token_tags.shape != (hidden_states.shape[0],):
-            raise ValueError("MiniMax-H3 token tags must be int64 [L]")
-        if not torch.all((token_tags == 0) | (token_tags == 1)):
-            raise ValueError("MiniMax-H3 token tags may contain only 0 and 1")
-        normalized[hidden_key] = hidden_states.detach().cpu().contiguous()
-        normalized[pair_tags_key] = token_tags.detach().cpu().contiguous()
+    Stored varlen (the collator returns lists): `hidden_states` [L,5120], `token_tags` int64 [L]
+    with 1 for text and 0 for vision rows."""
+    sd = _h3_text_rows("varlen_mmh3", hidden_states, token_tags, "text cache")
+    teacher_rows = (teacher_kind, teacher_hidden_states, teacher_token_tags)
+    if any(value is not None for value in teacher_rows):
+        if any(value is None for value in teacher_rows):
+            raise ValueError("MiniMax-H3 teacher text rows require the teacher kind, hidden states and token tags together")
+        prefix = MINIMAX_H3_TEACHER_TEXT_PREFIXES.get(teacher_kind)
+        if prefix is None:
+            raise ValueError(f"Unsupported MiniMax-H3 teacher kind: {teacher_kind}")
+        sd.update(_h3_text_rows(prefix, teacher_hidden_states, teacher_token_tags, "teacher text rows"))
     save_text_encoder_output_cache_common(
         item_info,
-        normalized,
+        sd,
         ARCHITECTURE_MINIMAX_H3_FULL,
         merge_existing=False,
         additional_metadata=metadata,

--- a/src/musubi_tuner/minimax_h3/packing.py
+++ b/src/musubi_tuner/minimax_h3/packing.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import math
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
@@ -37,6 +38,17 @@ FRAME_RESCALE = 5.0 / 3.0
 
 H3ReferenceKind = Literal["image", "audio", "video"]
 H3SegmentKind = Literal["text", "visual_condition", "audio_condition", "target_audio", "target_video"]
+H3ConditionFamily = Literal["fl", "one_frame", "reference"]
+
+# Condition role vocabulary. A role names one condition block of a layout and, prefixed with
+# `latents_`, the cache/batch entry that carries its latent (see dataset/cache_io.py):
+# - the released video FL2VA anchors `first` / `last` (the name selects the anchor time)
+# - the ordered one-frame FL2VA slots `cond_{i:03d}` (times come from the control indices)
+# - the numbered Ref2VA reference rows `ref_{i:03d}_{image|video|audio}`
+FL_CONDITION_ROLES: tuple[str, ...] = ("first", "last")
+REFERENCE_KINDS: tuple[H3ReferenceKind, ...] = ("image", "video", "audio")
+_ONE_FRAME_CONDITION_ROLE = re.compile(r"^cond_(\d{3})$")
+_REFERENCE_CONDITION_ROLE = re.compile(r"^ref_(\d{3})_(image|video|audio)$")
 
 
 @dataclass(frozen=True)
@@ -101,6 +113,49 @@ def one_frame_condition_role(index: int) -> str:
 
 def one_frame_condition_roles(count: int) -> tuple[str, ...]:
     return tuple(one_frame_condition_role(index) for index in range(count))
+
+
+def reference_condition_role(index: int, kind: H3ReferenceKind) -> str:
+    """Role of the index-th Ref2VA reference's ``kind`` rows (``ref_000_image``, ``ref_001_audio``, ...).
+
+    A video reference with audio owns two roles (``_video`` and ``_audio``) under one index.
+    """
+    if index < 0:
+        raise ValueError(f"MiniMax-H3 reference index must be nonnegative, got {index}")
+    if kind not in REFERENCE_KINDS:
+        raise ValueError(f"Unsupported MiniMax-H3 reference kind: {kind}")
+    return f"ref_{index:03d}_{kind}"
+
+
+@dataclass(frozen=True)
+class H3ConditionRole:
+    """A parsed condition role name (see the vocabulary above).
+
+    ``index`` is the one-frame slot or reference number (None for the ``first``/``last``
+    anchors); ``reference_kind`` is the reference row type (None outside the reference family).
+    """
+
+    name: str
+    family: H3ConditionFamily
+    index: int | None = None
+    reference_kind: H3ReferenceKind | None = None
+
+    @property
+    def is_audio(self) -> bool:
+        return self.reference_kind == "audio"
+
+
+def parse_condition_role(role: str) -> H3ConditionRole:
+    """Parses a condition role name; raises ValueError for anything outside the vocabulary."""
+    if role in FL_CONDITION_ROLES:
+        return H3ConditionRole(role, "fl")
+    match = _ONE_FRAME_CONDITION_ROLE.fullmatch(role)
+    if match is not None:
+        return H3ConditionRole(role, "one_frame", index=int(match.group(1)))
+    match = _REFERENCE_CONDITION_ROLE.fullmatch(role)
+    if match is not None:
+        return H3ConditionRole(role, "reference", index=int(match.group(1)), reference_kind=match.group(2))
+    raise ValueError(f"Unsupported MiniMax-H3 condition role: {role}")
 
 
 @dataclass(frozen=True)
@@ -368,15 +423,14 @@ def build_h3_layout(
             append(role, "visual_condition", condition.row_count)
     elif task == "ref2va":
         for index, reference in enumerate(references):
-            prefix = f"ref_{index:03d}"
             if reference.kind == "image":
-                append(f"{prefix}_image", "visual_condition", reference.video.row_count)
+                append(reference_condition_role(index, "image"), "visual_condition", reference.video.row_count)
             elif reference.kind == "audio":
-                append(f"{prefix}_audio", "audio_condition", reference.audio_frames * STEREO_CHANNELS)
+                append(reference_condition_role(index, "audio"), "audio_condition", reference.audio_frames * STEREO_CHANNELS)
             else:
                 if reference.audio_frames:
-                    append(f"{prefix}_audio", "audio_condition", reference.audio_frames * STEREO_CHANNELS)
-                append(f"{prefix}_video", "visual_condition", reference.video.row_count)
+                    append(reference_condition_role(index, "audio"), "audio_condition", reference.audio_frames * STEREO_CHANNELS)
+                append(reference_condition_role(index, "video"), "visual_condition", reference.video.row_count)
     append("target_audio", "target_audio", target_audio_frames * STEREO_CHANNELS)
     append("target_video", "target_video", target_video.row_count)
 
@@ -399,9 +453,9 @@ def _fl_condition_roles(condition_roles: Sequence[str] | None, condition_count: 
     if condition_roles is None:
         if condition_count != 2:
             raise ValueError("MiniMax-H3 FL2VA layout with a single condition requires explicit condition roles")
-        return ("first", "last")
+        return FL_CONDITION_ROLES
     roles = tuple(condition_roles)
-    if roles not in {("first",), ("last",), ("first", "last")}:
+    if roles not in {("first",), ("last",), FL_CONDITION_ROLES}:
         raise ValueError(f"MiniMax-H3 FL2VA condition roles must be first, last, or first+last in order, got {roles}")
     if len(roles) != condition_count:
         raise ValueError(f"MiniMax-H3 FL2VA layout has {condition_count} conditions for {len(roles)} roles")
@@ -469,28 +523,27 @@ def build_position_grid(layout: H3PackedLayout, *, device: torch.device | str | 
             positions[segment.row_slice, 1:] = target_frame
     elif layout.task == "ref2va":
         for index, reference in enumerate(layout.references):
-            prefix = f"ref_{index:03d}"
             if reference.kind == "image":
-                segment = layout.segment(f"{prefix}_image")
+                segment = layout.segment(reference_condition_role(index, "image"))
                 frame, _ = _frame_grid(reference.video)
                 positions[segment.row_slice, 0] = cursor
                 positions[segment.row_slice, 1:] = frame
                 cursor += 1.0
             elif reference.kind == "audio":
-                segment = layout.segment(f"{prefix}_audio")
+                segment = layout.segment(reference_condition_role(index, "audio"))
                 positions[segment.row_slice] = _audio_grid(cursor, reference.audio_frames, *target_width_endpoints)
                 cursor += float(reference.audio_frames)
             else:
                 frame, width = _frame_grid(reference.video)
                 if reference.audio_frames:
-                    audio = layout.segment(f"{prefix}_audio")
+                    audio = layout.segment(reference_condition_role(index, "audio"))
                     positions[audio.row_slice] = _audio_grid(
                         cursor,
                         reference.audio_frames,
                         float(width[0]),
                         float(width[-1]),
                     )
-                video = layout.segment(f"{prefix}_video")
+                video = layout.segment(reference_condition_role(index, "video"))
                 positions[video.row_slice] = _video_grid(reference.video, cursor)
                 cursor += max(float(reference.audio_frames), sum(_video_t_spans(reference.video.frames)))
 

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -97,7 +97,10 @@ def _fl_visual_keys(visuals: Mapping[object, H3TextVisual]) -> list[str]:
             raise ValueError(f"MiniMax-H3 one-frame FL2VA visuals must be the contiguous {expected}, got {cond_keys}")
         present_keys = cond_keys
     if not present_keys:
-        raise ValueError("MiniMax-H3 FL2VA presentation requires at least one of the first and last visuals")
+        raise ValueError(
+            "MiniMax-H3 FL2VA presentation requires the first/last visuals (video targets)"
+            " or the cond_{i} control visuals (one-frame targets)"
+        )
     return present_keys
 
 

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -25,7 +25,6 @@ import hashlib
 import json
 import logging
 from pathlib import Path
-import re
 from typing import Any
 
 import numpy as np
@@ -34,6 +33,7 @@ import torch.nn as nn
 
 from musubi_tuner.minimax_h3.checkpoint import resolve_safetensors_files
 from musubi_tuner.minimax_h3.media import TEXT_VISUAL_FPS, H3Record, H3Task
+from musubi_tuner.minimax_h3.packing import FL_CONDITION_ROLES, one_frame_condition_roles, parse_condition_role
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,28 @@ def _require_visual(visuals: Mapping[object, H3TextVisual], key: object, label: 
         raise ValueError(f"MiniMax-H3 presentation is missing {label} visual data") from error
 
 
-_ONE_FRAME_CONDITION_KEY = re.compile(r"^cond_\d{3}$")
+def _fl_visual_keys(visuals: Mapping[object, H3TextVisual]) -> list[str]:
+    """The FL2VA visual keys present, in <Picture i> order: the released first/last anchors or
+    the contiguous one-frame cond_{i} slots (the same role vocabulary as the latent cache)."""
+    present_keys = [key for key in FL_CONDITION_ROLES if key in visuals]
+    cond_keys = sorted(key for key in visuals if isinstance(key, str) and _is_one_frame_condition_role(key))
+    if present_keys and cond_keys:
+        raise ValueError("MiniMax-H3 FL2VA presentation cannot mix first/last visuals with one-frame cond_ visuals")
+    if cond_keys:
+        expected = list(one_frame_condition_roles(len(cond_keys)))
+        if cond_keys != expected:
+            raise ValueError(f"MiniMax-H3 one-frame FL2VA visuals must be the contiguous {expected}, got {cond_keys}")
+        present_keys = cond_keys
+    if not present_keys:
+        raise ValueError("MiniMax-H3 FL2VA presentation requires at least one of the first and last visuals")
+    return present_keys
+
+
+def _is_one_frame_condition_role(key: str) -> bool:
+    try:
+        return parse_condition_role(key).family == "one_frame"
+    except ValueError:
+        return False
 
 
 def build_presentation(
@@ -109,18 +130,7 @@ def build_presentation(
         # in packed (first, last) order: a lone last frame is still <Picture 1>, and the
         # first/last distinction is carried only by the rotary anchor times. One-frame
         # layouts use the ordered cond_{i} slots instead, numbered in slot order.
-        present_keys = [key for key in ("first", "last") if key in visuals]
-        cond_keys = sorted(key for key in visuals if isinstance(key, str) and _ONE_FRAME_CONDITION_KEY.fullmatch(key))
-        if present_keys and cond_keys:
-            raise ValueError("MiniMax-H3 FL2VA presentation cannot mix first/last visuals with one-frame cond_ visuals")
-        if cond_keys:
-            expected = [f"cond_{index:03d}" for index in range(len(cond_keys))]
-            if cond_keys != expected:
-                raise ValueError(f"MiniMax-H3 one-frame FL2VA visuals must be the contiguous {expected}, got {cond_keys}")
-            present_keys = cond_keys
-        if not present_keys:
-            raise ValueError("MiniMax-H3 FL2VA presentation requires at least one of the first and last visuals")
-        for index, key in enumerate(present_keys, start=1):
+        for index, key in enumerate(_fl_visual_keys(visuals), start=1):
             visual = visuals[key]
             if visual.frames.shape[0] != 1:
                 raise ValueError(f"MiniMax-H3 FL2VA {key} visual must contain exactly one frame")

--- a/src/musubi_tuner/minimax_h3_cache_latents.py
+++ b/src/musubi_tuner/minimax_h3_cache_latents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from collections import Counter
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from fractions import Fraction
 import json
 import logging
@@ -15,12 +15,7 @@ import torch
 import musubi_tuner.cache_latents as cache_latents
 from musubi_tuner.dataset import config_utils
 from musubi_tuner.dataset.architectures import ARCHITECTURE_MINIMAX_H3
-from musubi_tuner.dataset.cache_io import (
-    append_audio_present_entry,
-    append_one_frame_control_indices_entry,
-    append_one_frame_target_index_entry,
-    save_latent_cache_minimax_h3,
-)
+from musubi_tuner.dataset.cache_io import save_latent_cache_minimax_h3
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
 from musubi_tuner.dataset.image_video_dataset import ItemInfo
 from musubi_tuner.minimax_h3.audio_vae import encode_audio_mode, load_audio_vae
@@ -35,7 +30,13 @@ from musubi_tuner.minimax_h3.cache_plan import (
     plan_h3_datasets,
 )
 from musubi_tuner.minimax_h3.checkpoint import fingerprint_checkpoint
-from musubi_tuner.minimax_h3.packing import ONE_FRAME_AUDIO_LATENT_FRAMES, ONE_FRAME_VIDEO_LATENT_FRAMES, one_frame_condition_role
+from musubi_tuner.minimax_h3.packing import (
+    FL_CONDITION_ROLES,
+    ONE_FRAME_AUDIO_LATENT_FRAMES,
+    ONE_FRAME_VIDEO_LATENT_FRAMES,
+    one_frame_condition_role,
+    reference_condition_role,
+)
 from musubi_tuner.minimax_h3.media import (
     H3_AUDIO_SPEC,
     ONE_FRAME_REFERENCE_FRAME_CAP,
@@ -58,7 +59,6 @@ from musubi_tuner.minimax_h3.video_vae import (
     encode_video_target,
     load_video_vae,
 )
-from musubi_tuner.utils.model_utils import dtype_to_str
 
 
 logger = logging.getLogger(__name__)
@@ -67,8 +67,34 @@ logging.basicConfig(level=logging.INFO)
 
 @dataclass(frozen=True)
 class H3LatentCachePayload:
-    tensors: dict[str, torch.Tensor]
+    """Everything one MiniMax-H3 latent cache stores, before the writer names the entries.
+
+    The conditions are keyed by their layout role (`first`/`last`, `cond_{i}`,
+    `ref_{i}_{image|video|audio}`); `save_latent_cache_minimax_h3` turns each field into the
+    `latents[_<role>]_<shape>_<dtype>` entry the trainer reads back as `latents[_<role>]`.
+    """
+
+    target_video: torch.Tensor  # [24,F,H,W]
+    target_audio: torch.Tensor  # [32,2,A]
+    audio_present: bool
     metadata: dict[str, str]
+    visual_conditions: dict[str, torch.Tensor] = field(default_factory=dict)  # role -> [24,F,H,W]
+    audio_conditions: dict[str, torch.Tensor] = field(default_factory=dict)  # role -> [32,2,A]
+    one_frame_target_index: int | None = None
+    one_frame_control_indices: tuple[int, ...] | None = None
+
+    def save(self, item: ItemInfo) -> None:
+        save_latent_cache_minimax_h3(
+            item,
+            target_video=self.target_video,
+            target_audio=self.target_audio,
+            audio_present=self.audio_present,
+            visual_conditions=self.visual_conditions,
+            audio_conditions=self.audio_conditions,
+            one_frame_target_index=self.one_frame_target_index,
+            one_frame_control_indices=self.one_frame_control_indices,
+            metadata=self.metadata,
+        )
 
 
 def _validate_task_record(record: H3Record, task: H3Task) -> None:
@@ -110,21 +136,6 @@ def _encode_audio(audio_vae, waveform: torch.Tensor) -> torch.Tensor:
         raise ValueError(f"MiniMax-H3 decoded audio must be stereo [2,L], got {tuple(waveform.shape)}")
     device, dtype = module_device_dtype(audio_vae, torch.float32)
     return encode_audio_mode(audio_vae, waveform.unsqueeze(0).to(device=device, dtype=dtype))
-
-
-def _visual_key(role: str, latent: torch.Tensor) -> str:
-    if latent.ndim != 4 or latent.shape[0] != 24:
-        raise ValueError(f"MiniMax-H3 visual latent must be [24,F,H,W], got {tuple(latent.shape)}")
-    _, frames, height, width = latent.shape
-    dtype_name = dtype_to_str(latent.dtype)
-    return f"latents_{role + '_' if role else ''}{frames}x{height}x{width}_{dtype_name}"
-
-
-def _audio_key(role: str, latent: torch.Tensor) -> str:
-    if latent.ndim != 3 or latent.shape[:2] != (32, 2):
-        raise ValueError(f"MiniMax-H3 audio latent must be [32,2,A], got {tuple(latent.shape)}")
-    dtype_name = dtype_to_str(latent.dtype)
-    return f"latents_{role + '_' if role else 'audio_'}32x2x{latent.shape[2]}_{dtype_name}"
 
 
 def _media_fingerprint_metadata(fingerprints: Mapping[Path, str]) -> str:
@@ -226,18 +237,15 @@ def build_latent_tensors(
     if target_audio.shape[2] != expected_audio_frames:
         raise ValueError(f"MiniMax-H3 audio VAE returned {target_audio.shape[2]} frames, expected {expected_audio_frames}")
 
-    tensors = {
-        _visual_key("", target_video): target_video,
-        _audio_key("", target_audio): target_audio,
-    }
-    append_audio_present_entry(tensors, audio_present)
+    visual_conditions: dict[str, torch.Tensor] = {}
+    audio_conditions: dict[str, torch.Tensor] = {}
     if task == "fl2va":
-        for role, frame in (("first", target_frames[:1]), ("last", target_frames[-1:])):
-            condition = _encode_condition_video(video_vae, prepare_pixels(frame))[0]
-            tensors[_visual_key(role, condition)] = condition
+        for role, frame in zip(FL_CONDITION_ROLES, (target_frames[:1], target_frames[-1:])):
+            visual_conditions[role] = _encode_condition_video(video_vae, prepare_pixels(frame))[0]
     elif task == "ref2va":
         _encode_reference_conditions(
-            tensors,
+            visual_conditions,
+            audio_conditions,
             record=record,
             reference_frame_cap=frame_count,
             target_size=(width, height),
@@ -255,11 +263,19 @@ def build_latent_tensors(
         audio_vae_fingerprint=audio_vae_fingerprint,
         media_fingerprints=media_fingerprints,
     )
-    return H3LatentCachePayload(tensors=tensors, metadata=metadata)
+    return H3LatentCachePayload(
+        target_video=target_video,
+        target_audio=target_audio,
+        audio_present=audio_present,
+        metadata=metadata,
+        visual_conditions=visual_conditions,
+        audio_conditions=audio_conditions,
+    )
 
 
 def _encode_reference_conditions(
-    tensors: dict[str, torch.Tensor],
+    visual_conditions: dict[str, torch.Tensor],
+    audio_conditions: dict[str, torch.Tensor],
     *,
     record: H3Record,
     reference_frame_cap: int,
@@ -277,7 +293,6 @@ def _encode_reference_conditions(
     one-frame targets do not have (callers reject them first).
     """
     for index, reference in enumerate(record.references):
-        role_prefix = f"ref_{index:03d}"
         visual_frames = None
         if reference.type in {"image", "video"}:
             visual_frames = media_decoder.decode_reference_visual(
@@ -287,8 +302,8 @@ def _encode_reference_conditions(
             )
             if reference.type == "video":
                 video_latent_frames(visual_frames.shape[0])
-            condition = _encode_condition_video(video_vae, prepare_pixels(visual_frames))[0]
-            tensors[_visual_key(f"{role_prefix}_{reference.type}", condition)] = condition
+            role = reference_condition_role(index, reference.type)
+            visual_conditions[role] = _encode_condition_video(video_vae, prepare_pixels(visual_frames))[0]
 
         if reference.audio is not None:
             if reference.type == "video":
@@ -306,8 +321,7 @@ def _encode_reference_conditions(
                 sample_count=reference_samples,
                 require_exact=require_exact,
             )
-            audio_latent = _encode_audio(audio_vae, waveform)[0]
-            tensors[_audio_key(f"{role_prefix}_audio", audio_latent)] = audio_latent
+            audio_conditions[reference_condition_role(index, "audio")] = _encode_audio(audio_vae, waveform)[0]
 
 
 def encode_one_frame_silence_latent(audio_vae) -> torch.Tensor:
@@ -383,6 +397,8 @@ def build_one_frame_latent_tensors(
             raise ValueError(
                 f"MiniMax-H3 one-frame control count {len(control_frames)} does not match {len(control_indices)} control indices"
             )
+        if any(int(index) < 0 for index in control_indices):
+            raise ValueError(f"MiniMax-H3 one-frame control indices must be nonnegative, got {list(control_indices)}")
 
     target_pixels = prepare_pixels(image_frames)
     canonical_item_key = f"{item_key}#1f"
@@ -390,13 +406,10 @@ def build_one_frame_latent_tensors(
     if target_video.shape[1] != ONE_FRAME_VIDEO_LATENT_FRAMES:
         raise ValueError(f"MiniMax-H3 video VAE returned {target_video.shape[1]} frames, expected {ONE_FRAME_VIDEO_LATENT_FRAMES}")
 
-    tensors = {
-        _visual_key("", target_video): target_video,
-        _audio_key("", silence_audio_latent): silence_audio_latent,
-    }
+    visual_conditions: dict[str, torch.Tensor] = {}
+    audio_conditions: dict[str, torch.Tensor] = {}
     if control_frames is not None:
         for index, control in enumerate(control_frames):
-            role = one_frame_condition_role(index)
             control = torch.as_tensor(control)
             if control.ndim != 3:
                 raise ValueError(f"MiniMax-H3 one-frame control must be [H,W,C], got {tuple(control.shape)}")
@@ -405,11 +418,12 @@ def build_one_frame_latent_tensors(
                     f"MiniMax-H3 one-frame control size {control.shape[1]}x{control.shape[0]} does not match"
                     f" the target {width}x{height} (controls are resized to the bucket resolution)"
                 )
-            condition = _encode_condition_video(video_vae, prepare_pixels(control.unsqueeze(0)))[0]
-            tensors[_visual_key(role, condition)] = condition
+            role = one_frame_condition_role(index)
+            visual_conditions[role] = _encode_condition_video(video_vae, prepare_pixels(control.unsqueeze(0)))[0]
     if references:
         _encode_reference_conditions(
-            tensors,
+            visual_conditions,
+            audio_conditions,
             record=record,
             reference_frame_cap=ONE_FRAME_REFERENCE_FRAME_CAP,
             target_size=(int(width), int(height)),
@@ -418,10 +432,6 @@ def build_one_frame_latent_tensors(
             audio_vae=audio_vae,
             media_decoder=media_decoder,
         )
-    append_audio_present_entry(tensors, False)
-    append_one_frame_target_index_entry(tensors, target_index)
-    if control_indices is not None:
-        append_one_frame_control_indices_entry(tensors, list(control_indices))
 
     if references:
         task: H3Task = "ref2va"
@@ -439,7 +449,16 @@ def build_one_frame_latent_tensors(
         one_frame_target_index=target_index,
         one_frame_control_indices=control_indices,
     )
-    return H3LatentCachePayload(tensors=tensors, metadata=metadata)
+    return H3LatentCachePayload(
+        target_video=target_video,
+        target_audio=silence_audio_latent,
+        audio_present=False,
+        metadata=metadata,
+        visual_conditions=visual_conditions,
+        audio_conditions=audio_conditions,
+        one_frame_target_index=target_index,
+        one_frame_control_indices=None if control_indices is None else tuple(int(index) for index in control_indices),
+    )
 
 
 def record_media_paths(record: H3Record) -> set[Path]:
@@ -660,7 +679,7 @@ def main() -> None:
             media_decoder=decoder,
         )
         logger.info("Saving MiniMax-H3 one-frame latent cache for %s to %s", item.item_key, item.latent_cache_path)
-        save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
+        payload.save(item)
 
     def encode_video(item: ItemInfo, plan: H3DatasetPlan) -> None:
         inputs = video_inputs(item, plan)
@@ -682,7 +701,7 @@ def main() -> None:
             allow_experimental_duration=args.allow_experimental_duration,
         )
         logger.info("Saving MiniMax-H3 latent cache for %s to %s", item.item_key, item.latent_cache_path)
-        save_latent_cache_minimax_h3(item, payload.tensors, payload.metadata)
+        payload.save(item)
 
     def encode(batch: list[ItemInfo]) -> None:
         for item in batch:

--- a/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
+++ b/src/musubi_tuner/minimax_h3_cache_text_encoder_outputs.py
@@ -56,7 +56,6 @@ from musubi_tuner.minimax_h3.cache_plan import (
     plan_h3_datasets,
 )
 from musubi_tuner.minimax_h3.checkpoint import fingerprint_checkpoint
-from musubi_tuner.utils.model_utils import dtype_to_str
 
 
 logger = logging.getLogger(__name__)
@@ -524,22 +523,12 @@ def main() -> None:
 
             hidden_states, token_tags = encode_h3_presentation(processor, text_encoder, presentation)
             hidden_states = hidden_states.to(_cache_dtype(args.text_cache_dtype))
-            tensors = {
-                f"varlen_mmh3_hidden_states_{dtype_to_str(hidden_states.dtype)}": hidden_states,
-                "varlen_mmh3_token_tags_int64": token_tags,
-            }
             payload_mib = hidden_states.numel() * hidden_states.element_size() / (1024**2)
             teacher_note = ""
+            teacher_hidden = teacher_tags = None
             if teacher_presentation is not None:
                 teacher_hidden, teacher_tags = encode_h3_presentation(processor, text_encoder, teacher_presentation)
                 teacher_hidden = teacher_hidden.to(_cache_dtype(args.text_cache_dtype))
-                # distinct keys per teacher kind, so the trainer hard-fails on a mode mismatch
-                key_prefix = {
-                    TEACHER_CONDITIONS_REF: "varlen_mmh3_teacher_ref",
-                    TEACHER_CONDITIONS_SUBJECT_REF: "varlen_mmh3_teacher_subject_ref",
-                }.get(teacher_conditions, "varlen_mmh3_teacher")
-                tensors[f"{key_prefix}_hidden_states_{dtype_to_str(teacher_hidden.dtype)}"] = teacher_hidden
-                tensors[f"{key_prefix}_token_tags_int64"] = teacher_tags
                 payload_mib += teacher_hidden.numel() * teacher_hidden.element_size() / (1024**2)
                 teacher_note = f", teacher_rows={teacher_hidden.shape[0]}"
             logger.info(
@@ -550,7 +539,15 @@ def main() -> None:
                 teacher_note,
                 payload_mib,
             )
-            save_text_encoder_output_cache_minimax_h3(item, tensors, metadata)
+            save_text_encoder_output_cache_minimax_h3(
+                item,
+                hidden_states=hidden_states,
+                token_tags=token_tags,
+                teacher_kind=teacher_conditions if teacher_presentation is not None else None,
+                teacher_hidden_states=teacher_hidden,
+                teacher_token_tags=teacher_tags,
+                metadata=metadata,
+            )
 
     # the text caches are per crop (the FL2VA presentations embed the crop endpoints), so every
     # task walks the latent batches; a per-record text cache for t2va/ref2va is a follow-up

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import gc
 import logging
-import re
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -43,7 +42,9 @@ from musubi_tuner.minimax_h3.media import (
 )
 from musubi_tuner.minimax_h3.model import load_h3_transformer
 from musubi_tuner.minimax_h3.packing import (
+    FL_CONDITION_ROLES,
     FRAME_RESCALE,
+    H3ConditionRole,
     H3PackedLayout,
     H3ReferenceGeometry,
     H3TimeOverrides,
@@ -52,6 +53,7 @@ from musubi_tuner.minimax_h3.packing import (
     ONE_FRAME_VIDEO_LATENT_FRAMES,
     build_h3_layout,
     one_frame_condition_roles,
+    parse_condition_role,
 )
 from musubi_tuner.minimax_h3.sampling import (
     augment_condition_latents,
@@ -84,9 +86,6 @@ from musubi_tuner.utils import model_utils
 logger = logging.getLogger(__name__)
 
 
-_RUNTIME_REF_KEY = re.compile(r"^latents_ref_(\d{3})_(image|video|audio)$")
-# one-frame FL2VA condition latents (ordered cond_{i} slots); video FL2VA caches use latents_first/last
-_RUNTIME_COND_KEY = re.compile(r"^latents_cond_(\d{3})$")
 # validated --h3_teacher_condition_sigma_max for the endpoint (first,last) and clip (ref) teachers:
 # above it the conditioned content is unpredictable from the text (and the FL2VA weights stop
 # aligning a reference near ~0.85), so the band is better spent as a base-preservation anchor
@@ -304,9 +303,23 @@ def _warn_once_coinciding_indices(control_indices: list[int], target_index: int)
     )
 
 
-def _one_frame_condition_roles_in(batch: Mapping[str, Any]) -> tuple[str, ...]:
-    """The ordered cond_{i} roles whose latents the batch carries (empty for video FL2VA caches)."""
-    indices = sorted(int(match.group(1)) for key in batch if (match := _RUNTIME_COND_KEY.fullmatch(key)) is not None)
+def _condition_roles_in(batch: Mapping[str, Any]) -> dict[str, H3ConditionRole]:
+    """The condition latents the batch carries, keyed by role: every `latents_<role>` entry other
+    than the targets (`latents`, `latents_audio`), parsed with the packing vocabulary."""
+    roles = {}
+    for key in batch:
+        if key.startswith("latents_") and key != "latents_audio":
+            role = key.removeprefix("latents_")
+            try:
+                roles[role] = parse_condition_role(role)
+            except ValueError as error:
+                raise ValueError(f"MiniMax-H3 batch entry {key} is neither a target nor a known condition latent") from error
+    return roles
+
+
+def _one_frame_condition_roles_in(condition_roles: Mapping[str, H3ConditionRole]) -> tuple[str, ...]:
+    """The ordered cond_{i} roles among the batch's conditions (empty for video FL2VA caches)."""
+    indices = sorted(role.index for role in condition_roles.values() if role.family == "one_frame")
     if indices and indices != list(range(len(indices))):
         raise ValueError(f"MiniMax-H3 one-frame FL2VA condition latents must be the contiguous cond_000..., got {indices}")
     return one_frame_condition_roles(len(indices))
@@ -320,8 +333,9 @@ def _collect_fl_conditions(
     *,
     one_frame: bool = False,
 ) -> tuple[str, ...]:
-    fl_roles = tuple(role for role in ("first", "last") if f"latents_{role}" in batch)
-    cond_roles = _one_frame_condition_roles_in(batch)
+    condition_roles = _condition_roles_in(batch)
+    fl_roles = tuple(role for role in FL_CONDITION_ROLES if role in condition_roles)
+    cond_roles = _one_frame_condition_roles_in(condition_roles)
     if one_frame:
         # one-frame conditions are the ordered cond_{i} slots; their temporal positions are
         # carried by one_frame_control_indices, not by role names
@@ -334,7 +348,7 @@ def _collect_fl_conditions(
     else:
         if cond_roles:
             raise ValueError("MiniMax-H3 video FL2VA batch cannot carry one-frame cond_ condition latents; re-run latent caching")
-        if fl_roles != ("first", "last"):
+        if fl_roles != FL_CONDITION_ROLES:
             raise ValueError("MiniMax-H3 FL2VA batch requires both first and last conditions")
         roles = fl_roles
     for role in roles:
@@ -438,7 +452,8 @@ def _runtime_batch_plan(
         raise ValueError("MiniMax-H3 hidden states and token tags must share [B,L]")
     if token_tags.dtype != torch.int64 or not torch.all((token_tags == 0) | (token_tags == 1)):
         raise ValueError("MiniMax-H3 text token tags must be int64 values 0 or 1")
-    has_fl_condition = "latents_first" in batch or "latents_last" in batch or any(_RUNTIME_COND_KEY.fullmatch(key) for key in batch)
+    condition_roles = _condition_roles_in(batch)
+    has_fl_condition = any(role.family in {"fl", "one_frame"} for role in condition_roles.values())
     has_fl_teacher_text = "mmh3_teacher_hidden_states" in batch or "mmh3_teacher_token_tags" in batch
     has_ref_teacher_text = "mmh3_teacher_ref_hidden_states" in batch or "mmh3_teacher_ref_token_tags" in batch
     has_subject_ref_teacher_text = (
@@ -467,13 +482,14 @@ def _runtime_batch_plan(
                 f" --h3_teacher_conditions {teacher_conditions};"
                 f" re-run minimax_h3_cache_text_encoder_outputs.py --task t2va --teacher_conditions {teacher_conditions}"
             )
-    reference_roles = {}
-    for key, value in batch.items():
-        match = _RUNTIME_REF_KEY.fullmatch(key)
-        if match is not None:
-            if not isinstance(value, torch.Tensor):
-                raise ValueError(f"MiniMax-H3 condition {key} must be a tensor")
-            reference_roles.setdefault(int(match.group(1)), {})[match.group(2)] = value
+    reference_roles: dict[int, dict[str, torch.Tensor]] = {}
+    for name, role in condition_roles.items():
+        if role.family != "reference":
+            continue
+        value = batch[f"latents_{name}"]
+        if not isinstance(value, torch.Tensor):
+            raise ValueError(f"MiniMax-H3 condition latents_{name} must be a tensor")
+        reference_roles.setdefault(role.index, {})[role.reference_kind] = value
     if has_fl_condition and reference_roles:
         raise ValueError("MiniMax-H3 batch cannot mix FL2VA and Ref2VA condition roles")
 

--- a/tests/test_minimax_h3_cache_contract.py
+++ b/tests/test_minimax_h3_cache_contract.py
@@ -42,6 +42,28 @@ from musubi_tuner.dataset.cache_io import (
     save_text_encoder_output_cache_minimax_h3,
 )
 from musubi_tuner.dataset.image_video_dataset import ItemInfo
+from musubi_tuner.utils.safetensors_utils import MemoryEfficientSafeOpen
+
+
+def _saved_keys(path: str) -> set[str]:
+    with MemoryEfficientSafeOpen(path) as f:
+        return set(f.keys())
+
+
+def _save_text_rows(item: ItemInfo, rows: int = 3, tags=None, metadata=None, **teacher) -> None:
+    save_text_encoder_output_cache_minimax_h3(
+        item,
+        hidden_states=torch.zeros(rows, 5120, dtype=torch.bfloat16),
+        token_tags=torch.tensor([1, 0, 1][:rows], dtype=torch.int64) if tags is None else tags,
+        metadata=metadata,
+        **teacher,
+    )
+
+
+_TEACHER_ROWS = dict(
+    teacher_hidden_states=torch.zeros(5, 5120, dtype=torch.bfloat16),
+    teacher_token_tags=torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64),
+)
 
 
 @pytest.mark.parametrize(
@@ -446,18 +468,28 @@ def _h3_item(tmp_path: Path) -> ItemInfo:
 
 def test_h3_cache_keys_round_trip_through_existing_bucket_collator(tmp_path: Path):
     item = _h3_item(tmp_path)
-    latent_tensors = {
-        "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
-        "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-        AUDIO_PRESENT_KEY: torch.tensor(1.0, dtype=torch.float32),
-        "latents_first_1x4x4_float16": torch.ones(24, 1, 4, 4, dtype=torch.float16),
+    save_latent_cache_minimax_h3(
+        item,
+        target_video=torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
+        target_audio=torch.zeros(32, 2, 8),
+        audio_present=True,
+        visual_conditions={"first": torch.ones(24, 1, 4, 4, dtype=torch.float16)},
+        metadata={"task": "fl2va"},
+    )
+    _save_text_rows(item, metadata={"task": "fl2va"})
+
+    # the writer names the entries (`latents[_<role>]_<shape>_<dtype>`, varlen text rows):
+    # existing caches depend on these exact names
+    assert _saved_keys(item.latent_cache_path) == {
+        "latents_2x4x4_bfloat16",
+        "latents_audio_32x2x8_float32",
+        AUDIO_PRESENT_KEY,
+        "latents_first_1x4x4_float16",
     }
-    text_tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
+    assert _saved_keys(item.text_encoder_output_cache_path) == {
+        "varlen_mmh3_hidden_states_bfloat16",
+        "varlen_mmh3_token_tags_int64",
     }
-    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "fl2va"})
-    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "fl2va"})
 
     manager = BucketBatchManager({(64, 64, 5): [item]}, batch_size=1)
     batch = manager[0]
@@ -474,38 +506,53 @@ def test_h3_cache_keys_round_trip_through_existing_bucket_collator(tmp_path: Pat
 
 def test_h3_latent_writer_rejects_transposed_audio_layout(tmp_path: Path):
     item = _h3_item(tmp_path)
-    tensors = {
-        "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
-        "latents_audio_32x2x8_float32": torch.zeros(2, 32, 8),
-    }
 
     with pytest.raises(ValueError, match=r"audio latent \[32,2,A\]"):
-        save_latent_cache_minimax_h3(item, tensors)
+        save_latent_cache_minimax_h3(
+            item,
+            target_video=torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
+            target_audio=torch.zeros(2, 32, 8),
+            audio_present=True,
+        )
 
 
-def test_h3_latent_writer_requires_binary_float32_audio_present_scalar(tmp_path: Path):
+def test_h3_latent_writer_records_audio_presence_as_the_binary_scalar_entry(tmp_path: Path):
     item = _h3_item(tmp_path)
-    base = {
-        "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
-        "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-    }
+    for audio_present in (True, False):
+        save_latent_cache_minimax_h3(
+            item,
+            target_video=torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
+            target_audio=torch.zeros(32, 2, 8),
+            audio_present=audio_present,
+            metadata={"task": "t2va"},
+        )
+        with MemoryEfficientSafeOpen(item.latent_cache_path) as f:
+            scalar = f.get_tensor(AUDIO_PRESENT_KEY)
+        assert scalar.dtype == torch.float32 and scalar.shape == torch.Size([])
+        assert scalar.item() == (1.0 if audio_present else 0.0)
 
-    with pytest.raises(ValueError, match=AUDIO_PRESENT_KEY):
-        save_latent_cache_minimax_h3(item, base, {"task": "t2va"})
 
-    invalid = (
-        torch.tensor([1.0], dtype=torch.float32),
-        torch.tensor(1.0, dtype=torch.float64),
-        torch.tensor(float("nan"), dtype=torch.float32),
-        torch.tensor(0.5, dtype=torch.float32),
-    )
-    for scalar in invalid:
-        with pytest.raises(ValueError, match=AUDIO_PRESENT_KEY):
-            save_latent_cache_minimax_h3(
-                item,
-                {**base, AUDIO_PRESENT_KEY: scalar},
-                {"task": "t2va"},
-            )
+@pytest.mark.parametrize(
+    ("conditions", "message"),
+    [
+        ({"visual_conditions": {"cond_0": torch.zeros(24, 1, 4, 4)}}, "Unsupported MiniMax-H3 condition role"),
+        ({"visual_conditions": {"ref_000_audio": torch.zeros(24, 1, 4, 4)}}, "carries audio rows"),
+        ({"audio_conditions": {"ref_000_video": torch.zeros(32, 2, 8)}}, "carries a visual latent"),
+        ({"visual_conditions": {"last": torch.zeros(1, 24, 4, 4)}}, r"visual condition last latent must be \[24,F,H,W\]"),
+        ({"audio_conditions": {"ref_001_audio": torch.zeros(32, 8)}}, r"audio condition ref_001_audio latent \[32,2,A\]"),
+    ],
+)
+def test_h3_latent_writer_rejects_conditions_outside_the_role_vocabulary(tmp_path: Path, conditions: dict, message: str):
+    item = _h3_item(tmp_path)
+
+    with pytest.raises(ValueError, match=message):
+        save_latent_cache_minimax_h3(
+            item,
+            target_video=torch.zeros(24, 2, 4, 4),
+            target_audio=torch.zeros(32, 2, 8),
+            audio_present=True,
+            **conditions,
+        )
 
 
 @pytest.mark.parametrize(
@@ -514,32 +561,32 @@ def test_h3_latent_writer_requires_binary_float32_audio_present_scalar(tmp_path:
 )
 def test_h3_text_writer_rejects_invalid_token_tags(tmp_path: Path, tags: torch.Tensor):
     item = _h3_item(tmp_path)
-    tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": tags,
-    }
 
     with pytest.raises(ValueError, match="token tags"):
-        save_text_encoder_output_cache_minimax_h3(item, tensors)
+        _save_text_rows(item, tags=tags)
 
 
 def test_h3_teacher_text_rows_round_trip_through_the_bucket_collator(tmp_path: Path):
     item = _h3_item(tmp_path)
-    latent_tensors = {
-        "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
-        "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-        AUDIO_PRESENT_KEY: torch.tensor(1.0, dtype=torch.float32),
-        "latents_first_1x4x4_float16": torch.ones(24, 1, 4, 4, dtype=torch.float16),
-        "latents_last_1x4x4_float16": torch.ones(24, 1, 4, 4, dtype=torch.float16),
+    save_latent_cache_minimax_h3(
+        item,
+        target_video=torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
+        target_audio=torch.zeros(32, 2, 8),
+        audio_present=True,
+        visual_conditions={
+            "first": torch.ones(24, 1, 4, 4, dtype=torch.float16),
+            "last": torch.ones(24, 1, 4, 4, dtype=torch.float16),
+        },
+        metadata={"task": "fl2va"},
+    )
+    _save_text_rows(item, metadata={"task": "t2va", "teacher_conditions": "first,last"}, teacher_kind="first,last", **_TEACHER_ROWS)
+
+    assert _saved_keys(item.text_encoder_output_cache_path) == {
+        "varlen_mmh3_hidden_states_bfloat16",
+        "varlen_mmh3_token_tags_int64",
+        "varlen_mmh3_teacher_hidden_states_bfloat16",
+        "varlen_mmh3_teacher_token_tags_int64",
     }
-    text_tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
-        "varlen_mmh3_teacher_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_teacher_token_tags_int64": torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64),
-    }
-    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "fl2va"})
-    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "t2va", "teacher_conditions": "first,last"})
 
     manager = BucketBatchManager({(64, 64, 5): [item]}, batch_size=1)
     batch = manager[0]
@@ -552,39 +599,38 @@ def test_h3_teacher_text_rows_round_trip_through_the_bucket_collator(tmp_path: P
 
 def test_h3_text_writer_rejects_a_one_sided_teacher_pair(tmp_path: Path):
     item = _h3_item(tmp_path)
-    student = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
-    }
 
     with pytest.raises(ValueError, match="teacher"):
-        save_text_encoder_output_cache_minimax_h3(
-            item,
-            {**student, "varlen_mmh3_teacher_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16)},
-        )
+        _save_text_rows(item, teacher_kind="first,last", teacher_hidden_states=torch.zeros(5, 5120, dtype=torch.bfloat16))
     with pytest.raises(ValueError, match="teacher"):
-        save_text_encoder_output_cache_minimax_h3(
-            item,
-            {**student, "varlen_mmh3_teacher_token_tags_int64": torch.ones(5, dtype=torch.int64)},
-        )
+        _save_text_rows(item, teacher_kind="ref", teacher_token_tags=torch.ones(5, dtype=torch.int64))
+    with pytest.raises(ValueError, match="teacher"):
+        _save_text_rows(item, **_TEACHER_ROWS)
+
+
+def test_h3_text_writer_rejects_an_unknown_teacher_kind(tmp_path: Path):
+    item = _h3_item(tmp_path)
+
+    with pytest.raises(ValueError, match="teacher kind"):
+        _save_text_rows(item, teacher_kind="first", **_TEACHER_ROWS)
 
 
 def test_h3_ref_teacher_text_rows_round_trip_through_the_bucket_collator(tmp_path: Path):
     # the ref teacher needs no endpoint condition latents: a plain T2VA latent cache suffices
     item = _h3_item(tmp_path)
-    latent_tensors = {
-        "latents_2x4x4_bfloat16": torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
-        "latents_audio_32x2x8_float32": torch.zeros(32, 2, 8),
-        AUDIO_PRESENT_KEY: torch.tensor(1.0, dtype=torch.float32),
+    save_latent_cache_minimax_h3(
+        item,
+        target_video=torch.zeros(24, 2, 4, 4, dtype=torch.bfloat16),
+        target_audio=torch.zeros(32, 2, 8),
+        audio_present=True,
+        metadata={"task": "t2va"},
+    )
+    _save_text_rows(item, metadata={"task": "t2va", "teacher_conditions": "ref"}, teacher_kind="ref", **_TEACHER_ROWS)
+
+    assert _saved_keys(item.text_encoder_output_cache_path) >= {
+        "varlen_mmh3_teacher_ref_hidden_states_bfloat16",
+        "varlen_mmh3_teacher_ref_token_tags_int64",
     }
-    text_tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
-        "varlen_mmh3_teacher_ref_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_teacher_ref_token_tags_int64": torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64),
-    }
-    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "t2va"})
-    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "t2va", "teacher_conditions": "ref"})
 
     manager = BucketBatchManager({(64, 64, 5): [item]}, batch_size=1)
     batch = manager[0]
@@ -602,21 +648,27 @@ def test_h3_subject_ref_teacher_text_keys_round_trip_through_the_bucket_collator
     item = ItemInfo("view", "sks girl", (64, 64), (64, 64))
     item.latent_cache_path = str(tmp_path / "view_0064x0064_mmh3.safetensors")
     item.text_encoder_output_cache_path = str(tmp_path / "view_mmh3_te.safetensors")
-    latent_tensors = {
-        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_ref_000_image_1x4x4_float32": torch.ones(24, 1, 4, 4),
-        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
-        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
-        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(0, dtype=torch.int64),
+    save_latent_cache_minimax_h3(
+        item,
+        target_video=torch.zeros(24, 1, 4, 4),
+        target_audio=torch.zeros(32, 2, 2),
+        audio_present=False,
+        visual_conditions={"ref_000_image": torch.ones(24, 1, 4, 4)},
+        one_frame_target_index=0,
+        metadata={"task": "ref2va", "one_frame": "1"},
+    )
+    _save_text_rows(
+        item,
+        tags=torch.tensor([1, 1, 1], dtype=torch.int64),
+        metadata={"task": "t2va", "teacher_conditions": "subject_ref"},
+        teacher_kind="subject_ref",
+        **_TEACHER_ROWS,
+    )
+
+    assert _saved_keys(item.text_encoder_output_cache_path) >= {
+        "varlen_mmh3_teacher_subject_ref_hidden_states_bfloat16",
+        "varlen_mmh3_teacher_subject_ref_token_tags_int64",
     }
-    text_tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 1, 1], dtype=torch.int64),
-        "varlen_mmh3_teacher_subject_ref_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_teacher_subject_ref_token_tags_int64": torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64),
-    }
-    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "ref2va", "one_frame": "1"})
-    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "t2va", "teacher_conditions": "subject_ref"})
 
     batch = BucketBatchManager({(64, 64): [item]}, batch_size=1)[0]
 
@@ -625,57 +677,24 @@ def test_h3_subject_ref_teacher_text_keys_round_trip_through_the_bucket_collator
     assert batch["mmh3_teacher_subject_ref_hidden_states"][0].shape == (5, 5120)
     torch.testing.assert_close(batch["mmh3_teacher_subject_ref_token_tags"][0], torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64))
 
-    with pytest.raises(ValueError, match="mix"):
-        save_text_encoder_output_cache_minimax_h3(
-            item,
-            {
-                **text_tensors,
-                "varlen_mmh3_teacher_ref_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16),
-                "varlen_mmh3_teacher_ref_token_tags_int64": torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64),
-            },
-        )
-
-
-def test_h3_text_writer_rejects_a_one_sided_ref_teacher_pair_and_mixed_teacher_kinds(tmp_path: Path):
-    item = _h3_item(tmp_path)
-    student = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
-    }
-    fl_pair = {
-        "varlen_mmh3_teacher_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_teacher_token_tags_int64": torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64),
-    }
-    ref_pair = {
-        "varlen_mmh3_teacher_ref_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_teacher_ref_token_tags_int64": torch.tensor([1, 0, 0, 1, 1], dtype=torch.int64),
-    }
-
-    with pytest.raises(ValueError, match="teacher"):
-        save_text_encoder_output_cache_minimax_h3(
-            item,
-            {**student, "varlen_mmh3_teacher_ref_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16)},
-        )
-    with pytest.raises(ValueError, match="teacher"):
-        save_text_encoder_output_cache_minimax_h3(
-            item,
-            {**student, "varlen_mmh3_teacher_ref_token_tags_int64": torch.ones(5, dtype=torch.int64)},
-        )
-    with pytest.raises(ValueError, match="mix"):
-        save_text_encoder_output_cache_minimax_h3(item, {**student, **fl_pair, **ref_pair})
-
 
 def test_h3_text_writer_validates_teacher_rows_like_student_rows(tmp_path: Path):
     item = _h3_item(tmp_path)
-    tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
-        "varlen_mmh3_teacher_hidden_states_bfloat16": torch.zeros(5, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_teacher_token_tags_int64": torch.tensor([1, 2, 0, 1, 1], dtype=torch.int64),
-    }
 
     with pytest.raises(ValueError, match="token tags"):
-        save_text_encoder_output_cache_minimax_h3(item, tensors)
+        _save_text_rows(
+            item,
+            teacher_kind="first,last",
+            teacher_hidden_states=torch.zeros(5, 5120, dtype=torch.bfloat16),
+            teacher_token_tags=torch.tensor([1, 2, 0, 1, 1], dtype=torch.int64),
+        )
+    with pytest.raises(ValueError, match=r"\[L,5120\]"):
+        _save_text_rows(
+            item,
+            teacher_kind="first,last",
+            teacher_hidden_states=torch.zeros(5, 4096, dtype=torch.bfloat16),
+            teacher_token_tags=torch.ones(5, dtype=torch.int64),
+        )
 
 
 class _FakeH3VideoVAE(torch.nn.Module):
@@ -763,16 +782,15 @@ def test_build_fl2va_latents_encodes_the_provided_audio_window(tmp_path: Path):
         allow_experimental_duration=True,
     )
 
-    assert set(payload.tensors) == {
-        "latents_2x4x4_float32",
-        "latents_audio_32x2x8_float32",
-        AUDIO_PRESENT_KEY,
-        "latents_first_1x4x4_float32",
-        "latents_last_1x4x4_float32",
+    assert payload.target_video.shape == (24, 2, 4, 4) and payload.target_video.dtype == torch.float32
+    assert payload.target_audio.shape == (32, 2, 8) and payload.target_audio.dtype == torch.float32
+    assert payload.audio_present is True
+    assert {role: tuple(latent.shape) for role, latent in payload.visual_conditions.items()} == {
+        "first": (24, 1, 4, 4),
+        "last": (24, 1, 4, 4),
     }
-    assert payload.tensors[AUDIO_PRESENT_KEY].shape == torch.Size([])
-    assert payload.tensors[AUDIO_PRESENT_KEY].dtype == torch.float32
-    assert payload.tensors[AUDIO_PRESENT_KEY].item() == 1.0
+    assert payload.audio_conditions == {}
+    assert payload.one_frame_target_index is None and payload.one_frame_control_indices is None
     assert decoder.audio_calls == []
     assert len(audio_vae.calls) == 1
     torch.testing.assert_close(audio_vae.calls[0], waveform.unsqueeze(0))
@@ -828,7 +846,7 @@ def test_missing_target_audio_encodes_silence_with_presence_zero(tmp_path: Path)
     assert len(audio_vae.calls) == 1
     assert audio_vae.calls[0].shape == (1, 2, 6400)
     assert torch.count_nonzero(audio_vae.calls[0]) == 0
-    assert payload.tensors[AUDIO_PRESENT_KEY].item() == 0.0
+    assert payload.audio_present is False
 
 
 def test_silence_placeholder_must_be_all_zeros(tmp_path: Path):
@@ -948,14 +966,15 @@ def test_build_ref2va_latents_preserves_ordered_numbered_roles(tmp_path: Path):
         allow_experimental_duration=True,
     )
 
-    assert set(payload.tensors) == {
-        "latents_2x4x4_float32",
-        "latents_audio_32x2x8_float32",
-        AUDIO_PRESENT_KEY,
-        "latents_ref_000_image_1x2x4_float32",
-        "latents_ref_001_video_2x4x2_float32",
-        "latents_ref_001_audio_32x2x8_float32",
-        "latents_ref_002_audio_32x2x2_float32",
+    assert payload.target_video.shape == (24, 2, 4, 4)
+    assert payload.target_audio.shape == (32, 2, 8)
+    assert {role: tuple(latent.shape) for role, latent in payload.visual_conditions.items()} == {
+        "ref_000_image": (24, 1, 2, 4),
+        "ref_001_video": (24, 2, 4, 2),
+    }
+    assert {role: tuple(latent.shape) for role, latent in payload.audio_conditions.items()} == {
+        "ref_001_audio": (32, 2, 8),
+        "ref_002_audio": (32, 2, 2),
     }
     assert [call[0].path for call in decoder.audio_calls] == [reference_video_audio, voice]
     assert decoder.audio_calls[0][1:] == (0, 6400, True)
@@ -1024,15 +1043,12 @@ def test_build_one_frame_latents_pack_silence_and_the_target_index(tmp_path: Pat
         media_fingerprints={image_path: "portrait-image"},
     )
 
-    assert set(payload.tensors) == {
-        "latents_1x4x4_float32",
-        "latents_audio_32x2x2_float32",
-        AUDIO_PRESENT_KEY,
-        ONE_FRAME_TARGET_INDEX_KEY,
-    }
-    assert payload.tensors[AUDIO_PRESENT_KEY].item() == 0.0
-    index = payload.tensors[ONE_FRAME_TARGET_INDEX_KEY]
-    assert index.dtype == torch.int64 and index.shape == torch.Size([]) and index.item() == 24
+    assert payload.target_video.shape == (24, 1, 4, 4)
+    assert payload.target_audio is silence
+    assert payload.audio_present is False
+    assert payload.visual_conditions == {} and payload.audio_conditions == {}
+    assert payload.one_frame_target_index == 24
+    assert payload.one_frame_control_indices is None
     assert [call.shape for call in video_vae.calls] == [(1, 3, 1, 64, 64)]
     assert payload.metadata["task"] == "t2va"
     assert payload.metadata["crop_start_frame"] == "0"
@@ -1073,18 +1089,22 @@ def test_one_frame_cache_keys_round_trip_through_the_bucket_collator(tmp_path: P
     item = ItemInfo("portrait", "an image caption", (64, 64), (64, 64))
     item.latent_cache_path = str(tmp_path / "portrait_0064x0064_mmh3.safetensors")
     item.text_encoder_output_cache_path = str(tmp_path / "portrait_mmh3_te.safetensors")
-    latent_tensors = {
-        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
-        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
-        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
+    save_latent_cache_minimax_h3(
+        item,
+        target_video=torch.zeros(24, 1, 4, 4),
+        target_audio=torch.zeros(32, 2, 2),
+        audio_present=False,
+        one_frame_target_index=24,
+        metadata={"task": "t2va", "one_frame": "1"},
+    )
+    _save_text_rows(item, tags=torch.tensor([1, 1, 1], dtype=torch.int64), metadata={"task": "t2va"})
+
+    assert _saved_keys(item.latent_cache_path) == {
+        "latents_1x4x4_float32",
+        "latents_audio_32x2x2_float32",
+        AUDIO_PRESENT_KEY,
+        ONE_FRAME_TARGET_INDEX_KEY,
     }
-    text_tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 1, 1], dtype=torch.int64),
-    }
-    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "t2va", "one_frame": "1"})
-    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "t2va"})
 
     manager = BucketBatchManager({(64, 64): [item]}, batch_size=1)
     batch = manager[0]
@@ -1097,19 +1117,16 @@ def test_one_frame_cache_keys_round_trip_through_the_bucket_collator(tmp_path: P
 
 def test_h3_latent_writer_rejects_invalid_one_frame_target_indices(tmp_path: Path):
     item = _h3_item(tmp_path)
-    base = {
-        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
-        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
-    }
-    invalid = (
-        torch.tensor([24], dtype=torch.int64),
-        torch.tensor(24, dtype=torch.int32),
-        torch.tensor(-1, dtype=torch.int64),
-    )
-    for index in invalid:
-        with pytest.raises(ValueError, match=ONE_FRAME_TARGET_INDEX_KEY):
-            save_latent_cache_minimax_h3(item, {**base, ONE_FRAME_TARGET_INDEX_KEY: index}, {"task": "t2va"})
+
+    with pytest.raises(ValueError, match="target index must be nonnegative"):
+        save_latent_cache_minimax_h3(
+            item,
+            target_video=torch.zeros(24, 1, 4, 4),
+            target_audio=torch.zeros(32, 2, 2),
+            audio_present=False,
+            one_frame_target_index=-1,
+            metadata={"task": "t2va"},
+        )
 
 
 @pytest.mark.parametrize("control_indices", [[0], [0, 48], [0, 24, 48]])
@@ -1134,16 +1151,13 @@ def test_build_one_frame_latents_pack_controls_and_their_indices(tmp_path: Path,
 
     # one-frame conditions are the ordered cond_{i} slots (any count), never the video first/last roles
     expected_roles = tuple(f"cond_{index:03d}" for index in range(len(control_indices)))
-    assert set(payload.tensors) == {
-        "latents_1x4x4_float32",
-        "latents_audio_32x2x2_float32",
-        AUDIO_PRESENT_KEY,
-        ONE_FRAME_TARGET_INDEX_KEY,
-        ONE_FRAME_CONTROL_INDICES_KEY,
-        *(f"latents_{role}_1x4x4_float32" for role in expected_roles),
+    assert payload.target_video.shape == (24, 1, 4, 4)
+    assert {role: tuple(latent.shape) for role, latent in payload.visual_conditions.items()} == {
+        role: (24, 1, 4, 4) for role in expected_roles
     }
-    indices = payload.tensors[ONE_FRAME_CONTROL_INDICES_KEY]
-    assert indices.dtype == torch.int64 and indices.tolist() == control_indices
+    assert payload.audio_conditions == {}
+    assert payload.one_frame_target_index == 24
+    assert payload.one_frame_control_indices == tuple(control_indices)
     # target encode + one condition encode per control
     assert [call.shape for call in video_vae.calls] == [(1, 3, 1, 64, 64)] * (1 + len(control_indices))
     assert payload.metadata["task"] == "fl2va"
@@ -1195,26 +1209,32 @@ def test_one_frame_control_cache_keys_round_trip_through_the_bucket_collator(tmp
     item = ItemInfo("edit", "an editing caption", (64, 64), (64, 64, 1))
     item.latent_cache_path = str(tmp_path / "edit_0064x0064_mmh3.safetensors")
     item.text_encoder_output_cache_path = str(tmp_path / "edit_mmh3_te.safetensors")
-    latent_tensors = {
-        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_first_1x4x4_float32": torch.ones(24, 1, 4, 4),
-        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
-        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
-        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
-        ONE_FRAME_CONTROL_INDICES_KEY: torch.tensor([0], dtype=torch.int64),
+    save_latent_cache_minimax_h3(
+        item,
+        target_video=torch.zeros(24, 1, 4, 4),
+        target_audio=torch.zeros(32, 2, 2),
+        audio_present=False,
+        visual_conditions={"cond_000": torch.ones(24, 1, 4, 4)},
+        one_frame_target_index=24,
+        one_frame_control_indices=[0],
+        metadata={"task": "fl2va", "one_frame": "1"},
+    )
+    _save_text_rows(item, tags=torch.tensor([1, 1, 1], dtype=torch.int64), metadata={"task": "fl2va"})
+
+    assert _saved_keys(item.latent_cache_path) == {
+        "latents_1x4x4_float32",
+        "latents_cond_000_1x4x4_float32",
+        "latents_audio_32x2x2_float32",
+        AUDIO_PRESENT_KEY,
+        ONE_FRAME_TARGET_INDEX_KEY,
+        ONE_FRAME_CONTROL_INDICES_KEY,
     }
-    text_tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 1, 1], dtype=torch.int64),
-    }
-    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "fl2va", "one_frame": "1"})
-    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "fl2va"})
 
     manager = BucketBatchManager({(64, 64, 1): [item]}, batch_size=1)
     batch = manager[0]
 
     assert batch["latents"].shape == (1, 24, 1, 4, 4)
-    assert batch["latents_first"].shape == (1, 24, 1, 4, 4)
+    assert batch["latents_cond_000"].shape == (1, 24, 1, 4, 4)
     torch.testing.assert_close(batch["one_frame_target_index"], torch.tensor([24], dtype=torch.int64))
     torch.testing.assert_close(batch["one_frame_control_indices"], torch.tensor([[0]], dtype=torch.int64))
 
@@ -1267,16 +1287,16 @@ def test_build_one_frame_latents_pack_references_under_numbered_roles(tmp_path: 
         media_decoder=decoder,
     )
 
-    assert set(payload.tensors) == {
-        "latents_1x4x4_float32",
-        "latents_audio_32x2x2_float32",
-        AUDIO_PRESENT_KEY,
-        ONE_FRAME_TARGET_INDEX_KEY,
-        "latents_ref_000_image_1x2x4_float32",
-        "latents_ref_001_video_2x4x2_float32",
-        "latents_ref_001_audio_32x2x8_float32",
+    assert payload.target_video.shape == (24, 1, 4, 4)
+    assert payload.target_audio.shape == (32, 2, 2)
+    assert payload.audio_present is False
+    assert {role: tuple(latent.shape) for role, latent in payload.visual_conditions.items()} == {
+        "ref_000_image": (24, 1, 2, 4),
+        "ref_001_video": (24, 2, 4, 2),
     }
-    assert ONE_FRAME_CONTROL_INDICES_KEY not in payload.tensors
+    assert {role: tuple(latent.shape) for role, latent in payload.audio_conditions.items()} == {"ref_001_audio": (32, 2, 8)}
+    assert payload.one_frame_target_index == 24
+    assert payload.one_frame_control_indices is None
     # references are decoded with the one-frame policy: images capped to the target area,
     # videos to the released 15 s span (not a target duration, which a single frame lacks)
     assert [(call[1], call[2]) for call in decoder.visual_calls] == [(ONE_FRAME_REFERENCE_FRAME_CAP, (64, 64))] * 2
@@ -1335,25 +1355,35 @@ def test_one_frame_reference_cache_keys_round_trip_through_the_bucket_collator(t
     item = ItemInfo("view", "a reference caption", (64, 64), (64, 64))
     item.latent_cache_path = str(tmp_path / "view_0064x0064_mmh3.safetensors")
     item.text_encoder_output_cache_path = str(tmp_path / "view_mmh3_te.safetensors")
-    latent_tensors = {
-        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_ref_000_image_1x4x4_float32": torch.ones(24, 1, 4, 4),
-        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
-        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
-        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
+    save_latent_cache_minimax_h3(
+        item,
+        target_video=torch.zeros(24, 1, 4, 4),
+        target_audio=torch.zeros(32, 2, 2),
+        audio_present=False,
+        visual_conditions={"ref_000_image": torch.ones(24, 1, 4, 4), "ref_001_video": torch.ones(24, 2, 4, 4)},
+        audio_conditions={"ref_001_audio": torch.zeros(32, 2, 8)},
+        one_frame_target_index=24,
+        metadata={"task": "ref2va", "one_frame": "1"},
+    )
+    _save_text_rows(item, metadata={"task": "ref2va"})
+
+    assert _saved_keys(item.latent_cache_path) == {
+        "latents_1x4x4_float32",
+        "latents_ref_000_image_1x4x4_float32",
+        "latents_ref_001_video_2x4x4_float32",
+        "latents_ref_001_audio_32x2x8_float32",
+        "latents_audio_32x2x2_float32",
+        AUDIO_PRESENT_KEY,
+        ONE_FRAME_TARGET_INDEX_KEY,
     }
-    text_tensors = {
-        "varlen_mmh3_hidden_states_bfloat16": torch.zeros(3, 5120, dtype=torch.bfloat16),
-        "varlen_mmh3_token_tags_int64": torch.tensor([1, 0, 1], dtype=torch.int64),
-    }
-    save_latent_cache_minimax_h3(item, latent_tensors, {"task": "ref2va", "one_frame": "1"})
-    save_text_encoder_output_cache_minimax_h3(item, text_tensors, {"task": "ref2va"})
 
     manager = BucketBatchManager({(64, 64): [item]}, batch_size=1)
     batch = manager[0]
 
     assert batch["latents"].shape == (1, 24, 1, 4, 4)
     assert batch["latents_ref_000_image"].shape == (1, 24, 1, 4, 4)
+    assert batch["latents_ref_001_video"].shape == (1, 24, 2, 4, 4)
+    assert batch["latents_ref_001_audio"].shape == (1, 32, 2, 8)
     torch.testing.assert_close(batch["one_frame_target_index"], torch.tensor([24], dtype=torch.int64))
 
 
@@ -1583,22 +1613,24 @@ def test_one_frame_format_tag_makes_skip_existing_rebuild_pre_cond_caches(tmp_pa
     assert cache_metadata_matches(path, expected)
 
 
-def test_h3_latent_writer_rejects_invalid_one_frame_control_indices(tmp_path: Path):
+@pytest.mark.parametrize(
+    ("one_frame", "message"),
+    [
+        ({"one_frame_target_index": 24, "one_frame_control_indices": [-1]}, "control indices must be nonnegative"),
+        ({"one_frame_target_index": 24, "one_frame_control_indices": []}, "at least one entry"),
+        ({"one_frame_control_indices": [0]}, "require the one-frame target index"),
+    ],
+)
+def test_h3_latent_writer_rejects_invalid_one_frame_control_indices(tmp_path: Path, one_frame: dict, message: str):
     item = _h3_item(tmp_path)
-    base = {
-        "latents_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_cond_000_1x4x4_float32": torch.zeros(24, 1, 4, 4),
-        "latents_audio_32x2x2_float32": torch.zeros(32, 2, 2),
-        AUDIO_PRESENT_KEY: torch.tensor(0.0, dtype=torch.float32),
-        ONE_FRAME_TARGET_INDEX_KEY: torch.tensor(24, dtype=torch.int64),
-    }
-    invalid = (
-        torch.tensor(0, dtype=torch.int64),
-        torch.tensor([0], dtype=torch.int32),
-        torch.tensor([-1], dtype=torch.int64),
-        torch.tensor([], dtype=torch.int64),
-        torch.zeros(1, 1, dtype=torch.int64),
-    )
-    for indices in invalid:
-        with pytest.raises(ValueError, match=ONE_FRAME_CONTROL_INDICES_KEY):
-            save_latent_cache_minimax_h3(item, {**base, ONE_FRAME_CONTROL_INDICES_KEY: indices}, {"task": "fl2va"})
+
+    with pytest.raises(ValueError, match=message):
+        save_latent_cache_minimax_h3(
+            item,
+            target_video=torch.zeros(24, 1, 4, 4),
+            target_audio=torch.zeros(32, 2, 2),
+            audio_present=False,
+            visual_conditions={"cond_000": torch.zeros(24, 1, 4, 4)},
+            metadata={"task": "fl2va"},
+            **one_frame,
+        )

--- a/tests/test_minimax_h3_packing.py
+++ b/tests/test_minimax_h3_packing.py
@@ -9,19 +9,85 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from musubi_tuner.minimax_h3.packing import (
+    FL_CONDITION_ROLES,
     FRAME_RESCALE,
     ONE_FRAME_AUDIO_LATENT_FRAMES,
     ONE_FRAME_VIDEO_LATENT_FRAMES,
+    H3ConditionRole,
     H3ReferenceGeometry,
     H3TimeOverrides,
     H3VideoGeometry,
     build_h3_layout,
     build_position_grid,
     build_timestep_rows,
+    one_frame_condition_role,
     pack_audio_rows,
     pack_video_rows,
+    parse_condition_role,
+    reference_condition_role,
     unpack_targets,
 )
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [
+        ("first", H3ConditionRole("first", "fl")),
+        ("last", H3ConditionRole("last", "fl")),
+        ("cond_000", H3ConditionRole("cond_000", "one_frame", index=0)),
+        ("cond_012", H3ConditionRole("cond_012", "one_frame", index=12)),
+        ("ref_000_image", H3ConditionRole("ref_000_image", "reference", index=0, reference_kind="image")),
+        ("ref_003_video", H3ConditionRole("ref_003_video", "reference", index=3, reference_kind="video")),
+        ("ref_003_audio", H3ConditionRole("ref_003_audio", "reference", index=3, reference_kind="audio")),
+    ],
+)
+def test_condition_roles_parse_the_cache_vocabulary(role: str, expected: H3ConditionRole):
+    parsed = parse_condition_role(role)
+
+    assert parsed == expected
+    assert parsed.is_audio == (role == "ref_003_audio")
+
+
+@pytest.mark.parametrize("role", ["", "audio", "cond_0", "cond_0000", "ref_000", "ref_000_text", "ref_00_image", "First"])
+def test_condition_roles_reject_names_outside_the_vocabulary(role: str):
+    with pytest.raises(ValueError, match="Unsupported MiniMax-H3 condition role"):
+        parse_condition_role(role)
+
+
+def test_condition_role_builders_round_trip_through_the_parser():
+    assert FL_CONDITION_ROLES == ("first", "last")
+    assert one_frame_condition_role(7) == "cond_007"
+    assert reference_condition_role(2, "audio") == "ref_002_audio"
+    for role in (*FL_CONDITION_ROLES, one_frame_condition_role(7), reference_condition_role(2, "audio")):
+        assert parse_condition_role(role).name == role
+    with pytest.raises(ValueError, match="nonnegative"):
+        reference_condition_role(-1, "image")
+    with pytest.raises(ValueError, match="reference kind"):
+        reference_condition_role(0, "text")
+
+
+def test_layout_segments_use_the_reference_condition_roles():
+    layout = build_h3_layout(
+        task="ref2va",
+        text_length=3,
+        target_video=TARGET_VIDEO,
+        target_audio_frames=8,
+        references=(
+            H3ReferenceGeometry("image", video=H3VideoGeometry(1, 2, 2)),
+            H3ReferenceGeometry("video", video=H3VideoGeometry(2, 2, 2), audio_frames=8),
+            H3ReferenceGeometry("audio", audio_frames=4),
+        ),
+    )
+
+    assert [segment.role for segment in layout.segments] == [
+        "text",
+        reference_condition_role(0, "image"),
+        reference_condition_role(1, "audio"),
+        reference_condition_role(1, "video"),
+        reference_condition_role(2, "audio"),
+        "target_audio",
+        "target_video",
+    ]
 
 
 TARGET_VIDEO = H3VideoGeometry(frames=2, height=4, width=4)

--- a/tests/test_minimax_h3_text_encoder.py
+++ b/tests/test_minimax_h3_text_encoder.py
@@ -86,7 +86,7 @@ def test_fl2va_presentation_numbers_a_lone_picture_one_for_either_role(tmp_path:
         assert presentation.text == f"<Picture 1>: {IMAGE_PLACEHOLDER}{record.caption}"
         assert len(presentation.images) == 1
 
-    with pytest.raises(ValueError, match="at least one of the first and last"):
+    with pytest.raises(ValueError, match=r"first/last visuals \(video targets\) or the cond_\{i\}"):
         build_presentation(record, "fl2va", {})
 
 


### PR DESCRIPTION
Fourth of the MiniMax-H3 cleanup series (after #1097, #1098, #1099): the key-minting inversion between the cache scripts and `dataset/cache_io.py`.

## What

Every other architecture hands `cache_io` typed tensors and lets the writer build the `latents_FxHxW_<dtype>` keys. H3 did the opposite: the cache scripts built the key strings (`latents_{role}_{F}x{H}x{W}_{dtype}`, `varlen_mmh3_*`, `{teacher_prefix}_hidden_states_{dtype}`) and `cache_io` parsed them back with four regexes and a `startswith` ladder to validate shapes and dtypes. The condition role vocabulary (`first`/`last`, `cond_NNN`, `ref_NNN_{image|video|audio}`) was spelled out independently in those regexes, in `packing.py`, in the trainer's own `_RUNTIME_*_KEY` regexes and in `text_encoder.py`.

- **Typed writers.** `save_latent_cache_minimax_h3(item, *, target_video, target_audio, audio_present, visual_conditions={role: tensor}, audio_conditions={role: tensor}, one_frame_target_index, one_frame_control_indices, metadata)` and `save_text_encoder_output_cache_minimax_h3(item, *, hidden_states, token_tags, teacher_kind, teacher_hidden_states, teacher_token_tags, metadata)`. The writer mints the keys, validates shapes against `packing.VIDEO_CHANNELS/AUDIO_CHANNELS/STEREO_CHANNELS` and `text_encoder.TEXT_WIDTH/MAX_TEXT_ROWS`, and rejects roles outside the vocabulary or an audio role passed as a visual condition. The regex block, the function-level `import re` and the dtype-suffix round-trip check are gone.
- **One role vocabulary** in `minimax_h3/packing.py`: `FL_CONDITION_ROLES`, `reference_condition_role(index, kind)` next to `one_frame_condition_role`, and `parse_condition_role(name) -> H3ConditionRole` (family `fl` / `one_frame` / `reference`, index, reference kind). The layout builder and position grid, the text presentation builder, the writer and the trainer's batch scan all go through it. The trainer no longer has regexes; unknown `latents_*` batch entries now fail loudly instead of being ignored.
- **`H3LatentCachePayload`** is a typed structure (targets, role-keyed conditions, one-frame indices, metadata) that `build_latent_tensors` / `build_one_frame_latent_tensors` fill and `payload.save(item)` writes; `_visual_key` / `_audio_key` and the `append_*_entry` calls left the CLI.
- `MINIMAX_H3_TEACHER_TEXT_PREFIXES` is now a `{teacher_kind: key stem}` dict used by the writer; the text CLI passes `teacher_kind` and no longer carries its own kind-to-prefix map.

The stored key names are unchanged, so existing caches stay valid and the collator/trainer read side is untouched.

One layering note for review: `dataset/cache_io.py` now imports `musubi_tuner.minimax_h3.packing` and `.text_encoder` (module-level, both light: no transformers at import time, no import cycle with `image_video_dataset`). This is the first `dataset/` -> architecture-package import in the repository; the alternative would be duplicating the channel/text-width constants inside `cache_io`.

## Tests

- `tests/test_minimax_h3_cache_contract.py` rewritten to the typed API; the round-trip tests now also pin the exact key names in the written files (cache compatibility) and cover the role/shape rejections and the teacher-kind validation.
- `tests/test_minimax_h3_packing.py`: `parse_condition_role` / role builders round trip, out-of-vocabulary names rejected, layout segments use the reference roles.
- Full suite: 698 passed (including the two GPU-kernel files); `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKNxpdNSD5Q5nhCzvHmJNK
