### PR TITLE
MiniMax-H3: train through the base sampling and noising seams (cleanup PR-5)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -188,6 +188,8 @@ Block swap supports up to 48 of the 50 main blocks. `--block_swap_h2d_only` is a
 
 MiniMax-H3 requires `batch_size = 1` in every H3 dataset. Use Accelerate gradient accumulation for a larger effective batch. The latent caching script warns when a dataset config sets any other value, and the trainer rejects the first batch whose size is not 1. Real packed batching needs text padding, an attention mask, and per-sample structural tensors, so it is deferred to a separate PR.
 
+`--task` decides which cache entries each batch is read with: `t2va` uses the targets only, `fl2va` the first/last (or timed one-frame) condition latents, `ref2va` the numbered reference latents, and a configured teacher additionally reads its own text rows and conditions. An entry the task needs but the cache lacks is an error; entries the task never reads (for example the endpoint latents of an `fl2va` cache in a `t2va` run) are ignored and reported once at the first step, so a cache written for another task shows up in the log.
+
 Saved `ss_minimax_h3_base_family` names the released transformer family, not the task. T2VA therefore records `ss_minimax_h3_task=t2va` and `ss_minimax_h3_base_family=fl2va`, because T2VA uses the released FL2VA base.
 
 ### Guidance-distillation countermeasure (guidance loss)
@@ -315,7 +317,7 @@ The reference pictures are canvas-capped to the target's bucket area, exactly as
 
 ### Training-time joint AV samples
 
-H3 overrides the shared `prepare_sampling` hook (whose default covers single-VAE architectures) and returns both VAEs as its sampling resources. It samples with the live transformer and current LoRA, decodes the video and audio latents with their own VAEs in sequence, and writes a muxed MP4 under `OUTPUT_DIR/sample`.
+H3 overrides the shared `prepare_sampling` hook (whose default covers single-VAE architectures) and returns both VAEs as its sampling resources. It samples with the live transformer and current LoRA, decodes the video and audio latents with their own VAEs in sequence, and writes a muxed MP4 under `OUTPUT_DIR/sample`, named like every other architecture's samples (`<output_name>_<step or epoch>_<prompt index>_<timestamp>_<seed>.mp4`). A one-frame sample (`--f 1`) decodes only the video frame and is saved through the shared image path, so it takes the same `_000.png` suffix as the other architectures' image samples.
 
 Add the sampling assets and normal sampling schedule flags to the training command:
 
@@ -327,7 +329,7 @@ Add the sampling assets and normal sampling schedule flags to the training comma
 --text_encoder /models/qwen3vl_32b_minimax_h3_bf16.safetensors
 ```
 
-The text presentations and condition latents are prepared once before the transformer is loaded. The two decode VAEs then remain on CPU and are moved to the accelerator one at a time for each scheduled sample. The shared trainer still owns sampling cadence, distributed prompt assignment, RNG restoration, and the block-swap inference/training transition.
+The text presentations and condition latents are prepared once before the transformer is loaded. The two decode VAEs then remain on CPU and are moved to the accelerator one at a time for each scheduled sample. The shared trainer still owns sampling cadence, distributed prompt assignment, per-sample seeding and RNG restoration, sample file naming, the eval/train switch, and the block-swap inference/training transition.
 
 Training-time samples load the selected Qwen3-VL text encoder on the training accelerator before the transformer. The BF16 artifact is approximately 48 GB, so `--sample_prompts` requires roughly 50 GB of available accelerator memory there; the ConvRot INT8 artifact lowers the persistent text-encoder weights to ~25 GB and the NVFP4+AWQ artifact to ~15 GB, selected simply by passing their paths. `--text_encoder_blocks_to_swap` (see Text Encoder Layer Streaming below) removes most of the remaining weight footprint by streaming the encoder layers from CPU during this phase.
 

--- a/src/musubi_tuner/dataset/cache_io.py
+++ b/src/musubi_tuner/dataset/cache_io.py
@@ -616,13 +616,8 @@ def save_latent_cache_minimax_h3(
 
 
 # key stem of the teacher text rows a MiniMax-H3 text cache may carry next to the student rows,
-# per teacher kind: each kind uses distinct keys so the trainer hard-fails on a cache/flag mode
-# mismatch instead of silently misreading the rows
-MINIMAX_H3_TEACHER_TEXT_PREFIXES = {
-    "first,last": "varlen_mmh3_teacher",
-    "ref": "varlen_mmh3_teacher_ref",
-    "subject_ref": "varlen_mmh3_teacher_subject_ref",
-}
+# per teacher kind (the vocabulary lives with the teacher-kind seam in minimax_h3.text_encoder)
+MINIMAX_H3_TEACHER_TEXT_PREFIXES = h3_text_encoder.TEACHER_TEXT_CACHE_PREFIXES
 
 
 def _h3_text_rows(prefix: str, hidden_states: torch.Tensor, token_tags: torch.Tensor, label: str) -> dict[str, torch.Tensor]:

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -47,12 +47,14 @@ from musubi_tuner.minimax_h3.packing import (
     H3VideoGeometry,
     build_h3_layout,
     one_frame_condition_role,
+    validate_clean_coefficient,
 )
 from musubi_tuner.minimax_h3.sampling import (
     DEFAULT_AUDIO_CONDITION_CLEAN,
     DEFAULT_AUDIO_SHIFT,
     DEFAULT_VIDEO_SHIFT,
     DEFAULT_VISUAL_CONDITION_CLEAN,
+    validate_shift,
 )
 from musubi_tuner.minimax_h3.text_encoder import H3TextVisual
 from musubi_tuner.minimax_h3.video_vae import VIDEO_VAE_ENCODE_DTYPE, encode_video_condition
@@ -316,15 +318,10 @@ def validate_generation_request(request: H3GenerationRequest) -> None:
             )
     if request.steps <= 0:
         raise ValueError("MiniMax-H3 --steps must be positive")
-    for label, value in (("h3_shift_video", request.h3_shift_video), ("h3_shift_audio", request.h3_shift_audio)):
-        if not 0.01 <= float(value) <= 100.0:
-            raise ValueError(f"MiniMax-H3 --{label} must be in [0.01,100.0], got {value}")
-    for label, value in (
-        ("h3_visual_cond_clean", request.h3_visual_cond_clean),
-        ("h3_audio_cond_clean", request.h3_audio_cond_clean),
-    ):
-        if not 0.0 <= float(value) <= 1.0:
-            raise ValueError(f"MiniMax-H3 --{label} must be in [0.0,1.0], got {value}")
+    validate_shift(request.h3_shift_video, "--h3_shift_video")
+    validate_shift(request.h3_shift_audio, "--h3_shift_audio")
+    validate_clean_coefficient(request.h3_visual_cond_clean, "--h3_visual_cond_clean")
+    validate_clean_coefficient(request.h3_audio_cond_clean, "--h3_audio_cond_clean")
     _validate_string_list(request.condition_image, "condition_image")
     _validate_string_list(request.ref, "ref")
 

--- a/src/musubi_tuner/minimax_h3/packing.py
+++ b/src/musubi_tuner/minimax_h3/packing.py
@@ -571,7 +571,9 @@ def _single_model_time(value: float | torch.Tensor, label: str) -> float:
     return scalar
 
 
-def _validate_clean_coefficient(value: float, label: str) -> float:
+def validate_clean_coefficient(value: float, label: str) -> float:
+    """The condition-augmentation clean coefficient (clean*x + (1-clean)*eps) must lie in [0,1];
+    the timestep rows, the samplers and the CLIs all validate through here."""
     value = float(value)
     if not math.isfinite(value) or not 0.0 <= value <= 1.0:
         raise ValueError(f"MiniMax-H3 {label} must be finite and in [0,1], got {value}")
@@ -601,8 +603,8 @@ def build_timestep_rows(
 ) -> H3TimestepRows:
     video_time = _single_model_time(model_t_video, "video model time")
     audio_time = _single_model_time(model_t_audio, "audio model time")
-    visual_clean = _validate_clean_coefficient(visual_condition_clean, "visual condition clean coefficient")
-    audio_clean = _validate_clean_coefficient(audio_condition_clean, "audio condition clean coefficient")
+    visual_clean = validate_clean_coefficient(visual_condition_clean, "visual condition clean coefficient")
+    audio_clean = validate_clean_coefficient(audio_condition_clean, "audio condition clean coefficient")
 
     text_token_tags = torch.as_tensor(text_token_tags)
     if text_token_tags.dtype != torch.int64 or text_token_tags.shape != (1, layout.text_length):

--- a/src/musubi_tuner/minimax_h3/sampling.py
+++ b/src/musubi_tuner/minimax_h3/sampling.py
@@ -29,7 +29,13 @@ from PIL import Image
 import torch
 
 from musubi_tuner.minimax_h3.media import AUDIO_SAMPLE_RATE, TARGET_FPS
-from musubi_tuner.minimax_h3.packing import AUDIO_CHANNELS, STEREO_CHANNELS, VIDEO_CHANNELS, H3PackedLayout
+from musubi_tuner.minimax_h3.packing import (
+    AUDIO_CHANNELS,
+    STEREO_CHANNELS,
+    VIDEO_CHANNELS,
+    H3PackedLayout,
+    validate_clean_coefficient,
+)
 
 # released sampler defaults, shared by the generation CLI, the trainer's sampling flags and
 # the function signatures below
@@ -60,15 +66,19 @@ class H3DecodedAV:
     sample_rate: int = AUDIO_SAMPLE_RATE
 
 
-def _validate_shift(value: float, label: str) -> float:
+def validate_shift(value: float, label: str) -> float:
+    """The per-modality timestep shift must lie in [0.01,100]; the schedule builder, the trainer
+    and the CLIs all validate through here."""
     value = float(value)
     if not 0.01 <= value <= 100.0:
-        raise ValueError(f"MiniMax-H3 {label} shift must be in [0.01,100.0], got {value}")
+        raise ValueError(f"MiniMax-H3 {label} must be in [0.01,100.0], got {value}")
     return value
 
 
-def _shift(base: torch.Tensor, value: float) -> torch.Tensor:
-    return value * base / (1.0 + (value - 1.0) * base)
+def shift_sigma(base: torch.Tensor, shift: float) -> torch.Tensor:
+    """The released H3 timestep shift ``s*u / (1 + (s-1)*u)`` of a base sigma in [0,1]; the
+    sampler applies it to its schedule, training to each step's drawn base sigma."""
+    return shift * base / (1.0 + (shift - 1.0) * base)
 
 
 def build_shifted_schedule(
@@ -80,10 +90,10 @@ def build_shifted_schedule(
 ) -> H3SigmaSchedule:
     if not isinstance(steps, int) or steps <= 0:
         raise ValueError(f"MiniMax-H3 sampling steps must be a positive integer, got {steps}")
-    video_shift = _validate_shift(video_shift, "video")
-    audio_shift = _validate_shift(audio_shift, "audio")
+    video_shift = validate_shift(video_shift, "video shift")
+    audio_shift = validate_shift(audio_shift, "audio shift")
     base = torch.linspace(1.0, 0.0, steps + 1, dtype=torch.float64, device=device)
-    return H3SigmaSchedule(base=base, video=_shift(base, video_shift), audio=_shift(base, audio_shift))
+    return H3SigmaSchedule(base=base, video=shift_sigma(base, video_shift), audio=shift_sigma(base, audio_shift))
 
 
 def create_sampling_generator(seed: int) -> torch.Generator:
@@ -117,7 +127,7 @@ def initialize_target_latents(
 def _augment_condition_group(
     tensors: Sequence[torch.Tensor],
     *,
-    generator: torch.Generator,
+    generator: torch.Generator | None,
     clean: float,
     device: torch.device | str,
 ) -> tuple[torch.Tensor, ...]:
@@ -126,9 +136,13 @@ def _augment_condition_group(
         return moved
     augmented = []
     for tensor in moved:
-        noise = torch.randn(tuple(tensor.shape), generator=generator, dtype=torch.float32, device="cpu").to(
-            device=tensor.device, dtype=tensor.dtype
-        )
+        if generator is None:
+            # training: fresh noise from the global RNG on the tensor's device, like the target noise
+            noise = torch.randn(tuple(tensor.shape), dtype=torch.float32, device=tensor.device).to(tensor.dtype)
+        else:
+            noise = torch.randn(tuple(tensor.shape), generator=generator, dtype=torch.float32, device="cpu").to(
+                device=tensor.device, dtype=tensor.dtype
+            )
         augmented.append(clean * tensor + (1.0 - clean) * noise)
     return tuple(augmented)
 
@@ -137,15 +151,18 @@ def augment_condition_latents(
     visual_conditions: Sequence[torch.Tensor],
     audio_conditions: Sequence[torch.Tensor],
     *,
-    generator: torch.Generator,
+    generator: torch.Generator | None,
     visual_clean: float = DEFAULT_VISUAL_CONDITION_CLEAN,
     audio_clean: float = DEFAULT_AUDIO_CONDITION_CLEAN,
     device: torch.device | str,
 ) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
-    if not 0.0 <= visual_clean <= 1.0:
-        raise ValueError(f"MiniMax-H3 visual condition clean coefficient must be in [0,1], got {visual_clean}")
-    if not 0.0 <= audio_clean <= 1.0:
-        raise ValueError(f"MiniMax-H3 audio condition clean coefficient must be in [0,1], got {audio_clean}")
+    """Blend independent Gaussian noise into the condition latents: clean*x + (1-clean)*eps.
+
+    Sampling passes the seed's CPU generator (see create_sampling_generator) so the noise is
+    reproducible; training passes ``generator=None`` and draws from the global RNG per step.
+    """
+    visual_clean = validate_clean_coefficient(visual_clean, "visual condition clean coefficient")
+    audio_clean = validate_clean_coefficient(audio_clean, "audio condition clean coefficient")
     return (
         _augment_condition_group(visual_conditions, generator=generator, clean=visual_clean, device=device),
         _augment_condition_group(audio_conditions, generator=generator, clean=audio_clean, device=device),

--- a/src/musubi_tuner/minimax_h3/text_encoder.py
+++ b/src/musubi_tuner/minimax_h3/text_encoder.py
@@ -602,6 +602,16 @@ TEACHER_CONDITIONS_FIRST_LAST = "first,last"
 TEACHER_CONDITIONS_REF = "ref"
 TEACHER_CONDITIONS_SUBJECT_REF = "subject_ref"
 
+# key stem of the teacher text rows a text cache may carry next to the student rows, per teacher
+# kind: each kind uses distinct keys so the trainer hard-fails on a cache/flag mode mismatch
+# instead of silently misreading the rows (the cache writer appends `_hidden_states_<dtype>` /
+# `_token_tags_int64`; the training collator drops the `varlen_` marker and the dtype suffix)
+TEACHER_TEXT_CACHE_PREFIXES = {
+    TEACHER_CONDITIONS_FIRST_LAST: "varlen_mmh3_teacher",
+    TEACHER_CONDITIONS_REF: "varlen_mmh3_teacher_ref",
+    TEACHER_CONDITIONS_SUBJECT_REF: "varlen_mmh3_teacher_subject_ref",
+}
+
 
 def normalize_teacher_conditions(value: str) -> str:
     parts = [part.strip() for part in str(value).split(",")]

--- a/src/musubi_tuner/minimax_h3_train_network.py
+++ b/src/musubi_tuner/minimax_h3_train_network.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import gc
 import logging
-import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -56,17 +55,21 @@ from musubi_tuner.minimax_h3.packing import (
     build_h3_layout,
     one_frame_condition_roles,
     parse_condition_role,
+    validate_clean_coefficient,
 )
 from musubi_tuner.minimax_h3.sampling import (
-    decoded_video_to_uint8,
+    H3DecodedAV,
+    augment_condition_latents,
     sample_joint_av_latents,
+    shift_sigma,
     synchronize_decoded_av,
-    write_image,
+    validate_shift,
     write_joint_av,
 )
 from musubi_tuner.minimax_h3.text_encoder import (
     TEACHER_CONDITIONS_REF,
     TEACHER_CONDITIONS_SUBJECT_REF,
+    TEACHER_TEXT_CACHE_PREFIXES,
     build_presentation,
     encode_h3_presentation,
     load_h3_processor,
@@ -78,7 +81,7 @@ from musubi_tuner.minimax_h3.video_vae import VIDEO_VAE_DECODE_DTYPE, VIDEO_VAE_
 from musubi_tuner.training.audio_loss import add_audio_train_args, effective_audio_loss_weights
 from musubi_tuner.training.parser_common import read_config_from_file, setup_parser_common
 from musubi_tuner.training.sampling_prompts import load_prompts
-from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer
+from musubi_tuner.training.trainer_base import DiTOutput, NetworkTrainer, wandb_tracker_and_module
 from musubi_tuner.utils.device_utils import clean_memory_on_device, synchronize_device
 from musubi_tuner.utils import model_utils
 
@@ -89,6 +92,15 @@ logger = logging.getLogger(__name__)
 # above it the conditioned content is unpredictable from the text (and the FL2VA weights stop
 # aligning a reference near ~0.85), so the band is better spent as a base-preservation anchor
 SIGMA_MAX_RECOMMENDED_COMPLETE_INFORMATION = 0.75
+
+
+def _sample_frame_count(frame_count: int) -> int:
+    """The house sample convention on the H3 frame grid: a one-frame sample stays 1, an off-grid
+    video frame count rounds down onto 17*n+5 instead of failing."""
+    if frame_count == 1:
+        return 1
+    # the H3 grid is not a stride, so the stride argument is unused for this architecture
+    return round_down_frame_count(frame_count, ARCHITECTURE_MINIMAX_H3, 0)
 
 
 def _sample_request(args: argparse.Namespace, parameter: Mapping[str, Any]) -> H3GenerationRequest:
@@ -103,12 +115,10 @@ def _sample_request(args: argparse.Namespace, parameter: Mapping[str, Any]) -> H
     if args.h3_allow_experimental_sample_duration:
         overrides["allow_experimental_duration"] = True
     requested_frame_count = overrides.get("frame_count", DEFAULT_FRAME_COUNT)
-    if requested_frame_count != 1:
-        # the house sample convention: an off-grid frame count rounds down instead of failing
-        frame_count = round_down_frame_count(requested_frame_count, ARCHITECTURE_MINIMAX_H3, 17)
-        if frame_count != requested_frame_count:
-            logger.warning("MiniMax-H3 sample frame count %d was rounded down to %d (17*n+5)", requested_frame_count, frame_count)
-        overrides["frame_count"] = frame_count
+    frame_count = _sample_frame_count(requested_frame_count)
+    if frame_count != requested_frame_count:
+        logger.warning("MiniMax-H3 sample frame count %d was rounded down to %d (17*n+5)", requested_frame_count, frame_count)
+    overrides["frame_count"] = frame_count
     reference_jsonl = overrides.get("reference_jsonl")
     if reference_jsonl and not Path(reference_jsonl).expanduser().is_absolute():
         # relative reference_jsonl paths resolve from the prompt file's directory, falling
@@ -129,30 +139,70 @@ def _sample_request(args: argparse.Namespace, parameter: Mapping[str, Any]) -> H
     return request
 
 
-def _validate_audio_present(value: Any, batch_size: int) -> torch.Tensor:
-    if not isinstance(value, torch.Tensor) or value.shape != (batch_size,) or value.dtype != torch.float32:
-        raise ValueError("MiniMax-H3 batch requires a float32 audio_present tensor with shape [B]; re-run latent caching")
-    if not torch.isfinite(value).all().item() or not ((value == 0.0) | (value == 1.0)).all().item():
-        raise ValueError("MiniMax-H3 audio_present must be exactly 0.0 or 1.0 per sample")
-    return value
-
-
 @dataclass(frozen=True)
 class _H3RuntimeBatch:
+    """One training batch as the transformer consumes it: the packed layout, the text rows, the
+    condition latents in layout order, and the audio-presence flags. The batch's cache entries
+    are read by the training --task (t2va uses none, fl2va the first/last or timed cond_
+    latents, ref2va the numbered references); a configured teacher additionally reads its own
+    text rows and conditions, which never reach the student."""
+
     layout: H3PackedLayout
     text_hidden_states: torch.Tensor
     text_token_tags: torch.Tensor
     visual_conditions: tuple[torch.Tensor, ...]
     audio_conditions: tuple[torch.Tensor, ...]
     audio_present: torch.Tensor
-    # teacher-matching extras: the teacher runs on its own layout with its own condition
-    # latents and text rows (FL2VA endpoints, or the Ref2VA self-reference), none of which
-    # reach the student
     teacher_layout: H3PackedLayout | None = None
     teacher_text_hidden_states: torch.Tensor | None = None
     teacher_text_token_tags: torch.Tensor | None = None
     teacher_visual_conditions: tuple[torch.Tensor, ...] = ()
     teacher_audio_conditions: tuple[torch.Tensor, ...] = ()
+    # warn-once observations about the batch's cache entries (see MiniMaxH3NetworkTrainer._notice)
+    notices: tuple[str, ...] = ()
+
+
+_REQUIRED_BATCH_KEYS = ("latents_audio", "audio_present", "mmh3_hidden_states", "mmh3_token_tags")
+
+
+class _BatchEntries:
+    """The H3 cache entries of one batch with consumption tracking: the condition latents
+    (``latents_<role>``), the teacher text rows and the one-frame index tensors. Whatever the
+    task and the teacher leave unread is reported, since it usually means the caches were
+    written for another task."""
+
+    def __init__(self, batch: Mapping[str, Any]):
+        self._batch = batch
+        self.unread = {
+            key
+            for key in batch
+            if (key.startswith("latents_") and key != "latents_audio")
+            or key.startswith("mmh3_teacher_")
+            or key.startswith("one_frame_")
+        }
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._batch
+
+    def take(self, key: str) -> Any:
+        self.unread.discard(key)
+        return self._batch[key]
+
+    def take_index_tensor(self, key: str, batch_size: int, *, ndim: int, hint: str) -> torch.Tensor:
+        value = self._batch.get(key)
+        if not isinstance(value, torch.Tensor) or value.ndim != ndim or value.shape[0] != batch_size:
+            shape = "[B]" if ndim == 1 else "[B,K]"
+            raise ValueError(
+                f"MiniMax-H3 one-frame batch requires a {shape} {key} tensor; re-run minimax_h3_cache_latents.py --one_frame{hint}"
+            )
+        return self.take(key)
+
+
+def _teacher_text_keys(teacher_conditions: str) -> tuple[str, str]:
+    """The batch keys of one teacher kind's text rows: the cache stems without the collator's
+    varlen_ marker."""
+    stem = TEACHER_TEXT_CACHE_PREFIXES[teacher_conditions].removeprefix("varlen_")
+    return f"{stem}_hidden_states", f"{stem}_token_tags"
 
 
 def _stack_single_text_rows(value, label: str) -> torch.Tensor:
@@ -163,22 +213,6 @@ def _stack_single_text_rows(value, label: str) -> torch.Tensor:
     if not isinstance(value, Sequence) or len(value) != 1 or not isinstance(value[0], torch.Tensor):
         raise ValueError(f"MiniMax-H3 {label} must contain exactly one tensor")
     return value[0].unsqueeze(0)
-
-
-_coinciding_one_frame_indices_warned = False
-
-
-def _warn_once_coinciding_indices(control_indices: list[int], target_index: int) -> None:
-    global _coinciding_one_frame_indices_warned
-    if _coinciding_one_frame_indices_warned or target_index not in control_indices:
-        return
-    _coinciding_one_frame_indices_warned = True
-    logger.warning(
-        "MiniMax-H3 one-frame FL2VA data places a control at the target index (%d): the base model's"
-        " prior at coinciding timestamps is verbatim anchor copying, so make sure that is the intended"
-        " training signal (see docs/minimax_h3_1f.md)",
-        target_index,
-    )
 
 
 def _condition_roles_in(batch: Mapping[str, Any]) -> dict[str, H3ConditionRole]:
@@ -204,348 +238,224 @@ def _one_frame_condition_roles_in(condition_roles: Mapping[str, H3ConditionRole]
 
 
 def _collect_fl_conditions(
-    batch: dict[str, Any],
-    batch_size: int,
+    entries: _BatchEntries,
+    condition_roles: Mapping[str, H3ConditionRole],
     visual_conditions: list[torch.Tensor],
     condition_geometries: list[H3VideoGeometry],
     *,
     one_frame: bool = False,
 ) -> tuple[str, ...]:
-    condition_roles = _condition_roles_in(batch)
-    fl_roles = tuple(role for role in FL_CONDITION_ROLES if role in condition_roles)
-    cond_roles = _one_frame_condition_roles_in(condition_roles)
+    """Reads the FL2VA condition latents in layout order and returns their roles: first/last for
+    video targets, the ordered cond_{i} slots (timed by one_frame_control_indices) for one-frame
+    targets. The layout builder and the transformer validate the tensors themselves."""
     if one_frame:
-        # one-frame conditions are the ordered cond_{i} slots; their temporal positions are
-        # carried by one_frame_control_indices, not by role names
-        if fl_roles or not cond_roles:
+        roles = _one_frame_condition_roles_in(condition_roles)
+        if not roles:
             raise ValueError(
                 "MiniMax-H3 one-frame FL2VA batch requires latents_cond_000... condition latents (first/last keys are the"
                 " video layout); re-run minimax_h3_cache_latents.py --one_frame --task fl2va"
             )
-        roles = cond_roles
     else:
-        if cond_roles:
-            raise ValueError("MiniMax-H3 video FL2VA batch cannot carry one-frame cond_ condition latents; re-run latent caching")
-        if fl_roles != FL_CONDITION_ROLES:
-            raise ValueError("MiniMax-H3 FL2VA batch requires both first and last conditions")
-        roles = fl_roles
+        roles = tuple(role for role in FL_CONDITION_ROLES if role in condition_roles)
+        if not roles:
+            raise ValueError(
+                "MiniMax-H3 FL2VA batch requires latents_first/latents_last condition latents;"
+                " re-run minimax_h3_cache_latents.py --task fl2va"
+            )
     for role in roles:
-        key = f"latents_{role}"
-        tensor = batch[key]
-        if not isinstance(tensor, torch.Tensor) or tensor.ndim != 5 or tensor.shape[1] != 24:
-            raise ValueError(f"MiniMax-H3 {key} must be [B,24,F,H,W]")
-        if tensor.shape[0] != batch_size:
-            raise ValueError(f"MiniMax-H3 {key} batch size does not match the targets")
+        tensor = entries.take(f"latents_{role}")
         visual_conditions.append(tensor)
         condition_geometries.append(H3VideoGeometry(*tensor.shape[2:]))
     return roles
 
 
 def _collect_reference_conditions(
-    reference_roles: dict[int, dict[str, torch.Tensor]], batch_size: int
+    entries: _BatchEntries, condition_roles: Mapping[str, H3ConditionRole]
 ) -> tuple[list[H3ReferenceGeometry], list[torch.Tensor], list[torch.Tensor]]:
     """Turns the numbered ``latents_ref_{i}_{image|video|audio}`` batch entries into ordered
     reference geometries plus the visual/audio condition tensors in layout order."""
+    by_index: dict[int, dict[str, torch.Tensor]] = {}
+    for name, role in condition_roles.items():
+        if role.family == "reference":
+            by_index.setdefault(role.index, {})[role.reference_kind] = entries.take(f"latents_{name}")
+    if set(by_index) != set(range(len(by_index))):
+        raise ValueError("MiniMax-H3 reference indices must be contiguous from 000")
     references: list[H3ReferenceGeometry] = []
     visual_conditions: list[torch.Tensor] = []
     audio_conditions: list[torch.Tensor] = []
-    if set(reference_roles) != set(range(len(reference_roles))):
-        raise ValueError("MiniMax-H3 reference indices must be contiguous from 000")
-    for index in range(len(reference_roles)):
-        roles = reference_roles[index]
+    for index in range(len(by_index)):
+        roles = by_index[index]
         image = roles.get("image")
         video = roles.get("video")
         audio = roles.get("audio")
         if image is not None:
             if video is not None or audio is not None:
                 raise ValueError(f"MiniMax-H3 reference {index:03d} image cannot share video/audio roles")
-            if image.ndim != 5 or image.shape[1] != 24 or image.shape[0] != batch_size:
-                raise ValueError(f"MiniMax-H3 reference {index:03d} image must be [B,24,1,H,W]")
-            geometry = H3VideoGeometry(*image.shape[2:])
-            references.append(H3ReferenceGeometry("image", video=geometry))
+            references.append(H3ReferenceGeometry("image", video=H3VideoGeometry(*image.shape[2:])))
             visual_conditions.append(image)
         elif video is not None:
-            if video.ndim != 5 or video.shape[1] != 24 or video.shape[0] != batch_size:
-                raise ValueError(f"MiniMax-H3 reference {index:03d} video must be [B,24,F,H,W]")
-            geometry = H3VideoGeometry(*video.shape[2:])
             audio_frames = 0
             if audio is not None:
-                if audio.ndim != 4 or tuple(audio.shape[1:3]) != (32, 2) or audio.shape[0] != batch_size:
-                    raise ValueError(f"MiniMax-H3 reference {index:03d} audio must be [B,32,2,A]")
                 audio_frames = audio.shape[-1]
                 audio_conditions.append(audio)
-            references.append(H3ReferenceGeometry("video", video=geometry, audio_frames=audio_frames))
+            references.append(H3ReferenceGeometry("video", video=H3VideoGeometry(*video.shape[2:]), audio_frames=audio_frames))
             visual_conditions.append(video)
-        elif audio is not None:
-            if audio.ndim != 4 or tuple(audio.shape[1:3]) != (32, 2) or audio.shape[0] != batch_size:
-                raise ValueError(f"MiniMax-H3 reference {index:03d} audio must be [B,32,2,A]")
+        else:
             references.append(H3ReferenceGeometry("audio", audio_frames=audio.shape[-1]))
             audio_conditions.append(audio)
-        else:
-            raise ValueError(f"MiniMax-H3 reference {index:03d} has no supported role")
     return references, visual_conditions, audio_conditions
 
 
-def _validate_teacher_text_rows(
-    teacher_hidden_states: torch.Tensor, teacher_token_tags: torch.Tensor, hidden_states: torch.Tensor
-) -> None:
-    if (
-        teacher_hidden_states.ndim != 3
-        or teacher_token_tags.ndim != 2
-        or teacher_hidden_states.shape[:2] != teacher_token_tags.shape
-    ):
-        raise ValueError("MiniMax-H3 teacher hidden states and token tags must share [B,L]")
-    if teacher_token_tags.dtype != torch.int64 or not torch.all((teacher_token_tags == 0) | (teacher_token_tags == 1)):
-        raise ValueError("MiniMax-H3 teacher text token tags must be int64 values 0 or 1")
-    if teacher_hidden_states.shape[2] != hidden_states.shape[2]:
-        raise ValueError(
-            f"MiniMax-H3 teacher text width {teacher_hidden_states.shape[2]} does not match"
-            f" the student text width {hidden_states.shape[2]}"
-        )
-
-
 def _runtime_batch_plan(
-    batch: dict[str, Any],
+    batch: Mapping[str, Any],
     video_latents: torch.Tensor,
     *,
+    task: str,
     teacher_conditions: str | None = None,
     one_frame: bool = False,
 ) -> _H3RuntimeBatch:
-    if video_latents.ndim != 5 or video_latents.shape[1] != 24:
-        raise ValueError(f"MiniMax-H3 target video latents must be [B,24,F,H,W], got {tuple(video_latents.shape)}")
+    missing = [key for key in _REQUIRED_BATCH_KEYS if key not in batch]
+    if missing:
+        raise ValueError(f"MiniMax-H3 batch is missing {', '.join(missing)}; re-run latent caching")
     batch_size = video_latents.shape[0]
     if batch_size != 1:
         raise ValueError(f"MiniMax-H3 R1 requires batch_size=1, got {batch_size}; use gradient accumulation")
-    audio_latents = batch.get("latents_audio")
-    if not isinstance(audio_latents, torch.Tensor) or audio_latents.ndim != 4 or tuple(audio_latents.shape[1:3]) != (32, 2):
-        shape = None if not isinstance(audio_latents, torch.Tensor) else tuple(audio_latents.shape)
-        raise ValueError(f"MiniMax-H3 target audio latents must be [B,32,2,A], got {shape}")
-    if audio_latents.shape[0] != batch_size:
-        raise ValueError("MiniMax-H3 target video and audio batch sizes differ")
-    audio_present = _validate_audio_present(batch.get("audio_present"), batch_size)
-
-    hidden_states = _stack_single_text_rows(batch.get("mmh3_hidden_states"), "text hidden states")
-    token_tags = _stack_single_text_rows(batch.get("mmh3_token_tags"), "text token tags")
-    if hidden_states.ndim != 3 or token_tags.ndim != 2 or hidden_states.shape[:2] != token_tags.shape:
-        raise ValueError("MiniMax-H3 hidden states and token tags must share [B,L]")
-    if token_tags.dtype != torch.int64 or not torch.all((token_tags == 0) | (token_tags == 1)):
-        raise ValueError("MiniMax-H3 text token tags must be int64 values 0 or 1")
+    audio_latents = batch["latents_audio"]
+    audio_present = batch["audio_present"]
+    if not isinstance(audio_present, torch.Tensor) or audio_present.shape != (batch_size,):
+        raise ValueError("MiniMax-H3 batch requires an audio_present tensor with shape [B]; re-run latent caching")
+    hidden_states = _stack_single_text_rows(batch["mmh3_hidden_states"], "text hidden states")
+    token_tags = _stack_single_text_rows(batch["mmh3_token_tags"], "text token tags")
+    entries = _BatchEntries(batch)
     condition_roles = _condition_roles_in(batch)
-    has_fl_condition = any(role.family in {"fl", "one_frame"} for role in condition_roles.values())
-    has_fl_teacher_text = "mmh3_teacher_hidden_states" in batch or "mmh3_teacher_token_tags" in batch
-    has_ref_teacher_text = "mmh3_teacher_ref_hidden_states" in batch or "mmh3_teacher_ref_token_tags" in batch
-    has_subject_ref_teacher_text = (
-        "mmh3_teacher_subject_ref_hidden_states" in batch or "mmh3_teacher_subject_ref_token_tags" in batch
-    )
-    if (has_fl_teacher_text or has_ref_teacher_text or has_subject_ref_teacher_text) and teacher_conditions is None:
-        raise ValueError(
-            "MiniMax-H3 text cache contains teacher rows (--teacher_conditions); pass --h3_teacher_matching"
-            " or rebuild the text cache without --teacher_conditions"
-        )
-    # the text cache kind must match the configured teacher: distinct keys per kind
-    present_teacher_kinds = {
-        kind
-        for kind, present in (
-            ("first,last", has_fl_teacher_text),
-            (TEACHER_CONDITIONS_REF, has_ref_teacher_text),
-            (TEACHER_CONDITIONS_SUBJECT_REF, has_subject_ref_teacher_text),
-        )
-        if present
-    }
-    if teacher_conditions is not None:
-        foreign = present_teacher_kinds - {teacher_conditions}
-        if foreign:
-            raise ValueError(
-                f"MiniMax-H3 text cache contains {sorted(foreign)[0]} teacher rows but training runs"
-                f" --h3_teacher_conditions {teacher_conditions};"
-                f" re-run minimax_h3_cache_text_encoder_outputs.py --task t2va --teacher_conditions {teacher_conditions}"
-            )
-    reference_roles: dict[int, dict[str, torch.Tensor]] = {}
-    for name, role in condition_roles.items():
-        if role.family != "reference":
-            continue
-        value = batch[f"latents_{name}"]
-        if not isinstance(value, torch.Tensor):
-            raise ValueError(f"MiniMax-H3 condition latents_{name} must be a tensor")
-        reference_roles.setdefault(role.index, {})[role.reference_kind] = value
-    if has_fl_condition and reference_roles:
-        raise ValueError("MiniMax-H3 batch cannot mix FL2VA and Ref2VA condition roles")
+    notices: list[str] = []
 
-    is_one_frame_batch = video_latents.shape[2] == 1
-    one_frame_index_value = batch.get("one_frame_target_index")
-    one_frame_control_value = batch.get("one_frame_control_indices")
-    time_overrides = None
-    if is_one_frame_batch:
+    is_one_frame = video_latents.shape[2] == ONE_FRAME_VIDEO_LATENT_FRAMES
+    target_index = None
+    if is_one_frame:
         if not one_frame:
             raise ValueError("MiniMax-H3 batch carries a one-frame latent cache; pass --one_frame to train on image targets")
-        if teacher_conditions is not None and teacher_conditions != TEACHER_CONDITIONS_SUBJECT_REF:
-            raise ValueError(
-                "MiniMax-H3 one-frame training supports teacher matching with --h3_teacher_conditions subject_ref only"
-            )
-        if (
-            not isinstance(one_frame_index_value, torch.Tensor)
-            or one_frame_index_value.shape != (batch_size,)
-            or one_frame_index_value.dtype != torch.int64
-        ):
-            raise ValueError(
-                "MiniMax-H3 one-frame batch requires an int64 one_frame_target_index tensor;"
-                " re-run minimax_h3_cache_latents.py --one_frame"
-            )
-        target_index = int(one_frame_index_value.item())
-        if target_index < 0:
-            raise ValueError(f"MiniMax-H3 one-frame target index must be nonnegative, got {target_index}")
-        condition_times: tuple[float, ...] = ()
-        if has_fl_condition:
-            if (
-                not isinstance(one_frame_control_value, torch.Tensor)
-                or one_frame_control_value.ndim != 2
-                or one_frame_control_value.shape[0] != batch_size
-                or one_frame_control_value.dtype != torch.int64
-            ):
-                raise ValueError(
-                    "MiniMax-H3 one-frame FL2VA batch requires an int64 one_frame_control_indices tensor;"
-                    " re-run minimax_h3_cache_latents.py --one_frame --task fl2va"
-                )
-            control_indices = [int(index) for index in one_frame_control_value[0].tolist()]
-            if any(index < 0 for index in control_indices):
-                raise ValueError(f"MiniMax-H3 one-frame control indices must be nonnegative, got {control_indices}")
-            _warn_once_coinciding_indices(control_indices, target_index)
-            condition_times = tuple(FRAME_RESCALE * index for index in control_indices)
-        elif one_frame_control_value is not None:
-            # references are untimed: only FL2VA controls carry condition indices
-            raise ValueError("MiniMax-H3 one-frame T2VA/Ref2VA batch cannot carry one_frame_control_indices; re-run latent caching")
-        time_overrides = H3TimeOverrides(condition_times=condition_times, target_time=FRAME_RESCALE * target_index)
-    elif one_frame_index_value is not None or one_frame_control_value is not None:
-        raise ValueError("MiniMax-H3 video batch cannot carry one-frame index tensors; re-run latent caching")
+        target_index = int(entries.take_index_tensor("one_frame_target_index", batch_size, ndim=1, hint="")[0].item())
 
-    visual_conditions = []
-    audio_conditions = []
-    condition_geometries = []
-    references = []
+    # the student's conditions, by the authoritative --task
+    visual_conditions: list[torch.Tensor] = []
+    audio_conditions: list[torch.Tensor] = []
+    condition_geometries: list[H3VideoGeometry] = []
+    references: list[H3ReferenceGeometry] = []
     fl_condition_roles: tuple[str, ...] | None = None
+    condition_times: tuple[float, ...] = ()
+    if task == "fl2va":
+        fl_condition_roles = _collect_fl_conditions(
+            entries, condition_roles, visual_conditions, condition_geometries, one_frame=is_one_frame
+        )
+        if is_one_frame:
+            # one-frame conditions are timed by their control indices, not by role names
+            control_value = entries.take_index_tensor("one_frame_control_indices", batch_size, ndim=2, hint=" --task fl2va")
+            control_indices = [int(index) for index in control_value[0].tolist()]
+            if target_index in control_indices:
+                notices.append(
+                    f"MiniMax-H3 one-frame FL2VA data places a control at the target index ({target_index}): the base"
+                    " model's prior at coinciding timestamps is verbatim anchor copying, so make sure that is the"
+                    " intended training signal (see docs/minimax_h3_1f.md)"
+                )
+            condition_times = tuple(FRAME_RESCALE * index for index in control_indices)
+    elif task == "ref2va":
+        references, visual_conditions, audio_conditions = _collect_reference_conditions(entries, condition_roles)
+        if not references:
+            raise ValueError(
+                "MiniMax-H3 Ref2VA batch requires latents_ref_000_* reference latents; re-run minimax_h3_cache_latents.py --task ref2va"
+            )
+    # references are untimed: only FL2VA controls carry condition times
+    time_overrides = H3TimeOverrides(condition_times, FRAME_RESCALE * target_index) if is_one_frame else None
+
+    target_geometry = H3VideoGeometry(*video_latents.shape[2:])
     teacher_layout = None
     teacher_hidden_states = None
     teacher_token_tags = None
     teacher_visual_conditions: list[torch.Tensor] = []
     teacher_audio_conditions: list[torch.Tensor] = []
-    if teacher_conditions == TEACHER_CONDITIONS_REF:
-        # the student trains as T2VA; the teacher runs on the Ref2VA layout with the cached
-        # target latents themselves (video + audio) as the reference condition, so the teacher
-        # sees complete information at every sigma. FL2VA first/last latents, if present in the
-        # caches, are simply unused in this mode.
-        if reference_roles:
-            raise ValueError("MiniMax-H3 teacher matching does not accept Ref2VA condition roles")
-        if not has_ref_teacher_text:
+    if teacher_conditions is not None:
+        hidden_key, tags_key = _teacher_text_keys(teacher_conditions)
+        if hidden_key not in entries or tags_key not in entries:
             raise ValueError(
-                "MiniMax-H3 ref teacher matching requires reference teacher text rows;"
-                " re-run minimax_h3_cache_text_encoder_outputs.py --task t2va --teacher_conditions ref"
+                f"MiniMax-H3 {teacher_conditions} teacher matching requires {teacher_conditions} teacher text rows;"
+                f" re-run minimax_h3_cache_text_encoder_outputs.py --task t2va --teacher_conditions {teacher_conditions}"
             )
-        task = "t2va"
-        teacher_hidden_states = _stack_single_text_rows(batch.get("mmh3_teacher_ref_hidden_states"), "teacher text hidden states")
-        teacher_token_tags = _stack_single_text_rows(batch.get("mmh3_teacher_ref_token_tags"), "teacher text token tags")
-        _validate_teacher_text_rows(teacher_hidden_states, teacher_token_tags, hidden_states)
-        target_geometry = H3VideoGeometry(*video_latents.shape[2:])
-        teacher_visual_conditions.append(video_latents)
-        teacher_audio_conditions.append(audio_latents)
-        teacher_layout = build_h3_layout(
-            task="ref2va",
-            text_length=teacher_hidden_states.shape[1],
-            target_video=target_geometry,
-            target_audio_frames=audio_latents.shape[-1],
-            references=(H3ReferenceGeometry("video", video=target_geometry, audio_frames=audio_latents.shape[-1]),),
-        )
-    elif teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF:
-        # the student trains as T2VA; the item's own reference latents (Ref2VA cache) and the
-        # subject-declaration text rows feed only the no-grad Ref2VA teacher forward. The
-        # references are other pictures of the subject, so the teacher supplies the concept
-        # without the complete-information degeneration of the self-reference teacher.
-        if has_fl_condition:
-            raise ValueError("MiniMax-H3 subject-reference teacher matching does not accept FL2VA condition latents")
-        if not reference_roles:
-            raise ValueError(
-                "MiniMax-H3 subject-reference teacher matching requires the item's reference latents;"
-                " re-run minimax_h3_cache_latents.py --task ref2va (with --one_frame for image datasets)"
+        teacher_hidden_states = _stack_single_text_rows(entries.take(hidden_key), "teacher text hidden states")
+        teacher_token_tags = _stack_single_text_rows(entries.take(tags_key), "teacher text token tags")
+        if teacher_conditions == TEACHER_CONDITIONS_REF:
+            # the teacher runs on the Ref2VA layout with the cached target latents themselves
+            # (video + audio) as the reference condition, so it sees complete information at every
+            # sigma; FL2VA first/last latents, if present in the caches, are simply unused
+            teacher_visual_conditions.append(video_latents)
+            teacher_audio_conditions.append(audio_latents)
+            teacher_layout = build_h3_layout(
+                task="ref2va",
+                text_length=teacher_hidden_states.shape[1],
+                target_video=target_geometry,
+                target_audio_frames=audio_latents.shape[-1],
+                references=(H3ReferenceGeometry("video", video=target_geometry, audio_frames=audio_latents.shape[-1]),),
             )
-        if not has_subject_ref_teacher_text:
-            raise ValueError(
-                "MiniMax-H3 subject-reference teacher matching requires subject_ref teacher text rows;"
-                " re-run minimax_h3_cache_text_encoder_outputs.py --task t2va --teacher_conditions subject_ref"
+        elif teacher_conditions == TEACHER_CONDITIONS_SUBJECT_REF:
+            # the item's own reference latents (Ref2VA cache) and the subject-declaration text
+            # rows feed only the no-grad Ref2VA teacher forward: other pictures of the subject
+            # supply the concept without the complete-information degeneration of the
+            # self-reference teacher
+            teacher_references, teacher_visual_conditions, teacher_audio_conditions = _collect_reference_conditions(
+                entries, condition_roles
             )
-        task = "t2va"
-        teacher_references, teacher_visual_conditions, teacher_audio_conditions = _collect_reference_conditions(
-            reference_roles, batch_size
-        )
-        if any(reference.kind != "image" for reference in teacher_references):
-            raise ValueError("MiniMax-H3 subject-reference teacher matching supports image references only (v1)")
-        teacher_hidden_states = _stack_single_text_rows(
-            batch.get("mmh3_teacher_subject_ref_hidden_states"), "teacher text hidden states"
-        )
-        teacher_token_tags = _stack_single_text_rows(batch.get("mmh3_teacher_subject_ref_token_tags"), "teacher text token tags")
-        _validate_teacher_text_rows(teacher_hidden_states, teacher_token_tags, hidden_states)
-        # a one-frame teacher layout must carry the one-frame flag and the target-time override
-        # (the same rebuild trap as the guidance-loss uncond layout); references are untimed
-        teacher_layout = build_h3_layout(
-            task="ref2va",
-            text_length=teacher_hidden_states.shape[1],
-            target_video=H3VideoGeometry(*video_latents.shape[2:]),
-            target_audio_frames=audio_latents.shape[-1],
-            references=tuple(teacher_references),
-            one_frame=is_one_frame_batch,
-            time_overrides=time_overrides,
-        )
-    elif teacher_conditions is not None:
-        # the student trains as T2VA; the first/last latents and the Picture-prefixed text rows
-        # feed only the no-grad FL2VA teacher forward
-        if reference_roles:
-            raise ValueError("MiniMax-H3 teacher matching does not accept Ref2VA condition roles")
-        if not has_fl_condition:
-            raise ValueError(
-                "MiniMax-H3 teacher matching requires FL2VA-style latent caches with first/last conditions;"
-                " re-run minimax_h3_cache_latents.py --task fl2va"
+            if not teacher_references:
+                raise ValueError(
+                    "MiniMax-H3 subject-reference teacher matching requires the item's reference latents;"
+                    " re-run minimax_h3_cache_latents.py --task ref2va (with --one_frame for image datasets)"
+                )
+            if any(reference.kind != "image" for reference in teacher_references):
+                raise ValueError("MiniMax-H3 subject-reference teacher matching supports image references only (v1)")
+            # a one-frame teacher layout must carry the one-frame flag and the target-time override
+            # (the same rebuild trap as the guidance-loss uncond layout); references are untimed
+            teacher_layout = build_h3_layout(
+                task="ref2va",
+                text_length=teacher_hidden_states.shape[1],
+                target_video=target_geometry,
+                target_audio_frames=audio_latents.shape[-1],
+                references=tuple(teacher_references),
+                one_frame=is_one_frame,
+                time_overrides=time_overrides,
             )
-        if not has_fl_teacher_text:
-            raise ValueError(
-                "MiniMax-H3 teacher matching requires teacher text rows;"
-                " re-run minimax_h3_cache_text_encoder_outputs.py --task t2va --teacher_conditions first,last"
+        else:
+            # the first/last latents and the Picture-prefixed text rows feed only the no-grad
+            # FL2VA teacher forward
+            teacher_geometries: list[H3VideoGeometry] = []
+            if not any(role.family == "fl" for role in condition_roles.values()):
+                raise ValueError(
+                    "MiniMax-H3 teacher matching requires FL2VA-style latent caches with first/last conditions;"
+                    " re-run minimax_h3_cache_latents.py --task fl2va"
+                )
+            _collect_fl_conditions(entries, condition_roles, teacher_visual_conditions, teacher_geometries)
+            teacher_layout = build_h3_layout(
+                task="fl2va",
+                text_length=teacher_hidden_states.shape[1],
+                target_video=target_geometry,
+                target_audio_frames=audio_latents.shape[-1],
+                visual_conditions=tuple(teacher_geometries),
             )
-        task = "t2va"
-        teacher_geometries: list[H3VideoGeometry] = []
-        _collect_fl_conditions(batch, batch_size, teacher_visual_conditions, teacher_geometries)
-        teacher_hidden_states = _stack_single_text_rows(batch.get("mmh3_teacher_hidden_states"), "teacher text hidden states")
-        teacher_token_tags = _stack_single_text_rows(batch.get("mmh3_teacher_token_tags"), "teacher text token tags")
-        _validate_teacher_text_rows(teacher_hidden_states, teacher_token_tags, hidden_states)
-        teacher_layout = build_h3_layout(
-            task="fl2va",
-            text_length=teacher_hidden_states.shape[1],
-            target_video=H3VideoGeometry(*video_latents.shape[2:]),
-            target_audio_frames=audio_latents.shape[-1],
-            visual_conditions=tuple(teacher_geometries),
-        )
-    elif has_fl_condition:
-        task = "fl2va"
-        fl_condition_roles = _collect_fl_conditions(
-            batch, batch_size, visual_conditions, condition_geometries, one_frame=is_one_frame_batch
-        )
-    elif reference_roles:
-        task = "ref2va"
-        references, visual_conditions, audio_conditions = _collect_reference_conditions(reference_roles, batch_size)
-    else:
-        task = "t2va"
 
-    if is_one_frame_batch and task == "fl2va" and len(condition_geometries) != len(time_overrides.condition_times):
-        raise ValueError(
-            f"MiniMax-H3 one-frame FL2VA batch has {len(condition_geometries)} condition latents for"
-            f" {len(time_overrides.condition_times)} control indices; re-run latent caching"
+    if entries.unread:
+        consumer = f"--task {task}" if teacher_conditions is None else f"--task {task} with the {teacher_conditions} teacher"
+        notices.append(
+            f"MiniMax-H3 batch entries {', '.join(sorted(entries.unread))} are not used by {consumer} and are ignored;"
+            " check that the caches were written for this task"
         )
+
     layout = build_h3_layout(
         task=task,
         text_length=hidden_states.shape[1],
-        target_video=H3VideoGeometry(*video_latents.shape[2:]),
+        target_video=target_geometry,
         target_audio_frames=audio_latents.shape[-1],
         visual_conditions=tuple(condition_geometries),
         references=tuple(references),
-        one_frame=is_one_frame_batch,
-        condition_roles=fl_condition_roles if is_one_frame_batch else None,
+        one_frame=is_one_frame,
+        condition_roles=fl_condition_roles,
         time_overrides=time_overrides,
     )
     return _H3RuntimeBatch(
@@ -560,11 +470,13 @@ def _runtime_batch_plan(
         teacher_text_token_tags=teacher_token_tags,
         teacher_visual_conditions=tuple(teacher_visual_conditions),
         teacher_audio_conditions=tuple(teacher_audio_conditions),
+        notices=tuple(notices),
     )
 
 
-def _shift_noise_amount(base: torch.Tensor, shift: float) -> torch.Tensor:
-    return shift * base / (1.0 + (shift - 1.0) * base)
+def _base_sigma_of(timesteps: torch.Tensor) -> float:
+    """The drawn pre-shift base sigma behind the trainer's 1..1000 timestep convention."""
+    return float((timesteps.reshape(-1)[0].item() - 1.0) / 1000.0)
 
 
 def _apply_timestep_focus(base: torch.Tensor, low: float, high: float, prob: float) -> torch.Tensor:
@@ -670,27 +582,25 @@ def _prediction_geometry_log(label: str, prediction: torch.Tensor, target: torch
     }
 
 
-def _augment_conditions(tensors: tuple[torch.Tensor, ...], clean: float) -> tuple[torch.Tensor, ...]:
-    """Blend independent Gaussian noise into condition latents: clean*x + (1-clean)*eps.
-
-    Training draws fresh noise from the global RNG, like the target noise; only the
-    sampling path (minimax_h3.sampling) needs seed-reproducible condition noise.
-    """
-    if clean == 1.0:
-        return tensors
-    augmented = []
-    for tensor in tensors:
-        noise = torch.randn(tuple(tensor.shape), dtype=torch.float32, device=tensor.device).to(tensor.dtype)
-        augmented.append(clean * tensor + (1.0 - clean) * noise)
-    return tuple(augmented)
+def _scalar_logs(logs: Mapping[str, torch.Tensor | float]) -> dict[str, float]:
+    """The per-step metrics as plain floats (the ``process_batch`` contract), fetched from the
+    device in one transfer instead of one sync per entry."""
+    if not logs:
+        return {}
+    scalars = [torch.as_tensor(value).detach().float().reshape(()) for value in logs.values()]
+    device = next((scalar.device for scalar in scalars if scalar.device.type != "cpu"), torch.device("cpu"))
+    values = torch.stack([scalar.to(device) for scalar in scalars]).cpu().tolist()
+    return dict(zip(logs.keys(), values))
 
 
-@dataclass(frozen=True)
-class H3SamplingResources:
-    """Training-time sampling payload: H3 decodes samples with two separate VAEs."""
+class H3SamplingResources(torch.nn.Module):
+    """Training-time sampling payload: H3 decodes samples with two separate VAEs. A Module, so the
+    base trainer's resource handling (device moves after each sample) covers both."""
 
-    video_vae: torch.nn.Module
-    audio_vae: torch.nn.Module
+    def __init__(self, video_vae: torch.nn.Module, audio_vae: torch.nn.Module):
+        super().__init__()
+        self.video_vae = video_vae
+        self.audio_vae = audio_vae
 
 
 @dataclass
@@ -721,12 +631,14 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         # first-epoch warning and the observed fraction saved in metadata
         self._audio_items_seen = 0
         self._audio_supervised_seen = 0
-        # guidance-loss uncond probe (CPU hidden rows + tags), loaded when
+        # guidance-loss uncond probe (CPU hidden rows + tags), loaded by on_train_start when
         # --h3_guidance_loss_scale is active
         self._guidance_uncond: tuple[torch.Tensor, torch.Tensor] | None = None
         # effective base quantization, known once load_transformer has seen the checkpoint
         # (pre-quantized ConvRot INT8 files are detected there, independent of --convrot_int8)
         self._convrot_int8_active: bool | None = None
+        # batch observations already warned about (each one is logged once per run)
+        self._warned_notices: set[str] = set()
 
     @property
     def architecture(self) -> str:
@@ -765,14 +677,10 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         upper = 1000.0 if args.max_timestep is None else float(args.max_timestep)
         if not 0.0 <= lower <= upper <= 1000.0:
             raise ValueError("MiniMax-H3 min_timestep/max_timestep must define a range inside [0,1000]")
-        for name, value in (("h3_shift_video", args.h3_shift_video), ("h3_shift_audio", args.h3_shift_audio)):
-            if not 0.01 <= float(value) <= 100.0:
-                raise ValueError(f"--{name} must be in [0.01,100.0], got {value}")
-        for name, value in (("h3_visual_cond_clean", args.h3_visual_cond_clean), ("h3_audio_cond_clean", args.h3_audio_cond_clean)):
-            if not 0.0 <= float(value) <= 1.0:
-                raise ValueError(f"--{name} must be in [0.0,1.0], got {value}")
-        if args.audio_loss_weight < 0:
-            raise ValueError(f"--audio_loss_weight must be nonnegative, got {args.audio_loss_weight}")
+        validate_shift(args.h3_shift_video, "--h3_shift_video")
+        validate_shift(args.h3_shift_audio, "--h3_shift_audio")
+        validate_clean_coefficient(args.h3_visual_cond_clean, "--h3_visual_cond_clean")
+        validate_clean_coefficient(args.h3_audio_cond_clean, "--h3_audio_cond_clean")
         if args.blocks_to_swap is not None and args.blocks_to_swap > 48:
             raise ValueError("--blocks_to_swap for MiniMax-H3 must be <= 48")
         if args.fp8_base or args.fp8_scaled:
@@ -873,25 +781,30 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             raise ValueError(f"--h3_guidance_loss_scale_audio must be nonnegative, got {args.h3_guidance_loss_scale_audio}")
         if not 0.0 <= float(args.h3_guidance_loss_sigma_min) <= 1.0:
             raise ValueError(f"--h3_guidance_loss_sigma_min must be in [0.0,1.0], got {args.h3_guidance_loss_sigma_min}")
-        self._guidance_uncond = None
         if guidance_scale > 0.0:
             if not args.h3_guidance_loss_uncond_cache:
                 raise ValueError(
                     "--h3_guidance_loss_scale requires --h3_guidance_loss_uncond_cache"
                     " (write one with minimax_h3_cache_text_encoder_outputs.py --uncond_output)"
                 )
+            require_path(args.h3_guidance_loss_uncond_cache, "h3_guidance_loss_uncond_cache")
+        elif args.h3_guidance_loss_uncond_cache:
+            logger.warning("--h3_guidance_loss_uncond_cache is ignored because --h3_guidance_loss_scale is 0")
+
+    def on_train_start(self, args: argparse.Namespace, accelerator: Accelerator, network, transformer, optimizer) -> None:
+        del accelerator, network, transformer, optimizer
+        self._guidance_uncond = None
+        if float(args.h3_guidance_loss_scale) > 0.0:
             hidden_states, token_tags, metadata = load_h3_uncond_cache(args.h3_guidance_loss_uncond_cache)
             self._guidance_uncond = (hidden_states, token_tags)
             logger.info(
                 "MiniMax-H3 guidance loss: scale=%s scale_audio=%s sigma_min=%s uncond=%r (%d rows)",
-                guidance_scale,
+                args.h3_guidance_loss_scale,
                 self._guidance_audio_scale(args),
                 args.h3_guidance_loss_sigma_min,
                 metadata.get("text", "?"),
                 hidden_states.shape[0],
             )
-        elif args.h3_guidance_loss_uncond_cache:
-            logger.warning("--h3_guidance_loss_uncond_cache is ignored because --h3_guidance_loss_scale is 0")
 
     def on_transformer_loaded(
         self,
@@ -912,13 +825,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 raise ValueError("--convrot_int8_bwd int8 requires a CUDA training device")
         if is_convrot_int8 and args.base_weights:
             raise ValueError("MiniMax-H3 --base_weights cannot be merged into a ConvRot INT8 transformer base")
-
-    def process_sample_prompts(self, args, accelerator, sample_prompts):
-        # only the default prepare_sampling needs this seam; guard against future
-        # base-side callers silently getting the base NotImplementedError instead
-        raise NotImplementedError(
-            "MiniMax-H3 prepares sample prompts inside prepare_sampling, which returns joint AV sampling resources"
-        )
 
     def prepare_sampling(self, args, accelerator, vae_dtype):
         del vae_dtype  # the H3 video/audio VAE dtypes are fixed per stage
@@ -1031,6 +937,12 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 else ()
             )
             logger.info("MiniMax-H3 training sample %d: %r", parameter["enum"], preparation.request.prompt)
+            # the resolved coordinates, so the base sampler's log lines describe the actual sample
+            parameter["width"] = preparation.request.width
+            parameter["height"] = preparation.request.height
+            parameter["frame_count"] = preparation.request.frame_count
+            parameter["sample_steps"] = preparation.request.steps
+            parameter["seed"] = preparation.request.seed
             parameter["h3_request"] = preparation.request
             parameter["h3_layout"] = build_generation_layout(
                 preparation.request,
@@ -1042,140 +954,110 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             parameter["h3_audio_conditions"] = preparation.audio_conditions
         return parameters, H3SamplingResources(video_vae=video_vae, audio_vae=audio_vae)
 
-    def sample_image_inference(
+    def round_sample_frame_count(self, frame_count: int) -> int:
+        return _sample_frame_count(frame_count)
+
+    def do_inference(
         self,
         accelerator,
         args,
-        transformer,
-        dit_dtype,
-        sample_resources,
-        save_dir,
         sample_parameter,
-        epoch,
-        steps,
+        vae,
+        dit_dtype,
+        transformer,
+        discrete_flow_shift,
+        sample_steps,
+        width,
+        height,
+        frame_count,
+        generator,
+        do_classifier_free_guidance,
+        guidance_scale,
+        cfg_scale,
+        image_path=None,
+        control_video_path=None,
     ):
-        del dit_dtype
-        if not isinstance(sample_resources, H3SamplingResources):
-            raise RuntimeError("MiniMax-H3 training sample VAEs were not prepared")
-        video_vae = sample_resources.video_vae
-        audio_vae = sample_resources.audio_vae
+        # the validated request prepared by prepare_sampling carries every sample coordinate
+        del args, dit_dtype, discrete_flow_shift, sample_steps, width, height, frame_count
+        del do_classifier_free_guidance, guidance_scale, cfg_scale, image_path, control_video_path
         request: H3GenerationRequest = sample_parameter["h3_request"]
         layout = sample_parameter["h3_layout"]
-        frame_count = request.frame_count
-        seed = request.seed
-        if seed is None:
-            seed = torch.seed()
-            if torch.cuda.is_available():
-                torch.cuda.seed()
-        else:
-            torch.manual_seed(seed)
-            if torch.cuda.is_available():
-                torch.cuda.manual_seed_all(seed)
-        logger.info(
-            "MiniMax-H3 joint sample: prompt=%r size=%dx%d frames=%d steps=%d seed=%d",
-            request.prompt,
-            request.width,
-            request.height,
-            frame_count,
-            request.steps,
-            seed,
-        )
-
         device = accelerator.device
-        has_self_ref_orig_mod = getattr(transformer, "_orig_mod", None) is transformer
-        was_training = transformer.training if not has_self_ref_orig_mod else True
-        if not has_self_ref_orig_mod:
-            transformer.eval()
-        try:
-            with tqdm(
-                total=request.steps,
-                desc=f"MiniMax-H3 sample {sample_parameter.get('enum', 0)}",
-                unit="step",
-                disable=not accelerator.is_local_main_process,
-            ) as progress:
-                sample = sample_joint_av_latents(
-                    transformer,
-                    layout=layout,
-                    seed=seed,
-                    text_hidden_states=sample_parameter["h3_text_hidden_states"],
-                    text_token_tags=sample_parameter["h3_text_token_tags"],
-                    visual_conditions=sample_parameter["h3_visual_conditions"],
-                    audio_conditions=sample_parameter["h3_audio_conditions"],
-                    steps=request.steps,
-                    video_shift=request.h3_shift_video,
-                    audio_shift=request.h3_shift_audio,
-                    visual_condition_clean=request.h3_visual_cond_clean,
-                    audio_condition_clean=request.h3_audio_cond_clean,
-                    device=device,
-                    step_callback=lambda completed, total: progress.update(1),
-                )
-            video_latents = sample.video
-            audio_latents = sample.audio
-            del sample
-            synchronize_device(device)
-            clean_memory_on_device(device)
+        logger.info(
+            "MiniMax-H3 joint sample: shift video=%s audio=%s, condition clean visual=%s audio=%s, output fps=%d",
+            request.h3_shift_video,
+            request.h3_shift_audio,
+            request.h3_visual_cond_clean,
+            request.h3_audio_cond_clean,
+            request.output_fps,
+        )
+        with tqdm(
+            total=request.steps,
+            desc=f"MiniMax-H3 sample {sample_parameter.get('enum', 0)}",
+            unit="step",
+            disable=not accelerator.is_local_main_process,
+        ) as progress:
+            sample = sample_joint_av_latents(
+                transformer,
+                layout=layout,
+                # the base seeds the generator from the prompt's seed, or from a fresh random one
+                seed=generator.initial_seed(),
+                text_hidden_states=sample_parameter["h3_text_hidden_states"],
+                text_token_tags=sample_parameter["h3_text_token_tags"],
+                visual_conditions=sample_parameter["h3_visual_conditions"],
+                audio_conditions=sample_parameter["h3_audio_conditions"],
+                steps=request.steps,
+                video_shift=request.h3_shift_video,
+                audio_shift=request.h3_shift_audio,
+                visual_condition_clean=request.h3_visual_cond_clean,
+                audio_condition_clean=request.h3_audio_cond_clean,
+                device=device,
+                step_callback=lambda completed, total: progress.update(1),
+            )
+        synchronize_device(device)
+        clean_memory_on_device(device)
 
-            logger.info("Decoding MiniMax-H3 training sample video")
-            video_vae.to(device).eval()
-            _, video_dtype = module_device_dtype(video_vae, VIDEO_VAE_DECODE_DTYPE)
-            decoded_video = video_vae.decode(video_latents.to(device=device, dtype=video_dtype)).cpu()
-            video_vae.to("cpu")
-            del video_latents
-            clean_memory_on_device(device)
+        logger.info("Decoding MiniMax-H3 training sample video")
+        video_vae = vae.video_vae
+        video_vae.to(device)
+        _, video_dtype = module_device_dtype(video_vae, VIDEO_VAE_DECODE_DTYPE)
+        decoded_video = video_vae.decode(sample.video.to(device=device, dtype=video_dtype)).cpu()
+        video_vae.to("cpu")
+        clean_memory_on_device(device)
+        if request.one_frame:
+            # one-frame sample: the audio rows are a byproduct and are never decoded; the single
+            # frame is saved by the base like any image sample ([1,3,1,H,W] in [0,1])
+            return (decoded_video[:, :, :1].float().clamp(-1.0, 1.0) + 1.0) / 2.0
 
-            timestamp = time.strftime("%Y%m%d%H%M%S", time.localtime())
-            number = f"e{epoch:06d}" if epoch is not None else f"{steps:06d}"
-            seed_suffix = "" if request.seed is None else f"_{request.seed}"
-            prompt_index = sample_parameter.get("enum", 0)
-            prefix = "" if args.output_name is None else f"{args.output_name}_"
-            output_stem = f"{prefix}{number}_{prompt_index:02d}_{timestamp}{seed_suffix}"
+        logger.info("Decoding MiniMax-H3 training sample audio")
+        audio_vae = vae.audio_vae
+        audio_vae.to(device)
+        _, audio_dtype = module_device_dtype(audio_vae, torch.float32)
+        decoded_audio = audio_vae.decode(sample.audio.to(device=device, dtype=audio_dtype)).cpu()
+        audio_vae.to("cpu")
+        clean_memory_on_device(device)
+        # a stretched sample (--ofps) plays its frame_count frames over the stretched real
+        # duration, like the generation CLI: the container rate and the audio trim follow it
+        return synchronize_decoded_av(decoded_video, decoded_audio, frame_count=request.frame_count, fps=request.output_fps)
 
-            if frame_count == 1:
-                # one-frame sample: the audio rows are a byproduct and are never decoded
-                del audio_latents
-                output_path = Path(save_dir) / f"{output_stem}.png"
-                write_image(decoded_video_to_uint8(decoded_video, frame_limit=1)[0], output_path)
-                logger.info("Saved MiniMax-H3 one-frame training sample: %s", output_path)
-            else:
-                logger.info("Decoding MiniMax-H3 training sample audio")
-                audio_vae.to(device).eval()
-                _, audio_dtype = module_device_dtype(audio_vae, torch.float32)
-                decoded_audio = audio_vae.decode(audio_latents.to(device=device, dtype=audio_dtype)).cpu()
-                audio_vae.to("cpu")
-                del audio_latents
-                clean_memory_on_device(device)
+    def save_sample(self, accelerator, args, sample_parameter, sample, save_dir: str, save_path: str, steps: int) -> None:
+        if not isinstance(sample, H3DecodedAV):
+            # a one-frame sample is a plain image tensor
+            return super().save_sample(accelerator, args, sample_parameter, sample, save_dir, save_path, steps)
+        output_path = Path(save_dir) / f"{save_path}.mp4"
+        write_joint_av(sample, output_path)
+        logger.info("Saved MiniMax-H3 joint training sample: %s", output_path)
+        wandb_tracker, wandb = wandb_tracker_and_module(accelerator)
+        if wandb_tracker is not None:
+            wandb_tracker.log(
+                {f"sample_{sample_parameter.get('enum', 0)}": wandb.Video(str(output_path), fps=sample.fps)}, step=steps
+            )
 
-                # a stretched sample (--ofps) plays its frame_count frames over the stretched real
-                # duration, like the generation CLI: the container rate and the audio trim follow it
-                decoded = synchronize_decoded_av(decoded_video, decoded_audio, frame_count=frame_count, fps=request.output_fps)
-                output_path = Path(save_dir) / f"{output_stem}.mp4"
-                write_joint_av(decoded, output_path)
-                logger.info("Saved MiniMax-H3 joint training sample: %s", output_path)
-
-            try:
-                wandb_tracker = accelerator.get_tracker("wandb")
-            except (AttributeError, ValueError):
-                wandb_tracker = None
-            if wandb_tracker is not None:
-                try:
-                    import wandb
-                except ImportError:
-                    logger.warning("wandb tracker is active but wandb is not installed")
-                else:
-                    if frame_count == 1:
-                        wandb_tracker.log({f"sample_{prompt_index}": wandb.Image(str(output_path))}, step=steps)
-                    else:
-                        wandb_tracker.log(
-                            {f"sample_{prompt_index}": wandb.Video(str(output_path), fps=request.output_fps)}, step=steps
-                        )
-            return output_path
-        finally:
-            video_vae.to("cpu")
-            audio_vae.to("cpu")
-            if not has_self_ref_orig_mod:
-                transformer.train(was_training)
-            gc.collect()
-            clean_memory_on_device(device)
+    def _notice(self, message: str) -> None:
+        """Logs a batch observation once per run (the same cache condition recurs every step)."""
+        if message not in self._warned_notices:
+            self._warned_notices.add(message)
+            logger.warning(message)
 
     def on_epoch_end(self, args: argparse.Namespace, accelerator: Accelerator, network, transformer, epoch: int) -> None:
         del network, transformer
@@ -1286,7 +1168,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         network_dtype: torch.dtype,
         **kwargs,
     ) -> DiTOutput:
-        del batch  # timesteps (the pre-shift base sigma) gates the guidance-loss forward
+        del batch
+        base_sigma = _base_sigma_of(timesteps)  # the pre-shift draw gates the guidance/teacher forwards
         audio_latents = kwargs.pop("audio_latents")
         audio_noise = kwargs.pop("audio_noise")
         noisy_audio_input = kwargs.pop("noisy_audio_input")
@@ -1308,14 +1191,15 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
 
         video_target = latents - noise
         audio_target = audio_latents - audio_noise
-        guidance_log: dict[str, torch.Tensor] = {}
+        guidance_log: dict[str, torch.Tensor | float] = {}
+        teacher_conditioned = True
         if self._guidance_uncond is not None:
             # the uncond forward runs before the grad forward so the block-swap offloader
             # keeps its forward->backward alternation and no autograd graph is live yet
-            applied = float(timesteps) >= float(args.h3_guidance_loss_sigma_min)
+            applied = base_sigma >= float(args.h3_guidance_loss_sigma_min)
             # the drawn pre-shift sigma, so the logged gap magnitudes can be binned by noise level
-            guidance_log["guidance/base_sigma"] = torch.as_tensor(float(timesteps))
-            guidance_log["guidance/applied"] = torch.tensor(1.0 if applied else 0.0)
+            guidance_log["guidance/base_sigma"] = base_sigma
+            guidance_log["guidance/applied"] = 1.0 if applied else 0.0
             if applied:
                 video_target, audio_target, gap_log = self._apply_guidance_loss_targets(
                     args,
@@ -1334,7 +1218,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 )
                 guidance_log.update(gap_log)
         if args.h3_teacher_matching:
-            video_target, audio_target, teacher_log = self._apply_teacher_matching_targets(
+            video_target, audio_target, teacher_conditioned, teacher_log = self._apply_teacher_matching_targets(
                 args,
                 accelerator,
                 transformer,
@@ -1349,7 +1233,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 video_target,
                 audio_target,
                 network_dtype,
-                timesteps,
+                base_sigma,
             )
             guidance_log.update(teacher_log)
 
@@ -1385,6 +1269,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 "audio_pred": prediction.audio,
                 "audio_target": audio_target,
                 "audio_loss_weight": audio_loss_weight,
+                "teacher_conditioned": teacher_conditioned,
                 "guidance_log": guidance_log,
             },
         )
@@ -1425,11 +1310,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         visual/audio conditions stay (the same augmented tensors as the main forward).
         """
         uncond_hidden, uncond_tags = self._guidance_uncond
-        if uncond_hidden.shape[1] != runtime.text_hidden_states.shape[2]:
-            raise ValueError(
-                f"MiniMax-H3 guidance-loss uncond cache width {uncond_hidden.shape[1]} does not match"
-                f" the text cache width {runtime.text_hidden_states.shape[2]}"
-            )
         # the probe swaps only the text rows; the one-frame times stay valid because they
         # are relative to the target-block cursor, which moves with the text length. The
         # FL2VA condition roles are recovered from the segments so a one-frame FL2VA layout
@@ -1495,8 +1375,8 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         video_target: torch.Tensor,
         audio_target: torch.Tensor,
         network_dtype: torch.dtype,
-        base_sigma,
-    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor]]:
+        base_sigma: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, bool, dict[str, torch.Tensor | float]]:
         """Replace both flow targets with the frozen base model's predictions.
 
         The teacher shares weights with the student: the same transformer runs once with the
@@ -1528,8 +1408,6 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         reference against a footing-less x_t); anchoring that band to the base also counters
         the collateral drift of the LoRA's shared weights.
         """
-        if runtime.teacher_layout is None or runtime.teacher_text_hidden_states is None:
-            raise RuntimeError("MiniMax-H3 teacher matching batch plan is missing the teacher layout")
         if network is None:
             raise RuntimeError("MiniMax-H3 teacher matching requires the LoRA network to disable it for the teacher forward")
         base_network = accelerator.unwrap_model(network)
@@ -1537,7 +1415,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         # reveals x_0, so every teacher's prediction collapses toward the raw velocity (the
         # complete-information de-amplification channel entering from below)
         sigma_min = float(args.h3_teacher_condition_sigma_min)
-        conditioned = sigma_min <= float(base_sigma) <= float(args.h3_teacher_condition_sigma_max)
+        conditioned = sigma_min <= base_sigma <= float(args.h3_teacher_condition_sigma_max)
         if conditioned:
             teacher_text = runtime.teacher_text_hidden_states
             teacher_tags = runtime.teacher_text_token_tags
@@ -1574,12 +1452,12 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
         # the flow-gap magnitudes measure how far the teacher deviates from the raw velocity
         # target (guidance amplification + endpoint information), binned by base sigma
         teacher_log = {
-            "teacher/base_sigma": torch.as_tensor(float(base_sigma)),
-            "teacher/conditioned": torch.tensor(1.0 if conditioned else 0.0),
+            "teacher/base_sigma": base_sigma,
+            "teacher/conditioned": 1.0 if conditioned else 0.0,
             "teacher/video_flow_gap_rms": (teacher_video - video_target.float()).pow(2).mean().sqrt().detach(),
             "teacher/audio_flow_gap_rms": (teacher_audio - audio_target.float()).pow(2).mean().sqrt().detach(),
         }
-        return teacher_video, teacher_audio, teacher_log
+        return teacher_video, teacher_audio, conditioned, teacher_log
 
     def process_batch(
         self,
@@ -1598,41 +1476,43 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
     ) -> tuple[torch.Tensor, dict[str, float]]:
         del sample_resources
         teacher_conditions = normalize_teacher_conditions(args.h3_teacher_conditions) if args.h3_teacher_matching else None
-        # _runtime_batch_plan rejects batches larger than one item (batch_size=1 rule)
-        runtime = _runtime_batch_plan(batch, latents, teacher_conditions=teacher_conditions, one_frame=bool(args.one_frame))
+        runtime = _runtime_batch_plan(
+            batch, latents, task=args.task, teacher_conditions=teacher_conditions, one_frame=bool(args.one_frame)
+        )
+        for notice in runtime.notices:
+            self._notice(notice)
+        # the shared audio-loss policy validates the cached presence flags
+        audio_loss_weight = effective_audio_loss_weights(runtime.audio_present, args)
         self._audio_items_seen += int(runtime.audio_present.numel())
         self._audio_supervised_seen += int(runtime.audio_present.sum().item())
-        if runtime.layout.task != args.task:
-            raise ValueError(f"MiniMax-H3 --task {args.task} cannot train a {runtime.layout.task.upper()} cache batch")
         device = latents.device
+        noisy_video, timesteps = self.get_noisy_model_input_and_timesteps(
+            args, noise, latents, batch["timesteps"], noise_scheduler, device, dit_dtype
+        )
+        # the audio shares the drawn base sigma under its own shift
+        base = (timesteps[0] - 1.0) / 1000.0
+        sigma_video = shift_sigma(base, args.h3_shift_video)
+        sigma_audio = shift_sigma(base, args.h3_shift_audio)
         audio_latents = batch["latents_audio"].to(device=device)
         audio_noise = torch.randn_like(audio_latents)
-        pool = batch.get("timesteps")
-        if pool is not None and len(pool) != 1:
-            raise ValueError("MiniMax-H3 R1 requires exactly one timestep value for its single-item batch")
-        base = self.sample_timesteps(args, 1, pool, latents, device)[0]
-        base = _apply_timestep_focus(
-            base, float(args.h3_timestep_focus_min), float(args.h3_timestep_focus_max), float(args.h3_timestep_focus_prob)
-        )
-        sigma_video = _shift_noise_amount(base, args.h3_shift_video)
-        sigma_audio = _shift_noise_amount(base, args.h3_shift_audio)
-        model_t_video = 1.0 - sigma_video
-        model_t_audio = 1.0 - sigma_audio
-        noisy_video = (1.0 - sigma_video) * latents + sigma_video * noise
         noisy_audio = (1.0 - sigma_audio) * audio_latents + sigma_audio * audio_noise
 
-        visual_conditions = _augment_conditions(
-            tuple(tensor.to(device) for tensor in runtime.visual_conditions), args.h3_visual_cond_clean
-        )
-        audio_conditions = _augment_conditions(
-            tuple(tensor.to(device) for tensor in runtime.audio_conditions), args.h3_audio_cond_clean
+        visual_conditions, audio_conditions = augment_condition_latents(
+            runtime.visual_conditions,
+            runtime.audio_conditions,
+            generator=None,
+            visual_clean=args.h3_visual_cond_clean,
+            audio_clean=args.h3_audio_cond_clean,
+            device=device,
         )
         # the teacher's conditions get the same per-step augmentation as FL2VA/Ref2VA training
-        teacher_visual_conditions = _augment_conditions(
-            tuple(tensor.to(device) for tensor in runtime.teacher_visual_conditions), args.h3_visual_cond_clean
-        )
-        teacher_audio_conditions = _augment_conditions(
-            tuple(tensor.to(device) for tensor in runtime.teacher_audio_conditions), args.h3_audio_cond_clean
+        teacher_visual_conditions, teacher_audio_conditions = augment_condition_latents(
+            runtime.teacher_visual_conditions,
+            runtime.teacher_audio_conditions,
+            generator=None,
+            visual_clean=args.h3_visual_cond_clean,
+            audio_clean=args.h3_audio_cond_clean,
+            device=device,
         )
         output = self.call_dit(
             args,
@@ -1642,22 +1522,37 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             batch,
             noise,
             noisy_video,
-            base,
+            timesteps,
             network_dtype,
             audio_latents=audio_latents,
             audio_noise=audio_noise,
             noisy_audio_input=noisy_audio,
             runtime=runtime,
-            model_t_video=model_t_video,
-            model_t_audio=model_t_audio,
+            model_t_video=1.0 - sigma_video,
+            model_t_audio=1.0 - sigma_audio,
             visual_conditions=visual_conditions,
             audio_conditions=audio_conditions,
-            audio_loss_weight=effective_audio_loss_weights(runtime.audio_present, args),
+            audio_loss_weight=audio_loss_weight,
             network=network,
             teacher_visual_conditions=teacher_visual_conditions,
             teacher_audio_conditions=teacher_audio_conditions,
         )
-        return self.compute_loss(args, output, base, noise_scheduler, dit_dtype, network_dtype, global_step)
+        return self.compute_loss(args, output, timesteps, noise_scheduler, dit_dtype, network_dtype, global_step)
+
+    def get_noisy_model_input_and_timesteps(self, args, noise, latents, timesteps, noise_scheduler, device, dtype):
+        """The video half of the H3 noising: one base sigma per item from the shared draw (uniform,
+        then the optional timestep focus), shifted by --h3_shift_video. The returned timesteps
+        follow the trainer's 1..1000 convention; process_batch derives the audio noising from the
+        same base sigma under --h3_shift_audio."""
+        del noise_scheduler, dtype
+        base = self.sample_timesteps(args, noise.shape[0], timesteps, latents, device)
+        base = _apply_timestep_focus(
+            base, float(args.h3_timestep_focus_min), float(args.h3_timestep_focus_max), float(args.h3_timestep_focus_prob)
+        )
+        sigma_video = shift_sigma(base, args.h3_shift_video).view(-1, 1, 1, 1, 1)
+        # blended in fp32, stored in the cache dtype (the released FP16 video latents stay FP16)
+        noisy_model_input = ((1.0 - sigma_video) * latents.float() + sigma_video * noise.float()).to(latents.dtype)
+        return noisy_model_input, base * 1000.0 + 1.0
 
     def compute_loss(
         self,
@@ -1671,9 +1566,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
     ) -> tuple[torch.Tensor, dict[str, float]]:
         del timesteps, noise_scheduler, dit_dtype, global_step
         teacher_matching = bool(args.h3_teacher_matching)
-        guidance_log = output.extra.get("guidance_log") or {}
-        conditioned_flag = guidance_log.get("teacher/conditioned")
-        conditioned = bool(conditioned_flag.item() > 0.5) if isinstance(conditioned_flag, torch.Tensor) else True
+        conditioned = bool(output.extra.get("teacher_conditioned", True))
         dc_weight = float(args.h3_teacher_loss_dc_weight)
         mag_weight = float(args.h3_teacher_loss_mag_weight)
 
@@ -1691,15 +1584,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
 
         # the DC attenuation targets the video palette axis; the audio anchor keeps its full DC
         video_loss = flow_loss(output.pred.to(network_dtype), output.target.to(network_dtype), attenuate_dc=True)
-        audio_loss_weight = output.extra.get("audio_loss_weight")
-        if (
-            not isinstance(audio_loss_weight, torch.Tensor)
-            or audio_loss_weight.shape != (1,)
-            or not torch.isfinite(audio_loss_weight).all().item()
-            or audio_loss_weight.item() < 0.0
-        ):
-            raise ValueError("MiniMax-H3 audio loss weight must be a finite nonnegative float32 tensor with shape [1]")
-        weight = audio_loss_weight.item()
+        weight = float(output.extra["audio_loss_weight"].item())
         if weight == 0.0:
             audio_loss = video_loss.detach().new_zeros(())
         else:
@@ -1708,11 +1593,11 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
                 output.extra["audio_target"].to(network_dtype),
                 attenuate_dc=False,
             )
-        logs = {
+        logs: dict[str, torch.Tensor | float] = {
             "loss/video": video_loss.detach(),
             "loss/audio": audio_loss.detach(),
+            **output.extra.get("guidance_log", {}),
         }
-        logs.update(guidance_log)
         total_loss = video_loss + weight * audio_loss
         if teacher_matching and not conditioned:
             # preservation-anchor step: user weight on top of the automatic focus compensation,
@@ -1727,7 +1612,7 @@ class MiniMaxH3NetworkTrainer(NetworkTrainer):
             )
             if multiplier != 1.0:
                 total_loss = total_loss * multiplier
-        return total_loss, logs
+        return total_loss, _scalar_logs(logs)
 
 
 def minimax_h3_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -1915,7 +1800,6 @@ def main() -> None:
     args = parser.parse_args()
     args = read_config_from_file(args, parser)
     args.dit_dtype = "bfloat16" if args.dit_dtype is None else args.dit_dtype
-    args.vae_dtype = "bfloat16" if args.vae_dtype is None else args.vae_dtype
     MiniMaxH3NetworkTrainer().train(args)
 
 

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -104,6 +104,20 @@ DIRECT_TIMESTEP_SAMPLING_METHODS = frozenset(
 )
 
 
+def wandb_tracker_and_module(accelerator):
+    """``(tracker, wandb)`` when a wandb tracker is active and wandb is importable, else ``(None, None)``."""
+    try:
+        tracker = accelerator.get_tracker("wandb")  # raises ValueError if wandb is not initialized
+    except (AttributeError, ValueError):
+        return None, None
+    try:
+        import wandb
+    except ImportError:
+        logger.warning("wandb tracker is active but wandb is not installed / wandb がインストールされていないようです")
+        return None, None
+    return tracker, wandb
+
+
 @dataclass
 class DiTOutput:
     """Return type for ``NetworkTrainer.call_dit``.
@@ -953,7 +967,7 @@ class NetworkTrainer:
         width = (width // 8) * 8
         height = (height // 8) * 8
 
-        frame_count = round_down_frame_count(frame_count, self.architecture, self.vae_frame_stride)
+        frame_count = self.round_sample_frame_count(frame_count)
 
         if self.i2v_training:
             image_path = sample_parameter.get("image_path", None)
@@ -1049,31 +1063,37 @@ class NetworkTrainer:
             f"{'' if args.output_name is None else args.output_name + '_'}{num_suffix}_{prompt_idx:02d}_{ts_str}{seed_suffix}"
         )
 
-        wandb_tracker = None
-        try:
-            wandb_tracker = accelerator.get_tracker("wandb")  # raises ValueError if wandb is not initialized
-            try:
-                import wandb
-            except ImportError:
-                raise ImportError("No wandb / wandb がインストールされていないようです")
-        except:  # wandb 無効時
-            wandb = None
-
-        if video.shape[2] == 1:
-            # In Qwen-Image-Layered, video is (N, C, 1, H, W) where N=Layers, otherwise (1, C, 1, H, W)
-            image_paths = save_images_grid(video, save_dir, save_path, n_rows=video.shape[0], create_subdir=False)
-            if wandb_tracker is not None and wandb is not None:
-                for image_path in image_paths:
-                    wandb_tracker.log({f"sample_{prompt_idx}": wandb.Image(image_path)}, step=steps)
-        else:
-            video_path = os.path.join(save_dir, save_path) + ".mp4"
-            save_videos_grid(video, video_path)
-            if wandb_tracker is not None and wandb is not None:
-                wandb_tracker.log({f"sample_{prompt_idx}": wandb.Video(video_path)}, step=steps)
+        self.save_sample(accelerator, args, sample_parameter, video, save_dir, save_path, steps)
 
         # Move models back to initial state
         vae.to("cpu")
         clean_memory_on_device(device)
+
+    def round_sample_frame_count(self, frame_count: int) -> int:
+        """Snaps a sample prompt's frame count (``--f``) onto the architecture's frame grid."""
+        return round_down_frame_count(frame_count, self.architecture, self.vae_frame_stride)
+
+    def save_sample(self, accelerator, args, sample_parameter, sample, save_dir: str, save_path: str, steps: int) -> None:
+        """Writes the value ``do_inference`` returned under ``save_dir/save_path`` (a stem without
+        extension) and logs it to wandb when a tracker is active.
+
+        Default: ``sample`` is a ``(N, C, F, H, W)`` video tensor in [0, 1], saved as an image grid
+        for single-frame outputs and as an mp4 otherwise. Architectures whose samples are not a
+        plain video tensor (e.g. joint audio/video) override this.
+        """
+        prompt_idx = sample_parameter.get("enum", 0)
+        wandb_tracker, wandb = wandb_tracker_and_module(accelerator)
+        if sample.shape[2] == 1:
+            # In Qwen-Image-Layered, video is (N, C, 1, H, W) where N=Layers, otherwise (1, C, 1, H, W)
+            image_paths = save_images_grid(sample, save_dir, save_path, n_rows=sample.shape[0], create_subdir=False)
+            if wandb_tracker is not None:
+                for image_path in image_paths:
+                    wandb_tracker.log({f"sample_{prompt_idx}": wandb.Image(image_path)}, step=steps)
+        else:
+            video_path = os.path.join(save_dir, save_path) + ".mp4"
+            save_videos_grid(sample, video_path)
+            if wandb_tracker is not None:
+                wandb_tracker.log({f"sample_{prompt_idx}": wandb.Video(video_path)}, step=steps)
 
     # region model specific (abstract hooks — implemented by architecture-specific subclasses)
 

--- a/tests/test_minimax_h3_convrot_runtime.py
+++ b/tests/test_minimax_h3_convrot_runtime.py
@@ -66,10 +66,12 @@ def _load_training_module(monkeypatch):
     _stub(
         monkeypatch,
         "musubi_tuner.minimax_h3.sampling",
-        decoded_video_to_uint8=noop,
+        H3DecodedAV=object,
+        augment_condition_latents=noop,
         sample_joint_av_latents=noop,
+        shift_sigma=noop,
         synchronize_decoded_av=noop,
-        write_image=noop,
+        validate_shift=noop,
         write_joint_av=noop,
     )
     _stub(
@@ -77,6 +79,7 @@ def _load_training_module(monkeypatch):
         "musubi_tuner.minimax_h3.text_encoder",
         TEACHER_CONDITIONS_REF="ref",
         TEACHER_CONDITIONS_SUBJECT_REF="subject_ref",
+        TEACHER_TEXT_CACHE_PREFIXES={},
         build_presentation=noop,
         encode_h3_presentation=noop,
         load_h3_processor=noop,
@@ -116,7 +119,13 @@ def _load_training_module(monkeypatch):
     class NetworkTrainer:
         pass
 
-    _stub(monkeypatch, "musubi_tuner.training.trainer_base", DiTOutput=SimpleNamespace, NetworkTrainer=NetworkTrainer)
+    _stub(
+        monkeypatch,
+        "musubi_tuner.training.trainer_base",
+        DiTOutput=SimpleNamespace,
+        NetworkTrainer=NetworkTrainer,
+        wandb_tracker_and_module=noop,
+    )
     _stub(monkeypatch, "musubi_tuner.utils.device_utils", clean_memory_on_device=noop, synchronize_device=noop)
     model_utils = _stub(monkeypatch, "musubi_tuner.utils.model_utils", compile_transformer=noop)
     spec = importlib.util.spec_from_file_location(

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -65,11 +65,6 @@ def test_process_batch_accumulates_observed_audio_supervision(monkeypatch):
     assert trainer.extra_metadata(args)["ss_minimax_h3_supervised_audio_fraction"] == 0.5
 
 
-def test_h3_rejects_the_single_vae_prompt_seam_with_a_pointer_to_prepare_sampling():
-    with pytest.raises(NotImplementedError, match="prepare_sampling"):
-        MiniMaxH3NetworkTrainer().process_sample_prompts(_trainer_args(), _Accelerator(), "prompts.json")
-
-
 def test_h3_warns_after_the_first_epoch_when_no_real_audio_was_seen(caplog):
     trainer = MiniMaxH3NetworkTrainer()
     trainer._audio_items_seen = 3
@@ -456,6 +451,10 @@ def test_h3_training_sample_uses_the_live_transformer_then_decodes_and_muxes_bot
     )
     sample_parameter = {
         "enum": 0,
+        # prepare_sampling copies the resolved request coordinates back for the base sampler
+        "frame_count": 5,
+        "sample_steps": 2,
+        "seed": 123,
         "h3_request": H3GenerationRequest(
             task="t2va", prompt="joint sample", steps=2, width=64, height=64, frame_count=5, seed=123, output_fps=output_fps
         ),
@@ -469,9 +468,10 @@ def test_h3_training_sample_uses_the_live_transformer_then_decodes_and_muxes_bot
         output_dir=str(tmp_path),
         output_name="h3",
     )
+    trainer.handle_model_specific_args(args)
     transformer = Transformer()
 
-    output = trainer.sample_image_inference(
+    trainer.sample_image_inference(
         _Accelerator(),
         args,
         transformer,
@@ -483,7 +483,10 @@ def test_h3_training_sample_uses_the_live_transformer_then_decodes_and_muxes_bot
         12,
     )
 
-    assert output == captured["output_path"]
+    # the base sampler's naming: <output_name>_<step>_<prompt index>_<timestamp>_<seed>.mp4
+    assert captured["output_path"].parent == tmp_path
+    assert captured["output_path"].name.startswith("h3_000012_00_")
+    assert captured["output_path"].stem.endswith("_123")
     assert captured["output_path"].suffix == ".mp4"
     assert captured["decoded"].video.shape == (5, 8, 8, 3)
     # the container plays the 5 frames at the sample's rate and the audio covers that duration
@@ -491,6 +494,110 @@ def test_h3_training_sample_uses_the_live_transformer_then_decodes_and_muxes_bot
     assert captured["decoded"].audio.shape == (2, audio_samples)
     assert events.index("sample_live_transformer") < events.index("decode_video") < events.index("decode_audio")
     assert transformer.training is True
+
+
+def test_h3_one_frame_training_sample_is_saved_by_the_base_image_path(tmp_path, monkeypatch):
+    # a one-frame sample decodes only the video frame and hands the base sampler a plain image
+    # tensor, so it lands as <stem>_000.png like every other architecture's image sample
+    import musubi_tuner.minimax_h3_train_network as train
+    from musubi_tuner.minimax_h3.packing import H3TimeOverrides
+
+    events = []
+
+    class Transformer:
+        training = True
+
+        def eval(self):
+            self.training = False
+            return self
+
+        def train(self, mode=True):
+            self.training = mode
+            return self
+
+        def __call__(self, **kwargs):
+            return SimpleNamespace(
+                video=torch.zeros_like(kwargs["video_latents"]),
+                audio=torch.zeros_like(kwargs["audio_latents"]),
+            )
+
+    class VideoVAE(torch.nn.Module):
+        def decode(self, latents):
+            events.append("decode_video")
+            assert latents.shape == (1, 24, 1, 4, 4)
+            return torch.full((1, 3, 1, 8, 8), -1.0)
+
+    class AudioVAE(torch.nn.Module):
+        def decode(self, latents):
+            events.append("decode_audio")
+            return torch.zeros(1, 2, 16)
+
+    monkeypatch.setattr(train, "write_joint_av", lambda *args, **kwargs: events.append("write_joint_av"))
+    trainer = train.MiniMaxH3NetworkTrainer()
+    layout = build_h3_layout(
+        task="t2va",
+        text_length=3,
+        target_video=H3VideoGeometry(1, 4, 4),
+        target_audio_frames=2,
+        one_frame=True,
+        time_overrides=H3TimeOverrides((), 0.0),
+    )
+    sample_parameter = {
+        "enum": 1,
+        "frame_count": 1,
+        "sample_steps": 2,
+        "seed": 7,
+        "h3_request": H3GenerationRequest(task="t2va", prompt="one frame", steps=2, width=64, height=64, frame_count=1, seed=7),
+        "h3_layout": layout,
+        "h3_text_hidden_states": torch.zeros(1, 3, 12),
+        "h3_text_token_tags": torch.tensor([[1, 0, 1]], dtype=torch.int64),
+        "h3_visual_conditions": (),
+        "h3_audio_conditions": (),
+    }
+    args = _trainer_args(output_dir=str(tmp_path), output_name="h3")
+    trainer.handle_model_specific_args(args)
+
+    trainer.sample_image_inference(
+        _Accelerator(),
+        args,
+        Transformer(),
+        torch.bfloat16,
+        train.H3SamplingResources(video_vae=VideoVAE(), audio_vae=AudioVAE()),
+        str(tmp_path),
+        sample_parameter,
+        3,
+        12,
+    )
+
+    assert events == ["decode_video"]
+    written = sorted(path.name for path in tmp_path.iterdir())
+    assert len(written) == 1
+    assert written[0].startswith("h3_e000003_01_") and written[0].endswith("_7_000.png")
+
+
+def test_h3_sample_frame_counts_keep_one_frame_and_round_video_onto_the_grid():
+    trainer = MiniMaxH3NetworkTrainer()
+    assert trainer.round_sample_frame_count(1) == 1
+    assert trainer.round_sample_frame_count(23) == 22
+    assert trainer.round_sample_frame_count(124) == 124
+
+
+def test_h3_save_sample_logs_the_joint_video_to_wandb_at_the_sample_rate(tmp_path, monkeypatch):
+    import musubi_tuner.minimax_h3_train_network as train
+    from musubi_tuner.minimax_h3.sampling import H3DecodedAV
+
+    logged = []
+    videos = []
+    tracker = SimpleNamespace(log=lambda payload, step: logged.append((payload, step)))
+    fake_wandb = SimpleNamespace(Video=lambda path, fps: videos.append((path, fps)) or ("video", path, fps))
+    monkeypatch.setattr(train, "wandb_tracker_and_module", lambda accelerator: (tracker, fake_wandb))
+    monkeypatch.setattr(train, "write_joint_av", lambda decoded, output_path: None)
+    decoded = H3DecodedAV(video=torch.zeros(5, 8, 8, 3, dtype=torch.uint8), audio=torch.zeros(2, 16), fps=12)
+
+    train.MiniMaxH3NetworkTrainer().save_sample(_Accelerator(), _trainer_args(), {"enum": 2}, decoded, str(tmp_path), "stem", 40)
+
+    assert videos == [(str(tmp_path / "stem.mp4"), 12)]
+    assert logged == [({"sample_2": ("video", str(tmp_path / "stem.mp4"), 12)}, 40)]
 
 
 def test_prepare_training_samples_encodes_text_once_and_returns_both_vaes_as_sampling_resources(tmp_path, monkeypatch):
@@ -580,6 +687,14 @@ def test_prepare_training_samples_encodes_text_once_and_returns_both_vaes_as_sam
     parameter = sample_parameters[0]
     assert parameter["h3_layout"].task == "t2va"
     assert parameter["h3_request"].frame_count == 22  # 23 rounds down to the 17*n+5 grid
+    # the resolved coordinates are copied back for the base sampler's logging and seeding
+    assert (parameter["width"], parameter["height"], parameter["frame_count"], parameter["sample_steps"], parameter["seed"]) == (
+        64,
+        64,
+        22,
+        2,
+        123,
+    )
     assert parameter["h3_layout"].target_video == H3VideoGeometry(7, 4, 4)
     assert parameter["h3_layout"].target_audio_frames == 37
     assert parameter["h3_text_hidden_states"].shape == (1, 3, 12)
@@ -919,35 +1034,27 @@ def test_runtime_rejects_batch_size_above_one():
         )
 
 
-def test_runtime_rejects_more_than_one_timestep_for_the_single_item():
+def test_noising_follows_the_trainer_timestep_convention_with_the_video_shift(monkeypatch):
+    # the seam returns the drawn base sigma in the base trainer's 1..1000 convention while the
+    # noisy input carries the shifted video sigma (base 0.25 -> 0.8 under shift 12)
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args()
     trainer.handle_model_specific_args(args)
-    video_latents = torch.zeros(1, 24, 2, 4, 4)
-    batch = _training_batch()
-    batch["timesteps"] = [0.1, 0.2]
-    with pytest.raises(ValueError, match="exactly one timestep"):
-        trainer.process_batch(
-            args,
-            _Accelerator(),
-            _RecordingTransformer(),
-            None,
-            batch,
-            video_latents,
-            torch.zeros_like(video_latents),
-            None,
-            torch.bfloat16,
-            torch.float32,
-            None,
-            0,
-        )
+    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
+    latents = torch.full((1, 24, 2, 4, 4), 5.0, dtype=torch.float16)
+    noise = torch.full_like(latents, -2.0)
+
+    noisy, timesteps = trainer.get_noisy_model_input_and_timesteps(args, noise, latents, None, None, torch.device("cpu"), None)
+
+    assert timesteps.tolist() == [251.0]
+    assert noisy.dtype == torch.float16
+    assert torch.allclose(noisy.float(), torch.full_like(latents, -0.6).float())
 
 
 @pytest.mark.parametrize(
     "present",
     [
         torch.tensor(1.0, dtype=torch.float32),
-        torch.tensor([1.0], dtype=torch.float64),
         torch.tensor([float("nan")], dtype=torch.float32),
         torch.tensor([0.5], dtype=torch.float32),
         torch.tensor([0.0, 1.0], dtype=torch.float32),
@@ -981,13 +1088,21 @@ def test_runtime_rejects_invalid_audio_present_before_transformer(present: torch
     assert transformer.calls == []
 
 
-def test_runtime_rejects_a_batch_from_a_different_authoritative_task():
+@pytest.mark.parametrize(
+    ("task", "message"),
+    [
+        ("ref2va", r"Ref2VA batch requires latents_ref_000_\*.*--task ref2va"),
+        ("fl2va", r"FL2VA batch requires latents_first/latents_last.*--task fl2va"),
+    ],
+)
+def test_runtime_requires_the_condition_latents_of_the_authoritative_task(task, message):
+    # --task decides which cache entries are read; a t2va cache lacks what fl2va/ref2va need
     trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(task="ref2va")
+    args = _trainer_args(task=task)
     trainer.handle_model_specific_args(args)
     video_latents = torch.zeros(1, 24, 2, 4, 4)
 
-    with pytest.raises(ValueError, match=r"--task ref2va.*T2VA"):
+    with pytest.raises(ValueError, match=message):
         trainer.process_batch(
             args,
             _Accelerator(),
@@ -1002,6 +1117,85 @@ def test_runtime_rejects_a_batch_from_a_different_authoritative_task():
             None,
             0,
         )
+
+
+def _fl_batch():
+    batch = _training_batch()
+    batch["latents_first"] = torch.zeros(1, 24, 1, 4, 4)
+    batch["latents_last"] = torch.zeros(1, 24, 1, 4, 4)
+    return batch
+
+
+@pytest.mark.parametrize(
+    ("overrides", "batch_factory", "unused"),
+    [
+        # a t2va run on an fl2va cache: the task never reads the endpoint latents
+        ({}, _fl_batch, "latents_first, latents_last"),
+        # a one-frame t2va/ref2va cache with control indices only fl2va would time
+        (
+            {"one_frame": True},
+            lambda: {**_one_frame_batch(), "one_frame_control_indices": torch.tensor([[0]])},
+            "one_frame_control_indices",
+        ),
+        (
+            {"task": "ref2va", "one_frame": True},
+            lambda: {**_one_frame_ref_batch(), "one_frame_control_indices": torch.tensor([[0]])},
+            "one_frame_control_indices",
+        ),
+        # a video batch carrying one-frame index tensors
+        ({}, lambda: {**_training_batch(), "one_frame_target_index": torch.tensor([0])}, "one_frame_target_index"),
+        # FL2VA endpoint latents next to Ref2VA references
+        (
+            {"task": "ref2va", "one_frame": True},
+            lambda: {**_one_frame_ref_batch(), "latents_first": torch.zeros(1, 24, 1, 4, 4)},
+            "latents_first",
+        ),
+        # teacher text rows without the teacher-matching flag
+        ({}, lambda: _teacher_batch(), "latents_first, latents_last, mmh3_teacher_hidden_states, mmh3_teacher_token_tags"),
+        ({}, lambda: _ref_teacher_batch(), "mmh3_teacher_ref_hidden_states, mmh3_teacher_ref_token_tags"),
+        # the subject_ref teacher does not time its references
+        (
+            {"h3_teacher_matching": True, "h3_teacher_conditions": "subject_ref", "one_frame": True},
+            lambda: {**_subject_ref_teacher_batch(one_frame=True), "one_frame_control_indices": torch.tensor([[0]])},
+            "one_frame_control_indices",
+        ),
+        (
+            {"h3_teacher_matching": True, "h3_teacher_conditions": "subject_ref"},
+            lambda: {**_subject_ref_teacher_batch(), "latents_first": torch.zeros(1, 24, 1, 4, 4)},
+            "latents_first",
+        ),
+    ],
+)
+def test_cache_entries_the_task_does_not_read_are_ignored_with_one_warning(monkeypatch, caplog, overrides, batch_factory, unused):
+    trainer = MiniMaxH3NetworkTrainer()
+    args = _trainer_args(**overrides)
+    trainer.handle_model_specific_args(args)
+    _patch_deterministic_noise(monkeypatch)
+    network = _ToggleNetwork()
+    transformer = _TeacherAwareTransformer(network)
+
+    with caplog.at_level(logging.WARNING, logger="musubi_tuner.minimax_h3_train_network"):
+        for _ in range(2):
+            video_latents = torch.zeros(1, 24, 1 if args.one_frame else 2, 4, 4)
+            trainer.process_batch(
+                args,
+                _Accelerator(),
+                transformer,
+                network,
+                batch_factory(),
+                video_latents,
+                torch.zeros_like(video_latents),
+                None,
+                torch.bfloat16,
+                torch.float32,
+                None,
+                0,
+            )
+
+    warnings = [record.getMessage() for record in caplog.records if "are not used by" in record.getMessage()]
+    assert len(warnings) == 1
+    assert f"batch entries {unused} are not used by --task {args.task}" in warnings[0]
+    assert transformer.calls, "the batch still trains on the entries the task does read"
 
 
 def _one_frame_batch(target_index: int | None = 24):
@@ -1067,7 +1261,7 @@ def test_one_frame_batch_requires_the_training_flag():
 
 @pytest.mark.parametrize(
     "index",
-    [None, torch.tensor(24, dtype=torch.int64), torch.tensor([24], dtype=torch.int32), torch.tensor([-1], dtype=torch.int64)],
+    [None, torch.tensor(24, dtype=torch.int64), torch.tensor([-1], dtype=torch.int64)],
 )
 def test_one_frame_batch_requires_a_valid_index_tensor(index):
     trainer = MiniMaxH3NetworkTrainer()
@@ -1132,7 +1326,6 @@ def test_one_frame_fl2va_batch_requires_the_control_indices_tensor():
     "indices",
     [
         torch.tensor([0], dtype=torch.int64),  # missing batch axis
-        torch.tensor([[0]], dtype=torch.int32),
         torch.tensor([[-1]], dtype=torch.int64),
     ],
 )
@@ -1166,18 +1359,8 @@ def test_one_frame_fl2va_batch_requires_matching_condition_and_index_counts():
     trainer.handle_model_specific_args(args)
     batch = _one_frame_fl_batch(control_indices=[0, 48], roles=("cond_000",))
 
-    with pytest.raises(ValueError, match="re-run latent caching"):
-        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
-
-
-def test_one_frame_t2va_batch_rejects_stray_control_indices():
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(one_frame=True)
-    trainer.handle_model_specific_args(args)
-    batch = _one_frame_batch()
-    batch["one_frame_control_indices"] = torch.tensor([[0]], dtype=torch.int64)
-
-    with pytest.raises(ValueError, match="T2VA/Ref2VA batch cannot carry one_frame_control_indices"):
+    # the layout builder owns the conditions/times invariant
+    with pytest.raises(ValueError, match="one condition time override per condition"):
         _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
 
 
@@ -1217,74 +1400,18 @@ def test_one_frame_ref2va_batch_builds_the_reference_layout(monkeypatch, with_vi
     assert trainer._audio_supervised_seen == 0
 
 
-def test_one_frame_ref2va_batch_rejects_stray_control_indices():
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(task="ref2va", one_frame=True)
-    trainer.handle_model_specific_args(args)
-    batch = _one_frame_ref_batch()
-    batch["one_frame_control_indices"] = torch.tensor([[0]], dtype=torch.int64)
-
-    with pytest.raises(ValueError, match="T2VA/Ref2VA batch cannot carry one_frame_control_indices"):
-        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
-
-
-def test_one_frame_ref2va_batch_rejects_mixed_fl_conditions():
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(task="ref2va", one_frame=True)
-    trainer.handle_model_specific_args(args)
-    batch = _one_frame_ref_batch()
-    batch["latents_first"] = torch.zeros(1, 24, 1, 4, 4)
-
-    with pytest.raises(ValueError, match="cannot mix FL2VA and Ref2VA"):
-        _one_frame_process_batch(trainer, args, batch, _RecordingTransformer())
-
-
 def test_one_frame_coinciding_control_and_target_indices_warn_once(monkeypatch, caplog):
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(task="fl2va", one_frame=True)
     trainer.handle_model_specific_args(args)
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
-    import musubi_tuner.minimax_h3_train_network as train_module
 
-    monkeypatch.setattr(train_module, "_coinciding_one_frame_indices_warned", False)
     with caplog.at_level(logging.WARNING):
         for _ in range(2):
             _one_frame_process_batch(trainer, args, _one_frame_fl_batch(control_indices=[24]), _RecordingTransformer())
 
     warnings = [record for record in caplog.records if "verbatim anchor copying" in record.getMessage()]
     assert len(warnings) == 1
-
-
-@pytest.mark.parametrize(
-    ("extra_key", "message"),
-    [
-        ("one_frame_target_index", "one-frame index tensors"),
-        ("one_frame_control_indices", "one-frame index tensors"),
-    ],
-)
-def test_video_batch_rejects_stray_one_frame_index_tensors(extra_key, message):
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(one_frame=True)
-    trainer.handle_model_specific_args(args)
-    video_latents = torch.zeros(1, 24, 2, 4, 4)
-    batch = _training_batch()
-    batch[extra_key] = torch.tensor([0], dtype=torch.int64)
-
-    with pytest.raises(ValueError, match=message):
-        trainer.process_batch(
-            args,
-            _Accelerator(),
-            _RecordingTransformer(),
-            None,
-            batch,
-            video_latents,
-            torch.zeros_like(video_latents),
-            None,
-            torch.bfloat16,
-            torch.float32,
-            None,
-            0,
-        )
 
 
 @pytest.mark.parametrize(
@@ -1498,16 +1625,25 @@ def test_compute_loss_is_video_mean_plus_weighted_audio_mean_mse():
     assert metrics["loss/audio"] == pytest.approx(2.0)
 
 
-def test_compute_loss_requires_the_audio_weight_tensor():
+def test_compute_loss_returns_plain_float_metrics_from_tensor_logs():
+    # the process_batch contract is dict[str, float]; call_dit's tensor logs are fetched in one go
     trainer = MiniMaxH3NetworkTrainer()
     output = DiTOutput(
-        pred=torch.tensor([1.0]),
-        target=torch.tensor([3.0]),
-        extra={"audio_pred": torch.tensor([0.0]), "audio_target": torch.tensor([2.0])},
+        pred=torch.tensor([1.0, 5.0]),
+        target=torch.tensor([3.0, 1.0]),
+        extra={
+            "audio_pred": torch.tensor([0.0, 2.0]),
+            "audio_target": torch.tensor([2.0, 2.0]),
+            "audio_loss_weight": torch.tensor([1.0], dtype=torch.float32),
+            "guidance_log": {"guidance/base_sigma": 0.25, "guidance/video_gap_rms": torch.tensor(2.0)},
+        },
     )
 
-    with pytest.raises(ValueError, match="audio loss weight"):
-        trainer.compute_loss(_trainer_args(), output, torch.tensor(0.25), object(), torch.bfloat16, torch.float32, 7)
+    _, metrics = trainer.compute_loss(_trainer_args(), output, torch.tensor([251.0]), object(), torch.bfloat16, torch.float32, 7)
+
+    assert all(type(value) is float for value in metrics.values())
+    assert metrics["guidance/base_sigma"] == 0.25
+    assert metrics["guidance/video_gap_rms"] == 2.0
 
 
 def test_compute_loss_skips_audio_expression_and_gradient_for_zero_weight():
@@ -1805,6 +1941,7 @@ def test_guidance_loss_rewrites_both_targets_around_the_uncond_prediction(tmp_pa
     trainer = MiniMaxH3NetworkTrainer()
     args = _trainer_args(h3_guidance_loss_scale=3.0, h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path))
     trainer.handle_model_specific_args(args)
+    trainer.on_train_start(args, _Accelerator(), None, None, None)
     transformer = _RecordingTransformer(video_prediction=2.0, audio_prediction=-1.0)
     batch = _training_batch()
     video_latents = torch.zeros(1, 24, 2, 4, 4)
@@ -1857,6 +1994,7 @@ def test_guidance_loss_uncond_layout_carries_the_one_frame_overrides(tmp_path, m
         h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
     )
     trainer.handle_model_specific_args(args)
+    trainer.on_train_start(args, _Accelerator(), None, None, None)
     transformer = _RecordingTransformer()
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
@@ -1885,6 +2023,7 @@ def test_guidance_loss_uncond_layout_carries_one_frame_fl_condition_roles(tmp_pa
         h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
     )
     trainer.handle_model_specific_args(args)
+    trainer.on_train_start(args, _Accelerator(), None, None, None)
     transformer = _RecordingTransformer()
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
@@ -1911,6 +2050,7 @@ def test_guidance_loss_uncond_layout_carries_one_frame_references(tmp_path, monk
         h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
     )
     trainer.handle_model_specific_args(args)
+    trainer.on_train_start(args, _Accelerator(), None, None, None)
     transformer = _RecordingTransformer()
     monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
     monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
@@ -1938,6 +2078,7 @@ def test_guidance_loss_audio_scale_can_differ_from_video(tmp_path, monkeypatch):
         h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
     )
     trainer.handle_model_specific_args(args)
+    trainer.on_train_start(args, _Accelerator(), None, None, None)
     transformer = _RecordingTransformer(video_prediction=2.0, audio_prediction=-1.0)
     batch = _training_batch()
     video_latents = torch.zeros(1, 24, 2, 4, 4)
@@ -1971,6 +2112,7 @@ def test_guidance_loss_sigma_gate_skips_the_uncond_forward(tmp_path, monkeypatch
         h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path),
     )
     trainer.handle_model_specific_args(args)
+    trainer.on_train_start(args, _Accelerator(), None, None, None)
     transformer = _RecordingTransformer(video_prediction=2.0)
     batch = _training_batch()
     video_latents = torch.zeros(1, 24, 2, 4, 4)
@@ -2000,30 +2142,18 @@ def test_guidance_loss_sigma_gate_skips_the_uncond_forward(tmp_path, monkeypatch
     assert metrics["loss/video"] == pytest.approx(torch.nn.functional.mse_loss(torch.tensor(2.0), torch.tensor(0.0)).item())
 
 
-def test_guidance_loss_rejects_a_width_mismatch_against_the_text_cache(tmp_path, monkeypatch):
+def test_guidance_loss_uncond_cache_is_checked_at_args_time_and_loaded_at_train_start(tmp_path):
     trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(h3_guidance_loss_scale=3.0, h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path, width=8))
-    trainer.handle_model_specific_args(args)
-    batch = _training_batch()
-    video_latents = torch.zeros(1, 24, 2, 4, 4)
-    monkeypatch.setattr(torch, "rand", lambda shape, **kwargs: torch.tensor([0.25], device=kwargs.get("device")))
-    monkeypatch.setattr(torch, "randn_like", lambda tensor, *args, **kwargs: torch.zeros_like(tensor))
-
-    with pytest.raises(ValueError, match="width"):
-        trainer.process_batch(
-            args,
-            _Accelerator(),
-            _RecordingTransformer(),
-            None,
-            batch,
-            video_latents,
-            torch.zeros_like(video_latents),
-            None,
-            torch.bfloat16,
-            torch.float32,
-            None,
-            0,
+    with pytest.raises(ValueError, match="h3_guidance_loss_uncond_cache does not exist"):
+        trainer.handle_model_specific_args(
+            _trainer_args(h3_guidance_loss_scale=3.0, h3_guidance_loss_uncond_cache=str(tmp_path / "missing.safetensors"))
         )
+
+    args = _trainer_args(h3_guidance_loss_scale=3.0, h3_guidance_loss_uncond_cache=_uncond_cache(tmp_path))
+    trainer.handle_model_specific_args(args)
+    assert trainer._guidance_uncond is None
+    trainer.on_train_start(args, _Accelerator(), None, None, None)
+    assert trainer._guidance_uncond[0].shape == (2, 12)
 
 
 def test_guidance_loss_metadata_is_recorded_only_when_active(tmp_path):
@@ -2257,7 +2387,7 @@ def _dc_split_output(conditioned: float) -> DiTOutput:
         "audio_pred": None,
         "audio_target": None,
         "audio_loss_weight": torch.tensor([0.0]),
-        "guidance_log": {"teacher/conditioned": torch.tensor(conditioned)},
+        "teacher_conditioned": conditioned > 0.5,
     }
     return DiTOutput(pred=pred, target=target, extra=extra)
 
@@ -2275,7 +2405,7 @@ def test_compute_loss_attenuates_the_video_residual_dc_component_on_teaching_ste
             torch.float32,
             0,
         )
-        assert logs["loss/video"].item() == pytest.approx(expected)
+        assert logs["loss/video"] == pytest.approx(expected)
         assert loss.item() == pytest.approx(expected)
 
 
@@ -2294,7 +2424,7 @@ def test_compute_loss_keeps_full_dc_and_applies_the_preservation_weight_on_ancho
 
     # the anchor step ignores the DC attenuation (full MSE value) and doubles the returned loss;
     # loss/video is logged unweighted so sigma-binned reads stay comparable
-    assert logs["loss/video"].item() == pytest.approx(2.5)
+    assert logs["loss/video"] == pytest.approx(2.5)
     assert loss.item() == pytest.approx(5.0)
 
 
@@ -2306,12 +2436,12 @@ def test_compute_loss_keeps_the_full_magnitude_term_on_anchor_steps():
 
     # anchor step: mag_weight is ignored, the loss keeps the full MSE value
     _, anchor_logs = trainer.compute_loss(args, _dc_split_output(conditioned=0.0), None, None, torch.bfloat16, torch.float32, 0)
-    assert anchor_logs["loss/video"].item() == pytest.approx(2.5)
+    assert anchor_logs["loss/video"] == pytest.approx(2.5)
 
     # conditioned step: mag_weight 0 drops the magnitude term (the fixture residual is a
     # target of zeros, so the direction term vanishes too and only the magnitude term remains)
     _, edu_logs = trainer.compute_loss(args, _dc_split_output(conditioned=1.0), None, None, torch.bfloat16, torch.float32, 0)
-    assert edu_logs["loss/video"].item() == pytest.approx(0.0, abs=1e-6)
+    assert edu_logs["loss/video"] == pytest.approx(0.0, abs=1e-6)
 
 
 def test_preservation_density_compensation_restores_the_anchor_share_under_focus():
@@ -2481,24 +2611,6 @@ def test_teacher_matching_requires_fl2va_latent_caches(monkeypatch):
         _teacher_matching_process_batch(trainer, args, batch, network=_ToggleNetwork())
 
 
-def test_teacher_text_rows_are_rejected_without_the_teacher_matching_flag():
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args()
-    trainer.handle_model_specific_args(args)
-
-    with pytest.raises(ValueError, match="--h3_teacher_matching"):
-        _teacher_matching_process_batch(trainer, args, _teacher_batch(), network=None)
-
-
-def test_teacher_matching_rejects_a_teacher_text_width_mismatch(monkeypatch):
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(h3_teacher_matching=True)
-    trainer.handle_model_specific_args(args)
-
-    with pytest.raises(ValueError, match="width"):
-        _teacher_matching_process_batch(trainer, args, _teacher_batch(teacher_width=8), network=_ToggleNetwork())
-
-
 # --- ref teacher (Ref2VA self-reference teacher for a T2VA student) ---
 
 
@@ -2616,9 +2728,9 @@ def test_ref_teacher_switches_to_the_preservation_anchor_above_sigma_max(monkeyp
     [
         # the text cache kind must match the configured teacher conditions: distinct tensor
         # keys per kind turn a cache/flag mismatch into a hard error instead of a silent desync
-        ("ref", _teacher_batch, "first,last teacher rows"),
-        ("ref", _training_batch, "reference teacher text rows"),
-        ("first,last", lambda: _ref_teacher_batch(include_fl=True), "ref teacher rows"),
+        ("ref", _teacher_batch, "requires ref teacher text rows.*--teacher_conditions ref"),
+        ("ref", _training_batch, "requires ref teacher text rows"),
+        ("first,last", lambda: _ref_teacher_batch(include_fl=True), "requires first,last teacher text rows"),
     ],
 )
 def test_teacher_mode_and_text_cache_kind_must_match(conditions, batch_factory, message):
@@ -2628,15 +2740,6 @@ def test_teacher_mode_and_text_cache_kind_must_match(conditions, batch_factory, 
 
     with pytest.raises(ValueError, match=message):
         _teacher_matching_process_batch(trainer, args, batch_factory(), network=_ToggleNetwork())
-
-
-def test_ref_teacher_text_rows_are_rejected_without_the_teacher_matching_flag():
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args()
-    trainer.handle_model_specific_args(args)
-
-    with pytest.raises(ValueError, match="--h3_teacher_matching"):
-        _teacher_matching_process_batch(trainer, args, _ref_teacher_batch(), network=None)
 
 
 def _subject_ref_teacher_batch(
@@ -2738,9 +2841,8 @@ def test_subject_ref_teacher_switches_to_the_preservation_anchor_below_sigma_min
     [
         (lambda: _subject_ref_teacher_batch(reference_count=0), "requires the item's reference latents"),
         (lambda: _subject_ref_teacher_batch(include_video_reference=True), "image references only"),
-        (lambda: {**_subject_ref_teacher_batch(), "latents_first": torch.zeros(1, 24, 1, 4, 4)}, "cannot mix FL2VA and Ref2VA"),
-        (_ref_teacher_batch, "ref teacher rows"),
-        (_teacher_batch, "first,last teacher rows"),
+        (_ref_teacher_batch, "requires subject_ref teacher text rows"),
+        (_teacher_batch, "requires subject_ref teacher text rows"),
     ],
 )
 def test_subject_ref_teacher_guards(batch_factory, message):
@@ -2769,19 +2871,8 @@ def test_subject_ref_teacher_rows_are_rejected_by_the_other_teacher_modes():
         trainer = MiniMaxH3NetworkTrainer()
         args = _trainer_args(h3_teacher_matching=True, h3_teacher_conditions=conditions)
         trainer.handle_model_specific_args(args)
-        with pytest.raises(ValueError, match="subject_ref teacher rows"):
+        with pytest.raises(ValueError, match=f"requires {conditions} teacher text rows"):
             _teacher_matching_process_batch(trainer, args, _subject_ref_teacher_batch(), network=_ToggleNetwork())
-
-
-def test_one_frame_subject_ref_batch_rejects_stray_control_indices():
-    trainer = MiniMaxH3NetworkTrainer()
-    args = _trainer_args(h3_teacher_matching=True, h3_teacher_conditions="subject_ref", one_frame=True)
-    trainer.handle_model_specific_args(args)
-    batch = _subject_ref_teacher_batch(one_frame=True)
-    batch["one_frame_control_indices"] = torch.tensor([[0]], dtype=torch.int64)
-
-    with pytest.raises(ValueError, match="cannot carry one_frame_control_indices"):
-        _one_frame_process_batch(trainer, args, batch, _TeacherAwareTransformer(_ToggleNetwork()))
 
 
 def test_teacher_condition_sigma_min_validation_and_metadata():


### PR DESCRIPTION
Part 5 of the pre-`main` MiniMax-H3 cleanup (after #1097, #1098, #1099, #1104, #1105): the trainer stops re-implementing `NetworkTrainer`'s seams.

## Base (`trainer_base.py`)

Two small hooks split out of `sample_image_inference`, both with the previous behaviour as default:

- `round_sample_frame_count(frame_count)` — the `--f` grid (default `round_down_frame_count`). H3 keeps `1` for one-frame samples and snaps video counts onto `17n+5`.
- `save_sample(accelerator, args, sample_parameter, sample, save_dir, save_path, steps)` — writes what `do_inference` returned and logs it to wandb (default: image grid / mp4). H3 muxes its joint AV mp4 here.
- `wandb_tracker_and_module(accelerator)` replaces the bare `except:` tracker lookup and is shared.

## H3 trainer

- `sample_image_inference` override → `do_inference` + `save_sample`. The base owns seeding (`generator.initial_seed()`), the eval/train switch, file naming, RNG restore and wandb. `H3SamplingResources` is a `torch.nn.Module` so the base's resource moves cover both VAEs. `prepare_sampling` copies the resolved width/height/frame_count/steps/seed back into the sample dict so the base's log lines and seed match the request.
- **`--task` is the authority** for which cache entries a batch is read with; the batch plan no longer infers the task from key names and then checks it against `args.task`. Missing entries raise with a re-cache hint. Entries the task (and the configured teacher) never read are ignored and reported once at the first step.
- `get_noisy_model_input_and_timesteps` override: base sigma draw (uniform + timestep focus) and the video shift; `call_dit` / `compute_loss` get timesteps in the base's 1..1000 convention, and `process_batch` derives the audio noising from the same base. Condition augmentation and the shift function come from `minimax_h3.sampling` (`generator=None` = global RNG). `--show_timesteps` now shows H3's video sigma distribution.
- Per-step metrics are plain floats (one device transfer). The teacher regime flag travels in `DiTOutput.extra`, not the log dict.
- Copies of invariants owned elsewhere are dropped (tensor shapes → model forward / packing, token-tag values → `build_timestep_rows`, text widths → model config, one-frame index signs → `H3TimeOverrides`, condition/time counts → `build_h3_layout`, `audio_present` values → `effective_audio_loss_weights`, the `compute_loss` weight re-check, the timestep-pool length). `raise` sites in the trainer: 91 → 50.
- Shift / clean ranges validate through `sampling.validate_shift` and `packing.validate_clean_coefficient` (now public); `validate_generation_request` uses the same functions.
- The uncond cache is path-checked at args time and loaded in `on_train_start`; the warn-once state moves off the module global.
- `process_sample_prompts` dead override, `args.vae_dtype` and unused imports removed. Teacher text cache stems live next to the teacher-kind constants in `text_encoder` (`cache_io` keeps its alias).

## Behaviour changes to be aware of

- **Unused cache entries warn instead of raising.** Previously an `fl2va` cache in a `t2va` run, FL latents next to Ref2VA references, stray one-frame index tensors, or teacher rows without `--h3_teacher_matching` were hard errors; now they are ignored with one warning (the ref teacher's "FL latents are simply unused" allowance is the same mechanism). Flipping this back to an error is one line at the end of `_runtime_batch_plan` if preferred.
- One-frame training samples are saved through the shared image path and get the `_000.png` suffix of the other architectures.
- One-frame index tensors are no longer required to be int64 (any integer tensor of the right shape is read).
- Docs: `docs/minimax_h3.md` (task/cache entry reading, sample naming).

## Tests

- `tests/test_minimax_h3_training.py` follows the new contract (task-authority errors, unused-entry warnings, base-convention timesteps, float metrics, one-frame sample through the base image path, `round_sample_frame_count`, `save_sample` wandb fps, `on_train_start` uncond load).
- Full suite: 706 passed. No real-hardware smoke yet (training step + training-time sample, video and one-frame, are the things to check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKNxpdNSD5Q5nhCzvHmJNK
