### PR TITLE
MiniMax-H3: align the generation CLI with the house vocabulary (PR-H1)

### DIFF
--- a/docs/minimax_h3.md
+++ b/docs/minimax_h3.md
@@ -407,25 +407,24 @@ python minimax_h3_generate_video.py \
   --audio_vae /models/minimax_h3_audio_vae_fp32.safetensors \
   --text_encoder /models/qwen3vl_32b_minimax_h3_bf16.safetensors \
   --prompt "A singer performs under stage lights." \
-  --width 768 \
-  --height 1344 \
-  --frame_count 124 \
-  --steps 30 \
+  --video_size 1344 768 \
+  --video_length 124 \
+  --infer_steps 30 \
   --seed 42 \
   --blocks_to_swap 48 \
-  --output output.mp4
+  --save_path output.mp4
 ```
 
 `--seed` is optional: when omitted, each generation draws a fresh random seed and logs it (auto-named outputs embed it in the filename).
 
-`--output` accepts either a file name or a directory: an existing directory, a trailing path separator, or an extension-free path selects auto-naming (`<timestamp>_<seed>` plus the output type's extension) inside that directory, while any other unrecognized extension stays an error (a directory name containing a dot needs the trailing-separator spelling, e.g. `some.dir/`). An existing output is never overwritten — the new file is renamed with a `-1`, `-2`, ... suffix and a warning is logged — so re-running an edited command line without changing `--output` cannot destroy earlier results.
+The generation options follow the other architectures' vocabulary: `--video_size HEIGHT WIDTH` (multiples of 32), `--video_length` (pixel frames, `17*n+5`), `--infer_steps`, `--save_path`. `--save_path` accepts either a directory (the other architectures' convention) or a file name: an existing directory, a trailing path separator, or an extension-free path selects auto-naming (`<timestamp>_<seed>` plus the output type's extension) inside that directory, while any other unrecognized extension stays an error (a directory name containing a dot needs the trailing-separator spelling, e.g. `some.dir/`). An existing output is never overwritten — the new file is renamed with a `-1`, `-2`, ... suffix and a warning is logged — so re-running an edited command line without changing `--save_path` cannot destroy earlier results.
 
 `--output_type {video,latent,both,images,latent_images}` (default `video`) selects what is saved:
 
 - `video` — the muxed video (or the one-frame PNG), as above.
 - `latent` — only the sampled video+audio latents, as a safetensors file (a `.safetensors` output name, or auto-named `<timestamp>_<seed>_latent.safetensors`); VAE decoding is skipped and `--latent_path` turns the file into a video later. `--trajectory_dir` requires decoding and is rejected.
 - `both` — the video plus the latents as `<name>_latent.safetensors` next to it.
-- `images` — the decoded frames as `00000.png`-numbered files plus the decoded audio as `audio.wav`, written into an auto-named `<timestamp>_<seed>/` directory under `--output` (which always names a directory for the image types, so two runs never mix their frames).
+- `images` — the decoded frames as `00000.png`-numbered files plus the decoded audio as `audio.wav`, written into an auto-named `<timestamp>_<seed>/` directory under `--save_path` (which always names a directory for the image types, so two runs never mix their frames).
 - `latent_images` — `images` plus `latent.safetensors` inside the same directory.
 
 In `--from_file` mode the latent-bearing types simply keep the intermediate latent files (with their `<timestamp>_<index>_<seed>_latent.safetensors` names) instead of removing them, and `--output_type latent` skips the decode phase entirely; `--latent_path` decoding accepts `video` and `images`.
@@ -446,7 +445,7 @@ For FL2VA, keep the FL2VA base and replace the task inputs:
 --task fl2va --prompt "..." --first_frame first.png --last_frame last.png
 ```
 
-Condition images are fitted to the `--width`/`--height` canvas the way training fits controls to the bucket: scaled to cover the canvas, then center-cropped (never stretched), so a LoRA sees its conditions preprocessed exactly as during training. Pass images with the canvas aspect ratio to keep the whole picture.
+Condition images are fitted to the `--video_size` canvas the way training fits controls to the bucket: scaled to cover the canvas, then center-cropped (never stretched), so a LoRA sees its conditions preprocessed exactly as during training. Pass images with the canvas aspect ratio to keep the whole picture.
 
 The official prompt guide treats I2VA (first frame only) and L2VA (last frame only) as FL2VA variants, and the released FL2VA base supports both: pass only `--first_frame` to develop forward from the image, or only `--last_frame` to converge onto it. The lone picture is `<Picture 1>` in either case — the released prompt builder numbers the pictures that are present — and the first/last distinction is carried by the rotary anchor times (a lone last frame keeps its end-of-video anchor), so the prompt should use the matching official instruction line: the I2VA "at 0.00 seconds ... fully referenced" form, or the L2VA alignment form anchoring `<Picture 1>` at the final second mark.
 
@@ -469,9 +468,9 @@ Alternatively, inline references skip the JSONL (and its target `video_path` pla
 
 T2VA and Ref2VA generation may use `--text_cache` instead of `--text_encoder`. The cache must match the requested task, cache format version, and exact presentation fingerprint (which covers the prompt, frame count, and size+mtime identities of the reference media, so the cache must be used on the machine holding the original files). T2VA still requires `--prompt` so that identity can be verified; Ref2VA uses the selected record caption unless `--prompt` overrides it. FL2VA generation does not accept a dataset text cache because external first/last images cannot be proven identical to the crop presentation that produced that cache.
 
-`--frame_count 1` switches to the experimental one-frame (image) mode — PNG output, no audio, optional `--one_frame_inference` time indices; see `docs/minimax_h3_1f.md`.
+`--video_length 1` switches to the experimental one-frame (image) mode — PNG output, no audio, optional `--one_frame_inference` time indices; see `docs/minimax_h3_1f.md`.
 
-`--steps N` means N model evaluations, so the schedule uses N+1 grid points. The released implementations (SGLang serving and the diffusers scheduler) instead count grid points: their `num_inference_steps = N` performs N-1 evaluations. Musubi `--steps N` is therefore grid-identical to official `num_inference_steps = N+1`; to reproduce the official 50-step serving default exactly, pass `--steps 49`.
+`--infer_steps N` means N model evaluations, so the schedule uses N+1 grid points. The released implementations (SGLang serving and the diffusers scheduler) instead count grid points: their `num_inference_steps = N` performs N-1 evaluations. Musubi `--infer_steps N` is therefore grid-identical to official `num_inference_steps = N+1`; to reproduce the official 50-step serving default exactly, pass `--infer_steps 49`.
 
 `--compile` wraps the 50 DiT blocks with torch.compile using the same flags as training (`--compile_backend`, `--compile_mode`, `--compile_dynamic`, `--compile_fullgraph`, `--compile_cache_size_limit`; requires triton). The exclusions also match training: with block swap or a ConvRot INT8 base the Linear layers stay eager (the INT8 path's custom autograd + Triton kernels are not dynamo-traceable), so the speedup comes from fusing the rest of the block graph. The first sampling steps pay the compilation latency, and each new latent shape triggers a recompile — in interactive or batch sessions with varying resolutions or frame counts, pass `--compile_dynamic true` or budget one recompilation per shape.
 
@@ -481,9 +480,9 @@ The native sampler builds one common base grid, derives independent shifted vide
 
 ### Temporal stretch (experimental)
 
-`--output_fps N` (default 24, accepted range 1-24; rates above the native 24 are rejected until the squeeze direction is validated) samples the generated timeline at N fps instead of the trained 24. `--frame_count` still counts generated pixel frames, so the clip covers `frame_count / N` seconds: the target video's rotary time spans scale by `24/N` (the H3 time axis is real-time, 1 unit = 1/40 s), the audio track keeps its native 40 Hz latent rate over the stretched real duration, and the output container, trajectory dumps, and intermediate latent files all carry the requested rate. The released 5-15 s duration gate applies to the real (stretched) duration. References, FL2VA conditions, and one-frame mode keep native 24 fps spans (one-frame mode rejects a stretch).
+`--output_fps N` (default 24, accepted range 1-24; rates above the native 24 are rejected until the squeeze direction is validated) samples the generated timeline at N fps instead of the trained 24. `--video_length` still counts generated pixel frames, so the clip covers `video_length / N` seconds: the target video's rotary time spans scale by `24/N` (the H3 time axis is real-time, 1 unit = 1/40 s), the audio track keeps its native 40 Hz latent rate over the stretched real duration, and the output container, trajectory dumps, and intermediate latent files all carry the requested rate. The released 5-15 s duration gate applies to the real (stretched) duration. References, FL2VA conditions, and one-frame mode keep native 24 fps spans (one-frame mode rejects a stretch).
 
-Two ways to use it: keeping `--frame_count` fixed doubles the clip length at 12 fps for nearly the same compute (only the audio rows grow), while generating the same real duration with proportionally fewer frames cuts the packed sequence roughly in half at 12 fps (about a quarter of the video-video attention cost; 124 frames at 12 fps measured ~2.1x faster than the equal-duration 243 frames at 24 fps).
+Two ways to use it: keeping `--video_length` fixed doubles the clip length at 12 fps for nearly the same compute (only the audio rows grow), while generating the same real duration with proportionally fewer frames cuts the packed sequence roughly in half at 12 fps (about a quarter of the video-video attention cost; 124 frames at 12 fps measured ~2.1x faster than the equal-duration 243 frames at 24 fps).
 
 The model was trained at 24 fps only, so a plain stretch produces periodic artifacts with a 17-pixel-frame period: the leading (highest-frequency) temporal RoPE bands have periods at or below the latent token spacing and carry a per-token lattice phase rather than time, and stretching re-dials that phase against the `(1,4,4,4,4)` VAE token grouping. `--stretch_keep_bands K` rotates the K leading temporal bands by the unstretched grid instead, which restores the trained lattice phase while the remaining bands carry the stretched clock. Recommended values: `3` at 12 fps (where `4` also removes the last residual glitches), `2` at 16 fps, `1` at 20 fps — the count of bands whose per-token rotation changes regime at that stretch.
 
@@ -501,10 +500,10 @@ A singer performs under stage lights. --w 768 --h 1344 --f 124 --d 42 --s 30
 
 | Line option | Maps to |
 | --- | --- |
-| `--w`, `--h` | `--width`, `--height` |
-| `--f` | `--frame_count` (`--f 1` selects one-frame mode) |
+| `--w`, `--h` | `--video_size` (`--w` is the width, `--h` the height) |
+| `--f` | `--video_length` (`--f 1` selects one-frame mode) |
 | `--d` | `--seed` |
-| `--s` | `--steps` |
+| `--s` | `--infer_steps` |
 | `--fs`, `--fsa` | `--h3_shift_video`, `--h3_shift_audio` |
 | `--ofps`, `--skb` | `--output_fps`, `--stretch_keep_bands` |
 | `--i`, `--ei` | `--first_frame`, `--last_frame` (end image) |
@@ -513,11 +512,11 @@ A singer performs under stage lights. --w 768 --h 1344 --f 124 --d 42 --s 30
 | `--of` | `--one_frame_inference` |
 | `--o` | output filename inside the output directory |
 
-The line vocabulary is the shared training sample-prompt one (`training/sampling_prompts.py`, the same lines `--sample_prompts` reads), so an unknown option is logged as a warning and ignored rather than failing the line, and the generic `--n`/`--l`/`--g` options are rejected (H3 has no negative prompt or CFG). Unspecified options inherit the command-line values, so a fixed `--ref` set with varying prompts works. A line starting with `--` carries only options and keeps the command-line `--prompt` in effect — with a session prompt, `--d 43` alone re-runs it with a new seed. The literal string `\n` in prompt text (line prompts and `--prompt` alike) becomes a newline, so the multi-line official prompt format fits on one line. `--task`, the model artifacts, and the LoRA configuration are fixed for the session, and `--text_cache` and `--trajectory_dir` are not accepted. In both modes `--output` names a directory (created if missing); files are auto-named `<timestamp>_<seed>` with the output type's extension (a per-generation directory for the image types) unless a line overrides the name with `--o`, and omitting `--d` draws a fresh random seed per line.
+The line vocabulary is the shared training sample-prompt one (`training/sampling_prompts.py`, the same lines `--sample_prompts` reads), so an unknown option is logged as a warning and ignored rather than failing the line, and the generic `--n`/`--l`/`--g` options are rejected (H3 has no negative prompt or CFG). Unspecified options inherit the command-line values, so a fixed `--ref` set with varying prompts works. A line starting with `--` carries only options and keeps the command-line `--prompt` in effect — with a session prompt, `--d 43` alone re-runs it with a new seed. The literal string `\n` in prompt text (line prompts and `--prompt` alike) becomes a newline, so the multi-line official prompt format fits on one line. `--task`, the model artifacts, and the LoRA configuration are fixed for the session, and `--text_cache` and `--trajectory_dir` are not accepted. In both modes `--save_path` names a directory (created if missing); files are auto-named `<timestamp>_<seed>` with the output type's extension (a per-generation directory for the image types) unless a line overrides the name with `--o`, and omitting `--d` draws a fresh random seed per line.
 
-**`--from_file prompts.txt`** runs the prompts in four phases, loading each model family exactly once: condition VAE encoding for every line (lines starting with `#` and empty lines are skipped), then all text encodings, then all samplings, then all decodes. Peak VRAM therefore matches single-shot generation — the same `--blocks_to_swap`/`--text_encoder_blocks_to_swap` settings apply unchanged. Each sampled result is written to `<output>/<timestamp>_<index>_<seed>_latent.safetensors` before any decoding, so a crash never loses finished sampling work; the file is removed once its output is written (unless `--output_type` keeps latents) and kept (with a log message) when decoding fails. A failing line is reported and skipped without aborting the rest of the batch.
+**`--from_file prompts.txt`** runs the prompts in four phases, loading each model family exactly once: condition VAE encoding for every line (lines starting with `#` and empty lines are skipped), then all text encodings, then all samplings, then all decodes. Peak VRAM therefore matches single-shot generation — the same `--blocks_to_swap`/`--text_encoder_blocks_to_swap` settings apply unchanged. Each sampled result is written to `<save_path>/<timestamp>_<index>_<seed>_latent.safetensors` before any decoding, so a crash never loses finished sampling work; the file is removed once its output is written (unless `--output_type` keeps latents) and kept (with a log message) when decoding fails. A failing line is reported and skipped without aborting the rest of the batch.
 
-**`--latent_path FILE...`** decodes those intermediate latent files without loading the transformer or text encoder — only the VAEs (`--audio_vae` may be omitted when every file is a one-frame latent). Outputs go to the `--output` directory.
+**`--latent_path FILE...`** decodes those intermediate latent files without loading the transformer or text encoder — only the VAEs (`--audio_vae` may be omitted when every file is a one-frame latent). Outputs go to the `--save_path` directory.
 
 **`--interactive`** reads prompt lines from the console and keeps every model resident for the whole session: the text encoder and the transformer stay loaded with their configured placements, and the VAEs idle on the CPU between prompts. Unlike the batch phases, both large models coexist, so VRAM-limited setups (24 GB and below) should combine a quantized transformer plus a generous `--blocks_to_swap` with `--text_encoder_blocks_to_swap 50` (and `--text_encoder_attn_mode flash_attention_2` for long Ref2VA presentations). The CPU-resident copies mean host RAM must hold both artifacts — 64 GB is a comfortable floor for the quantized pair. Text conditioning is cached by prompt and media fingerprints, so re-running a line with only a new seed skips the text encoder entirely. Ctrl+D (or Ctrl+Z on Windows) exits; Ctrl+C interrupts the current generation and returns to the prompt. `--bell` rings the terminal bell after each generation (in the other modes, once at the end).
 

--- a/docs/minimax_h3_1f.md
+++ b/docs/minimax_h3_1f.md
@@ -5,9 +5,9 @@
 
 ## Overview
 
-`--frame_count 1` switches `minimax_h3_generate_video.py` into one-frame mode:
+`--video_length 1` switches `minimax_h3_generate_video.py` into one-frame mode:
 
-- The target is one video latent token plus the two audio latent frames the joint layout requires. The audio is a byproduct and is never decoded; the output is a PNG (`--output` must use `.png`).
+- The target is one video latent token plus the two audio latent frames the joint layout requires. The audio is a byproduct and is never decoded; the output is a PNG (`--save_path` must use `.png`).
 - The single-token VAE decode duplicates the latent to a pseudo two-token clip and keeps pixel frame 0 (a solo token decode breaks down; the duplication decodes within ~1-2 dB of a true two-token decode). This happens inside the VAE automatically.
 - All tasks are available: `t2va` (plain image), `fl2va` with one or more condition images (editing/inbetween-style probes; one or two is the released API, three or more is experimental), and `ref2va` (reference-driven images, including single-image novel-view generation).
 - `--trajectory_dir` writes per-step PNGs instead of per-step videos.
@@ -42,11 +42,11 @@ python minimax_h3_generate_video.py \
   --audio_vae /models/minimax_h3_audio_vae_fp32.safetensors \
   --text_encoder /models/qwen3vl_32b_minimax_h3_bf16.safetensors \
   --prompt "A watercolor lighthouse at dusk." \
-  --width 1024 --height 1024 \
-  --frame_count 1 \
-  --steps 30 --seed 42 \
+  --video_size 1024 1024 \
+  --video_length 1 \
+  --infer_steps 30 --seed 42 \
   --blocks_to_swap 48 \
-  --output output.png
+  --save_path output.png
 ```
 
 ## Conditioned images (FL2VA, one or more pictures)
@@ -57,16 +57,16 @@ One or two pictures is officially in-distribution for the FL2VA checkpoint (its 
 
 ```bash
 # generate "frame 24" of a nominal clip anchored by one condition image at frame 0
-... --task fl2va --frame_count 1 \
+... --task fl2va --video_length 1 \
   --first_frame anchor.png \
   --one_frame_inference "target_index=24,control_index=0" \
-  --prompt "..." --output frame24.png
+  --prompt "..." --save_path frame24.png
 
 # three anchors: frames 0, 48 and 96, generating frame 24 (experimental)
-... --task fl2va --frame_count 1 \
+... --task fl2va --video_length 1 \
   --condition_image a.png --condition_image b.png --condition_image c.png \
   --one_frame_inference "target_index=24,control_index=0;48;96" \
-  --prompt "..." --output frame24.png
+  --prompt "..." --save_path frame24.png
 ```
 
 For best results the caption should follow the official alignment-line formats from the prompt-writing guide (I2VA/L2VA/FL2VA opening lines); the base model reads condition times far more continuously with official-format captions than with plain ones.
@@ -77,9 +77,9 @@ Ref2VA one-frame combines with inline `--ref` references (see `docs/minimax_h3.m
 
 ```bash
 ... --task ref2va --dit /models/minimax_h3_ref2va_bf16.safetensors \
-  --frame_count 1 \
+  --video_length 1 \
   --ref character.png \
-  --prompt "..." --output view.png
+  --prompt "..." --save_path view.png
 ```
 
 With a full-reference-style caption, a single image reference yields novel views of the referenced subject (front/side/back selectable by text) with the environment plausibly extended — useful for synthesizing character-LoRA training data. Note that for dense 2D illustrations the reference is re-drawn rather than preserved pixel-exactly, and unseen-angle environments are plausible inventions, not geometry.

--- a/src/musubi_tuner/minimax_h3/generation_inputs.py
+++ b/src/musubi_tuner/minimax_h3/generation_inputs.py
@@ -108,9 +108,11 @@ def parse_one_frame_options(spec: str) -> tuple[int, tuple[int, ...] | None]:
 class H3GenerationRequest:
     """One generation, as the shared helpers read it.
 
-    The fields are named like the generation CLI's arguments (``request_from_args`` copies them
-    one to one); a training sample prompt dict reaches the same shape through
-    ``request_overrides``. A request is only trusted after ``validate_generation_request``.
+    The fields are named like the generation CLI's namespace attributes (``request_from_args``
+    copies them one to one; the house flags ``--video_size`` / ``--video_length`` /
+    ``--infer_steps`` land on ``height``+``width`` / ``frame_count`` / ``steps``); a training
+    sample prompt dict reaches the same shape through ``request_overrides``. A request is only
+    trusted after ``validate_generation_request``.
     """
 
     task: H3Task
@@ -156,7 +158,7 @@ def unescape_prompt(prompt: str | None) -> str | None:
 
 
 def request_from_args(args) -> H3GenerationRequest:
-    """The request of a generation CLI namespace (the parser in minimax_h3_generate_video.py defines every field)."""
+    """The request of a generation CLI namespace (the parser in minimax_h3_generate_video.py defines every attribute)."""
     return H3GenerationRequest(
         task=args.task,
         prompt=unescape_prompt(args.prompt),
@@ -305,7 +307,7 @@ def validate_generation_request(request: H3GenerationRequest) -> None:
             raise ValueError("MiniMax-H3 --one_frame_inference control_index applies only to FL2VA conditions")
     else:
         if request.one_frame_inference is not None:
-            raise ValueError("MiniMax-H3 --one_frame_inference options require --frame_count 1 (--f 1 in prompt lines)")
+            raise ValueError("MiniMax-H3 --one_frame_inference options require --video_length 1 (--f 1 in prompt lines)")
         video_latent_frames(request.frame_count)
         # with a temporal stretch the rotary timeline spans the real (stretched) duration,
         # so that is the quantity to hold inside the released range
@@ -317,7 +319,7 @@ def validate_generation_request(request: H3GenerationRequest) -> None:
                 "pass --allow_experimental_duration to proceed"
             )
     if request.steps <= 0:
-        raise ValueError("MiniMax-H3 --steps must be positive")
+        raise ValueError("MiniMax-H3 --infer_steps must be positive (--s in prompt lines)")
     validate_shift(request.h3_shift_video, "--h3_shift_video")
     validate_shift(request.h3_shift_audio, "--h3_shift_audio")
     validate_clean_coefficient(request.h3_visual_cond_clean, "--h3_visual_cond_clean")
@@ -414,7 +416,7 @@ def fl_condition_entries(request: H3GenerationRequest) -> tuple[tuple[str, str],
     if not request.one_frame:
         if condition_images:
             raise ValueError(
-                "MiniMax-H3 --condition_image applies to one-frame targets (--frame_count 1); video FL2VA takes"
+                "MiniMax-H3 --condition_image applies to one-frame targets (--video_length 1); video FL2VA takes"
                 " --first_frame and/or --last_frame"
             )
         return tuple((role, path) for role, path in (("first", first_frame), ("last", last_frame)) if path)

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -9,7 +9,6 @@ import random
 from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
-from datetime import datetime
 from pathlib import Path
 
 from safetensors import safe_open
@@ -17,6 +16,7 @@ from safetensors.torch import load_file, save_file
 import torch
 from tqdm.auto import tqdm
 
+from musubi_tuner.hv_generate_video import get_time_flag
 from musubi_tuner.minimax_h3.args import add_h3_sampling_args, add_h3_text_encoder_args, add_h3_vae_args
 from musubi_tuner.minimax_h3.audio_vae import load_audio_vae
 from musubi_tuner.minimax_h3.generation_inputs import (
@@ -87,12 +87,16 @@ LATENT_FILE_FORMAT = "minimax-h3-latents-v1"
 TEXT_CONDITIONING_CACHE_ENTRIES = 16
 
 
-def _time_flag() -> str:
-    return datetime.now().strftime("%Y%m%d-%H%M%S-%f")[:-3]
+class _VideoSizeAction(argparse.Action):
+    """--video_size HEIGHT WIDTH lands on the ``height`` / ``width`` namespace attributes, the
+    H3GenerationRequest field names that the rest of the script and the prompt-line overrides use."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        namespace.height, namespace.width = values
 
 
 def _output_is_directory(raw_output: str) -> bool:
-    """Directory interpretation of a single-generation --output: an existing directory, a
+    """Directory interpretation of a single-generation --save_path: an existing directory, a
     trailing path separator, or an extension-free path selects auto-naming inside that
     directory; a recognized extension names an explicit file, and any other extension
     stays an error (typo guard). Directory names containing a dot need the trailing
@@ -108,9 +112,9 @@ def _explicit_output_name(args: argparse.Namespace, *, directory_output: bool) -
         return None
     if directory_output:
         return Path(args.output_name) if args.output_name else None
-    if _output_is_directory(args.output):
+    if _output_is_directory(args.save_path):
         return None
-    return Path(args.output)
+    return Path(args.save_path)
 
 
 def validate_session_args(args: argparse.Namespace) -> None:
@@ -167,11 +171,11 @@ def validate_prompt_args(args: argparse.Namespace, *, directory_output: bool = F
     validate_generation_request(request)
     one_frame = request.one_frame
     if args.output_type in ("images", "latent_images"):
-        # --output is a directory holding an auto-named per-generation subdirectory; a
-        # media extension signals a video command line reused without adjusting --output
-        if Path(args.output).suffix.lower() in (*VIDEO_OUTPUT_SUFFIXES, ".png", ".safetensors"):
+        # --save_path is a directory holding an auto-named per-generation subdirectory; a
+        # media extension signals a video command line reused without adjusting --save_path
+        if Path(args.save_path).suffix.lower() in (*VIDEO_OUTPUT_SUFFIXES, ".png", ".safetensors"):
             raise ValueError(
-                f"MiniMax-H3 --output_type {args.output_type} writes into a directory; --output must not name a media file"
+                f"MiniMax-H3 --output_type {args.output_type} writes into a directory; --save_path must not name a media file"
             )
     checked_output = _explicit_output_name(args, directory_output=directory_output)
     if checked_output is not None:
@@ -752,7 +756,7 @@ def _resolve_seed(args: argparse.Namespace) -> int:
 
 
 def _auto_output_name(args: argparse.Namespace, seed: int) -> str:
-    base = f"{_time_flag()}_{seed}"
+    base = f"{get_time_flag()}_{seed}"
     if args.output_type == "latent":
         return f"{base}_latent.safetensors"
     if args.output_type in ("images", "latent_images"):
@@ -775,16 +779,16 @@ def _dedupe_output_path(path: Path) -> Path:
 def _resolve_output_path(args: argparse.Namespace, seed: int, *, directory_mode: bool) -> Path:
     """Resolve the primary output target: the media file for video/both, the latent file
     for latent, or the image-sequence directory for images/latent_images. A single
-    generation writes to --output itself when it names a file and auto-names inside it
+    generation writes to --save_path itself when it names a file and auto-names inside it
     when it selects a directory (see _output_is_directory); the multi-prompt modes and
-    the image-sequence types always auto-name inside the --output directory."""
+    the image-sequence types always auto-name inside the --save_path directory."""
     images = args.output_type in ("images", "latent_images")
-    if directory_mode or images or _output_is_directory(args.output):
-        output_dir = Path(args.output).expanduser()
+    if directory_mode or images or _output_is_directory(args.save_path):
+        output_dir = Path(args.save_path).expanduser()
         output_dir.mkdir(parents=True, exist_ok=True)
         output_name = args.output_name if directory_mode else None
         return _dedupe_output_path(output_dir / (output_name or _auto_output_name(args, seed)))
-    return _dedupe_output_path(Path(args.output).expanduser())
+    return _dedupe_output_path(Path(args.save_path).expanduser())
 
 
 def _resolve_latent_path(args: argparse.Namespace, output_path: Path) -> Path | None:
@@ -994,7 +998,7 @@ def process_from_file(args: argparse.Namespace, device: torch.device) -> None:
     if not items:
         logger.warning("MiniMax-H3 --from_file %s contains no prompts", args.from_file)
         return
-    output_dir = Path(args.output).expanduser()
+    output_dir = Path(args.save_path).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
     shared = H3SharedModels(device=device)
     decoder = PyAVH3MediaDecoder()
@@ -1061,7 +1065,7 @@ def process_from_file(args: argparse.Namespace, device: torch.device) -> None:
                 # the 2-frame audio target is a byproduct of the joint layout, not an output
                 item.audio_latents = None
             item.latent_file = _save_latent_file(
-                output_dir / f"{_time_flag()}_{item.index:03d}_{item.seed}_latent.safetensors",
+                output_dir / f"{get_time_flag()}_{item.index:03d}_{item.seed}_latent.safetensors",
                 item.video_latents,
                 item.audio_latents,
                 item.request,
@@ -1109,7 +1113,7 @@ def process_interactive(args: argparse.Namespace, device: torch.device) -> None:
     --text_encoder_blocks_to_swap 50 and a generous --blocks_to_swap."""
     shared = H3SharedModels(device=device)
     decoder = PyAVH3MediaDecoder()
-    Path(args.output).expanduser().mkdir(parents=True, exist_ok=True)
+    Path(args.save_path).expanduser().mkdir(parents=True, exist_ok=True)
 
     print("Interactive mode. Enter prompts (Ctrl+D or Ctrl+Z (Windows) to exit):")
     try:
@@ -1174,7 +1178,7 @@ def _parse_output_fps_metadata(source: Path, metadata: dict, requested_fps: int)
 
 def process_latent_decode(args: argparse.Namespace, device: torch.device) -> None:
     """Decode-only mode for --from_file intermediate latents; only the VAEs are loaded."""
-    output_dir = Path(args.output).expanduser()
+    output_dir = Path(args.save_path).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
     loaded = []
     for path in args.latent_path:
@@ -1191,10 +1195,10 @@ def process_latent_decode(args: argparse.Namespace, device: torch.device) -> Non
             item_args.output_fps = _parse_output_fps_metadata(source, metadata, args.output_fps)
             seed = metadata.get("seeds", "0")
             if args.output_type == "images":
-                output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}"
+                output_path = output_dir / f"{get_time_flag()}_{seed}_{source.stem}"
             else:
                 suffix = ".png" if frame_count == 1 else ".mp4"
-                output_path = output_dir / f"{_time_flag()}_{seed}_{source.stem}{suffix}"
+                output_path = output_dir / f"{get_time_flag()}_{seed}_{source.stem}{suffix}"
             _decode_and_save(item_args, video_latents, audio_latents, output_path, device, shared)
         except Exception as error:
             logger.error("MiniMax-H3 latent decode failed for %s: %s", source, error, exc_info=True)
@@ -1244,7 +1248,7 @@ def setup_parser() -> argparse.ArgumentParser:
         action="append",
         default=None,
         metavar="PATH",
-        help="one-frame FL2VA condition image, repeatable (requires --frame_count 1): the ordered condition list,"
+        help="one-frame FL2VA condition image, repeatable (requires --video_length 1): the ordered condition list,"
         " numbered <Picture i> in this order and placed by --one_frame control_index in the same order. Any count"
         " (the released FL2VA API takes one or two pictures; three or more is experimental). --first_frame /"
         " --last_frame are aliases for the first two slots and cannot be combined with this option",
@@ -1261,12 +1265,26 @@ def setup_parser() -> argparse.ArgumentParser:
         " extension unless ;type= overrides it; ;audio= attaches an external audio track to a video reference."
         " Validation matches the JSONL references schema exactly. Mutually exclusive with --reference_jsonl.",
     )
-    parser.add_argument("--width", type=int, default=DEFAULT_WIDTH)
-    parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
+    # The house generation vocabulary (--video_size / --video_length / --infer_steps, as in
+    # wan_generate_video.py) lands on the H3GenerationRequest field names (height+width /
+    # frame_count / steps): request_from_args copies the namespace one to one and the prompt-line
+    # overrides (apply_overrides) already speak the request vocabulary, so only the flags differ.
+    parser.set_defaults(height=DEFAULT_HEIGHT, width=DEFAULT_WIDTH)
     parser.add_argument(
-        "--frame_count",
+        "--video_size",
+        action=_VideoSizeAction,
+        type=int,
+        nargs=2,
+        default=argparse.SUPPRESS,
+        metavar=("HEIGHT", "WIDTH"),
+        help=f"video size, height and width (default {DEFAULT_HEIGHT} {DEFAULT_WIDTH})",
+    )
+    parser.add_argument(
+        "--video_length",
+        dest="frame_count",
         type=int,
         default=DEFAULT_FRAME_COUNT,
+        metavar="N",
         help="pixel frame count, 17*n+5 for video; 1 enables the experimental one-frame (image) mode, which writes"
         " a PNG and skips audio decoding",
     )
@@ -1274,7 +1292,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "--one_frame_inference",
         default=None,
         metavar="target_index=N,control_index=A;B",
-        help="one-frame mode time options (requires --frame_count 1; --of in prompt lines): 0-based 24 fps"
+        help="one-frame mode time options (requires --video_length 1; --of in prompt lines): 0-based 24 fps"
         " pixel-frame indices on the nominal timeline, converted to RoPE times relative to the target-block cursor."
         " target_index (default 0) places the generated frame; control_index places the FL2VA condition images in"
         " --condition_image order (or --first_frame, --last_frame) and is required when conditions are present."
@@ -1285,7 +1303,7 @@ def setup_parser() -> argparse.ArgumentParser:
         type=int,
         default=TARGET_FPS,
         help="experimental temporal stretch: sample the generated timeline at this rate (1-24) instead of"
-        " 24 fps. The --frame_count frames then cover frame_count/fps seconds -- target RoPE spans scale"
+        " 24 fps. The --video_length frames then cover video_length/fps seconds -- target RoPE spans scale"
         " by 24/fps, the audio track covers the stretched duration, and the output container is written"
         " at this rate. The model was trained at 24 fps only, so lower rates trade temporal resolution"
         " (and possibly quality) for compute; pair with --stretch_keep_bands, see docs. 24 disables the"
@@ -1305,16 +1323,23 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--allow_experimental_duration", action="store_true", help="allow durations outside the released 5-15 s range"
     )
-    parser.add_argument("--steps", type=int, default=DEFAULT_STEPS)
+    parser.add_argument(
+        "--infer_steps",
+        dest="steps",
+        type=int,
+        default=DEFAULT_STEPS,
+        help=f"number of inference steps, default is {DEFAULT_STEPS}",
+    )
     parser.add_argument("--seed", type=int, default=None, help="random when omitted")
     parser.add_argument(
-        "--output",
+        "--save_path",
         required=True,
-        help="output target. For a single generation: a file path (.png for one-frame, .mp4/.mkv/.mov otherwise,"
-        " .safetensors with --output_type latent), or a directory for auto-named files (an existing directory,"
-        " a trailing path separator, or an extension-free path). Always a directory with --output_type"
-        " images/latent_images, --interactive, --from_file, and --latent_path. An existing output is never"
-        " overwritten; the new file gets a numeric suffix instead",
+        help="output target. A directory receives auto-named files (<timestamp>_<seed> plus the output type's"
+        " extension) like the other architectures' --save_path: an existing directory, a trailing path separator,"
+        " or an extension-free path selects that. For a single generation it may instead name the file itself"
+        " (.png for one-frame, .mp4/.mkv/.mov otherwise, .safetensors with --output_type latent). Always a"
+        " directory with --output_type images/latent_images, --interactive, --from_file, and --latent_path."
+        " An existing output is never overwritten; the new file gets a numeric suffix instead",
     )
     parser.add_argument(
         "--output_type",
@@ -1322,14 +1347,14 @@ def setup_parser() -> argparse.ArgumentParser:
         default="video",
         help="what to save: the muxed video (or one-frame PNG; default), the sampled latents as a safetensors"
         " file decodable later with --latent_path, both (latent saved next to the video), a numbered PNG"
-        " sequence plus audio.wav in an auto-named directory under --output, or that sequence plus the latents",
+        " sequence plus audio.wav in an auto-named directory under --save_path, or that sequence plus the latents",
     )
     parser.add_argument(
         "--from_file",
         default=None,
         help="batch mode: read prompt lines (with inline --w/--h/--f/--d/--s/--fs/--fsa/--ofps/--skb/--i/--ei/--ci/--ref/--of/--o"
         " options) from a file and run them in phases, loading each model family once. Sampled latents are saved"
-        " to the --output directory before decoding so a crash loses nothing; the files are removed after their"
+        " to the --save_path directory before decoding so a crash loses nothing; the files are removed after their"
         " output is written unless --output_type keeps latents. See docs/minimax_h3.md",
     )
     parser.add_argument(
@@ -1343,7 +1368,7 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs="*",
         default=None,
         help="decode-only mode: decode latents safetensors saved by --from_file or --output_type into the"
-        " --output directory (only the VAEs are loaded; supports --output_type video or images)",
+        " --save_path directory (only the VAEs are loaded; supports --output_type video or images)",
     )
     parser.add_argument(
         "--bell",

--- a/tests/test_minimax_h3_generation_modes.py
+++ b/tests/test_minimax_h3_generation_modes.py
@@ -59,7 +59,7 @@ def _session_args(tmp_path, *, task="t2va", **overrides):
         "allow_experimental_duration": False,
         "steps": 2,
         "seed": 1,
-        "output": str(tmp_path / "output.mp4"),
+        "save_path": str(tmp_path / "output.mp4"),
         "output_type": "video",
         "output_name": None,
         "blocks_to_swap": 0,
@@ -166,7 +166,7 @@ def test_session_validation_enforces_mode_exclusivity_and_multi_prompt_restricti
 
 
 def test_prompt_validation_checks_output_name_suffixes_in_directory_modes(tmp_path):
-    args = _session_args(tmp_path, output=str(tmp_path))
+    args = _session_args(tmp_path, save_path=str(tmp_path))
     validate_prompt_args(args, directory_output=True)
 
     args.output_name = "clip.mp4"
@@ -175,7 +175,7 @@ def test_prompt_validation_checks_output_name_suffixes_in_directory_modes(tmp_pa
     with pytest.raises(ValueError, match="must use .mp4"):
         validate_prompt_args(args, directory_output=True)
 
-    image_args = _session_args(tmp_path, frame_count=1, output=str(tmp_path))
+    image_args = _session_args(tmp_path, frame_count=1, save_path=str(tmp_path))
     image_args.output_name = "image.png"
     validate_prompt_args(image_args, directory_output=True)
     image_args.output_name = "image.mp4"
@@ -188,7 +188,7 @@ def test_fl2va_accepts_single_anchor_frames(tmp_path):
     first.touch()
     last = tmp_path / "last.png"
     last.touch()
-    base = {"task": "fl2va", "output": str(tmp_path / "out.mp4")}
+    base = {"task": "fl2va", "save_path": str(tmp_path / "out.mp4")}
     validate_prompt_args(_session_args(tmp_path, **base, first_frame=str(first)))
     validate_prompt_args(_session_args(tmp_path, **base, last_frame=str(last)))
     validate_prompt_args(_session_args(tmp_path, **base, first_frame=str(first), last_frame=str(last)))
@@ -198,48 +198,48 @@ def test_fl2va_accepts_single_anchor_frames(tmp_path):
 
 def test_output_validation_covers_output_types_and_directory_interpretation(tmp_path):
     # latent-only output names must be .safetensors
-    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.safetensors"), output_type="latent"))
+    validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path / "out.safetensors"), output_type="latent"))
     with pytest.raises(ValueError, match=r"must use \.safetensors"):
-        validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.mp4"), output_type="latent"))
+        validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path / "out.mp4"), output_type="latent"))
 
-    # image-sequence outputs are directories, so a media-file --output is rejected
+    # image-sequence outputs are directories, so a media-file --save_path is rejected
     with pytest.raises(ValueError, match="must not name a media file"):
-        validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.mp4"), output_type="images"))
-    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "frames"), output_type="images"))
+        validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path / "out.mp4"), output_type="images"))
+    validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path / "frames"), output_type="images"))
 
     # an existing directory, a trailing separator, or an extension-free path selects auto-naming
-    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path)))
-    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "newdir") + "/"))
-    validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "newdir")))
+    validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path)))
+    validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path / "newdir") + "/"))
+    validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path / "newdir")))
     with pytest.raises(ValueError, match=r"must use \.mp4"):
-        validate_prompt_args(_session_args(tmp_path, output=str(tmp_path / "out.mp3")))
+        validate_prompt_args(_session_args(tmp_path, save_path=str(tmp_path / "out.mp3")))
 
     # the per-step trajectory diagnostic requires decoding
     with pytest.raises(ValueError, match="cannot combine with --output_type latent"):
         validate_prompt_args(
-            _session_args(tmp_path, output=str(tmp_path / "out.safetensors"), output_type="latent", trajectory_dir=str(tmp_path))
+            _session_args(tmp_path, save_path=str(tmp_path / "out.safetensors"), output_type="latent", trajectory_dir=str(tmp_path))
         )
 
 
 def test_resolve_output_path_auto_names_directories_and_never_overwrites(tmp_path):
     existing = tmp_path / "clip.mp4"
     existing.touch()
-    resolved = generate._resolve_output_path(_session_args(tmp_path, output=str(existing)), 7, directory_mode=False)
+    resolved = generate._resolve_output_path(_session_args(tmp_path, save_path=str(existing)), 7, directory_mode=False)
     assert resolved == tmp_path / "clip-1.mp4"
 
-    resolved = generate._resolve_output_path(_session_args(tmp_path, output=str(tmp_path / "outdir")), 7, directory_mode=False)
+    resolved = generate._resolve_output_path(_session_args(tmp_path, save_path=str(tmp_path / "outdir")), 7, directory_mode=False)
     assert resolved.parent == tmp_path / "outdir" and resolved.parent.is_dir()
     assert resolved.name.endswith("_7.mp4")
 
-    latent_args = _session_args(tmp_path, output=str(tmp_path / "outdir"), output_type="latent")
+    latent_args = _session_args(tmp_path, save_path=str(tmp_path / "outdir"), output_type="latent")
     resolved = generate._resolve_output_path(latent_args, 7, directory_mode=False)
     assert resolved.name.endswith("_7_latent.safetensors")
 
-    image_args = _session_args(tmp_path, output=str(tmp_path / "frames"), output_type="images")
+    image_args = _session_args(tmp_path, save_path=str(tmp_path / "frames"), output_type="images")
     resolved = generate._resolve_output_path(image_args, 7, directory_mode=False)
     assert resolved.parent == tmp_path / "frames" and resolved.suffix == ""
 
-    both_args = _session_args(tmp_path, output=str(tmp_path / "clip2.mp4"), output_type="both")
+    both_args = _session_args(tmp_path, save_path=str(tmp_path / "clip2.mp4"), output_type="both")
     output_path = generate._resolve_output_path(both_args, 7, directory_mode=False)
     assert generate._resolve_latent_path(both_args, output_path) == tmp_path / "clip2_latent.safetensors"
 
@@ -253,7 +253,7 @@ def test_one_frame_fl2va_control_index_error_reports_the_counts(tmp_path):
         frame_count=1,
         first_frame=str(first),
         one_frame_inference="target_index=6,control_index=0;123",
-        output=str(tmp_path / "out.png"),
+        save_path=str(tmp_path / "out.png"),
     )
 
     with pytest.raises(ValueError, match=r"got 2 control_index entries for 1 condition images \(.*first\.png\)"):
@@ -266,7 +266,7 @@ def test_one_frame_fl2va_accepts_an_ordered_condition_image_list(tmp_path):
         path = tmp_path / f"{name}.png"
         path.touch()
         conditions.append(str(path))
-    base = dict(task="fl2va", frame_count=1, output=str(tmp_path / "out.png"))
+    base = dict(task="fl2va", frame_count=1, save_path=str(tmp_path / "out.png"))
 
     validate_prompt_args(
         _session_args(tmp_path, **base, condition_image=conditions, one_frame_inference="target_index=24,control_index=0;24;48")
@@ -408,7 +408,7 @@ def _batch_args(tmp_path, prompt_lines):
         tmp_path,
         frame_count=5,
         allow_experimental_duration=True,
-        output=str(output_dir),
+        save_path=str(output_dir),
         from_file=str(prompts),
         device="cpu",
         attn_mode="torch",
@@ -481,7 +481,7 @@ def test_run_generation_latent_only_saves_a_decodable_file_without_vaes(tmp_path
         tmp_path,
         frame_count=5,
         allow_experimental_duration=True,
-        output=str(tmp_path / "out.safetensors"),
+        save_path=str(tmp_path / "out.safetensors"),
         output_type="latent",
         device="cpu",
         attn_mode="torch",
@@ -507,7 +507,7 @@ def test_run_generation_writes_an_image_sequence_with_audio_and_latents(tmp_path
         tmp_path,
         frame_count=5,
         allow_experimental_duration=True,
-        output=str(tmp_path / "frames"),
+        save_path=str(tmp_path / "frames"),
         output_type="latent_images",
         device="cpu",
         attn_mode="torch",
@@ -541,7 +541,7 @@ def test_compile_wraps_the_dit_once_with_training_parity_exclusions(tmp_path, mo
         tmp_path,
         frame_count=5,
         allow_experimental_duration=True,
-        output=str(tmp_path / "result.mp4"),
+        save_path=str(tmp_path / "result.mp4"),
         device="cpu",
         attn_mode="torch",
         split_attn=False,
@@ -573,7 +573,7 @@ def test_latent_decode_mode_loads_only_the_vaes(tmp_path, monkeypatch):
 
     args = _session_args(
         tmp_path,
-        output=str(tmp_path / "decoded"),
+        save_path=str(tmp_path / "decoded"),
         latent_path=[str(video_file), str(image_file)],
         disable_numpy_memmap=False,
     )

--- a/tests/test_minimax_h3_generation_request.py
+++ b/tests/test_minimax_h3_generation_request.py
@@ -23,14 +23,22 @@ from musubi_tuner.training.sampling_prompts import line_to_prompt_dict
 
 
 def test_generation_cli_defaults_are_the_request_defaults():
-    args = generation_parser().parse_args(["--task", "t2va", "--output", "out.mp4"])
+    args = generation_parser().parse_args(["--task", "t2va", "--save_path", "out.mp4"])
 
     assert request_from_args(args) == H3GenerationRequest(task="t2va")
+
+    # the house flags land on the request field names: --video_size is height then width
+    args = generation_parser().parse_args(
+        ["--task", "t2va", "--save_path", "out", "--video_size", "1344", "768", "--video_length", "39", "--infer_steps", "7"]
+    )
+    request = request_from_args(args)
+    assert (request.height, request.width, request.frame_count, request.steps) == (1344, 768, 39, 7)
+    assert not hasattr(args, "video_size")
 
 
 def test_trainer_and_generation_share_the_sampler_and_text_encoder_options():
     train = vars(minimax_h3_setup_parser(argparse.ArgumentParser()).parse_args(["--task", "t2va"]))
-    generate = vars(generation_parser().parse_args(["--task", "t2va", "--output", "out.mp4"]))
+    generate = vars(generation_parser().parse_args(["--task", "t2va", "--save_path", "out.mp4"]))
 
     for name in (
         "h3_shift_video",
@@ -103,7 +111,7 @@ def test_request_validation_covers_the_canvas_timeline_and_task_inputs(tmp_path)
     with pytest.raises(ValueError, match="released 5-15s"):
         validate_generation_request(H3GenerationRequest(task="t2va", prompt="p", frame_count=39))
     validate_generation_request(H3GenerationRequest(task="t2va", prompt="p", frame_count=39, allow_experimental_duration=True))
-    with pytest.raises(ValueError, match="--steps must be positive"):
+    with pytest.raises(ValueError, match="--infer_steps must be positive"):
         validate_generation_request(H3GenerationRequest(task="t2va", prompt="p", steps=0))
     with pytest.raises(ValueError, match="h3_shift_audio"):
         validate_generation_request(H3GenerationRequest(task="t2va", prompt="p", h3_shift_audio=0.0))

--- a/tests/test_minimax_h3_sampling.py
+++ b/tests/test_minimax_h3_sampling.py
@@ -334,7 +334,7 @@ def _generation_args(tmp_path, *, task="t2va", **overrides):
         "allow_experimental_duration": False,
         "steps": 2,
         "seed": 1,
-        "output": str(tmp_path / "output.mp4"),
+        "save_path": str(tmp_path / "output.mp4"),
         "output_type": "video",
         "output_name": None,
         "condition_image": None,
@@ -471,15 +471,15 @@ def test_one_frame_time_overrides_map_pixel_frame_indices_to_rotary_units():
 
 def test_generation_validation_gates_the_one_frame_mode(tmp_path):
     png = str(tmp_path / "output.png")
-    validate_generation_args(_generation_args(tmp_path, frame_count=1, output=png))
-    validate_generation_args(_generation_args(tmp_path, frame_count=1, output=png, one_frame_inference="target_index=240"))
+    validate_generation_args(_generation_args(tmp_path, frame_count=1, save_path=png))
+    validate_generation_args(_generation_args(tmp_path, frame_count=1, save_path=png, one_frame_inference="target_index=240"))
 
     with pytest.raises(ValueError, match="must use .png"):
         validate_generation_args(_generation_args(tmp_path, frame_count=1))
-    with pytest.raises(ValueError, match="require --frame_count 1"):
+    with pytest.raises(ValueError, match="require --video_length 1"):
         validate_generation_args(_generation_args(tmp_path, one_frame_inference="target_index=1"))
     with pytest.raises(ValueError, match="control_index applies only to FL2VA"):
-        validate_generation_args(_generation_args(tmp_path, frame_count=1, output=png, one_frame_inference="control_index=0"))
+        validate_generation_args(_generation_args(tmp_path, frame_count=1, save_path=png, one_frame_inference="control_index=0"))
 
     first = tmp_path / "first.png"
     first.touch()
@@ -488,27 +488,27 @@ def test_generation_validation_gates_the_one_frame_mode(tmp_path):
             tmp_path,
             task="fl2va",
             frame_count=1,
-            output=png,
+            save_path=png,
             first_frame=str(first),
             one_frame_inference="target_index=24,control_index=0",
         )
     )
     with pytest.raises(ValueError, match="one entry per condition image"):
-        validate_generation_args(_generation_args(tmp_path, task="fl2va", frame_count=1, output=png, first_frame=str(first)))
+        validate_generation_args(_generation_args(tmp_path, task="fl2va", frame_count=1, save_path=png, first_frame=str(first)))
     with pytest.raises(ValueError, match="one entry per condition image"):
         validate_generation_args(
             _generation_args(
                 tmp_path,
                 task="fl2va",
                 frame_count=1,
-                output=png,
+                save_path=png,
                 first_frame=str(first),
                 one_frame_inference="control_index=0;240",
             )
         )
     with pytest.raises(ValueError, match="requires --first_frame and/or --last_frame"):
         validate_generation_args(
-            _generation_args(tmp_path, task="fl2va", frame_count=1, output=png, one_frame_inference="control_index=0")
+            _generation_args(tmp_path, task="fl2va", frame_count=1, save_path=png, one_frame_inference="control_index=0")
         )
 
 
@@ -629,7 +629,7 @@ def test_generation_orchestrates_t2va_sampling_decode_and_mux_without_co_residen
         tmp_path,
         frame_count=5,
         allow_experimental_duration=True,
-        output=str(tmp_path / "result.mp4"),
+        save_path=str(tmp_path / "result.mp4"),
         device="cpu",
         attn_mode="torch",
         split_attn=False,
@@ -699,7 +699,7 @@ def test_generation_orchestrates_t2va_sampling_decode_and_mux_without_co_residen
 
     output = generate.run_generation(args)
 
-    assert output == Path(args.output)
+    assert output == Path(args.save_path)
     assert [event[0] for event in events] == [
         "transformer",
         "load_video_vae",
@@ -710,7 +710,7 @@ def test_generation_orchestrates_t2va_sampling_decode_and_mux_without_co_residen
     assert next(event for event in events if event[0] == "load_video_vae")[2] is torch.float16
     assert captured["decoded"].video.shape == (5, 4, 4, 3)
     assert captured["decoded"].audio.shape == (2, 6667)
-    assert captured["output"] == Path(args.output)
+    assert captured["output"] == Path(args.save_path)
 
 
 def test_generation_trajectory_dump_writes_sigma_schedule_and_per_step_videos(tmp_path, monkeypatch):
@@ -720,7 +720,7 @@ def test_generation_trajectory_dump_writes_sigma_schedule_and_per_step_videos(tm
         tmp_path,
         frame_count=5,
         allow_experimental_duration=True,
-        output=str(tmp_path / "result.mp4"),
+        save_path=str(tmp_path / "result.mp4"),
         device="cpu",
         attn_mode="torch",
         split_attn=False,

--- a/tests/test_minimax_h3_temporal_stretch.py
+++ b/tests/test_minimax_h3_temporal_stretch.py
@@ -129,7 +129,9 @@ def test_layout_validation_rejects_inconsistent_stretch_combinations():
 
 
 def _prompt_args(**overrides):
-    args = generate.setup_parser().parse_args(["--task", "t2va", "--output", "out.mp4", "--prompt", "p", "--frame_count", "124"])
+    args = generate.setup_parser().parse_args(
+        ["--task", "t2va", "--save_path", "out.mp4", "--prompt", "p", "--video_length", "124"]
+    )
     args.output_name = None
     for key, value in overrides.items():
         setattr(args, key, value)
@@ -145,7 +147,7 @@ def test_prompt_validation_bounds_the_stretch_arguments():
     with pytest.raises(ValueError, match="requires an --output_fps below"):
         generate.validate_prompt_args(_prompt_args(stretch_keep_bands=3))
     with pytest.raises(ValueError, match="one-frame"):
-        generate.validate_prompt_args(_prompt_args(frame_count=1, output_fps=12, output="out.png"))
+        generate.validate_prompt_args(_prompt_args(frame_count=1, output_fps=12, save_path="out.png"))
     # the released 5-15 s duration gate reads the real (stretched) duration
     generate.validate_prompt_args(_prompt_args(output_fps=12))  # 124/12 = 10.3 s
     with pytest.raises(ValueError, match="outside the released 5-15s range"):

--- a/tests/test_minimax_h3_training.py
+++ b/tests/test_minimax_h3_training.py
@@ -1460,7 +1460,7 @@ def test_one_frame_sample_request_parses_the_of_option():
             {"prompt": "x", "frame_count": 1, "ref": ["face.png"], "one_frame": "target_index=0,control_index=0"},
             "control_index applies only to FL2VA",
         ),
-        ({}, {"prompt": "x", "frame_count": 124, "one_frame": "target_index=24"}, r"require --frame_count 1"),
+        ({}, {"prompt": "x", "frame_count": 124, "one_frame": "target_index=24"}, r"require --video_length 1"),
         # fl2va one-frame: control_index is mandatory, one entry per condition image
         (
             {"task": "fl2va"},


### PR DESCRIPTION
## Summary

Last rename before dev reaches main. `minimax_h3_generate_video.py` now uses the same option names as the other generation scripts:

| before | after |
| --- | --- |
| `--output` | `--save_path` |
| `--width W --height H` | `--video_size H W` |
| `--frame_count` | `--video_length` |
| `--steps` | `--infer_steps` |

Kept on purpose:
- `--output_fps` is not renamed to `--fps`: it is the temporal stretch dial (rotary timeline and audio length change), not only the container rate.
- `--h3_allow_experimental_sample_duration` in the trainer: it applies to training-time samples only; the dataset duration gate is at cache time (`--allow_experimental_duration`).
- `--attn_mode` matches every other generation script (the `sdpa`→`torch` remap goes once #1092 lands the alias in the shared backend).

## Design

- `H3GenerationRequest` field names are unchanged. `--video_length` / `--infer_steps` land on `frame_count` / `steps` via `dest=`, and `--video_size` lands on `height` / `width` through a small argparse action, so `request_from_args`, the prompt-line overrides (`--w/--h/--f/--s`) and the trainer's sample requests are untouched.
- `--save_path` keeps the H3 extras (explicit file name for a single generation, no-clobber renaming) on top of the shared directory convention; a directory behaves like the other scripts.
- `_time_flag` replaced by the shared `hv_generate_video.get_time_flag`.
- Docs (`docs/minimax_h3.md`, `docs/minimax_h3_1f.md`) and error messages follow the new names.

## Tests

- New assertion in `tests/test_minimax_h3_generation_request.py`: the house flags map onto the request fields (`--video_size 1344 768` → height 1344, width 768).
- Full suite: 706 passed.

Not smoke-tested on hardware; the change is CLI-surface only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDFfKhCCDcKz2NRysn9A1A
