### PR TITLE
Drop the per-script sdpa->torch remaps after #1092

### DIFF
--- a/src/musubi_tuner/hv_generate_video.py
+++ b/src/musubi_tuner/hv_generate_video.py
@@ -652,8 +652,6 @@ def main():
         loading_device = "cpu"  # if blocks_to_swap > 0 else device
 
         logger.info(f"Loading DiT model from {args.dit}")
-        if args.attn_mode == "sdpa":
-            args.attn_mode = "torch"
 
         # if image_latents is given, the model should be I2V model, so the in_channels should be 32
         dit_in_channels = args.dit_in_channels if args.dit_in_channels is not None else (32 if image_latents is not None else 16)

--- a/src/musubi_tuner/ideogram4_generate_image.py
+++ b/src/musubi_tuner/ideogram4_generate_image.py
@@ -90,8 +90,6 @@ def main():
     height, width = args.image_size
     device = torch.device(args.device if args.device is not None else "cuda" if torch.cuda.is_available() else "cpu")
     dtype = str_to_dtype(args.dtype)
-    # "sdpa" is a user-facing alias for the shared attention()'s "torch" mode.
-    attn_mode = "torch" if args.attn_mode == "sdpa" else args.attn_mode
 
     ideogram4_utils.validate_prompt(args.prompt, warn_only=args.warn_on_caption_issues)
 
@@ -119,7 +117,7 @@ def main():
         dtype=dtype,
         expected_model_type=ideogram4_utils.IDEOGRAM4_COND_MODEL_TYPE,
         disable_mmap=args.disable_numpy_memmap,
-        attn_mode=attn_mode,
+        attn_mode=args.attn_mode,
         split_attn=args.split_attn,
     )
     # Ideogram 4's DiT is a frozen pre-quantized FP8 base that cannot have LoRA merged into it
@@ -143,7 +141,7 @@ def main():
             dtype=dtype,
             expected_model_type=ideogram4_utils.IDEOGRAM4_UNCOND_MODEL_TYPE,
             disable_mmap=args.disable_numpy_memmap,
-            attn_mode=attn_mode,
+            attn_mode=args.attn_mode,
             split_attn=args.split_attn,
         )
     else:

--- a/src/musubi_tuner/minimax_h3/model.py
+++ b/src/musubi_tuner/minimax_h3/model.py
@@ -424,7 +424,7 @@ class Attention(nn.Module):
         self.num_heads = num_heads
         self.head_dim = head_dim
         self.inner_dim = num_heads * head_dim
-        self.attn_mode = "torch" if attn_mode == "sdpa" else attn_mode
+        self.attn_mode = attn_mode
         self.split_attn = split_attn
         self.qkv_proj = nn.Linear(hidden_size, self.inner_dim * 3, bias=False, dtype=dtype, device=device)
         self.q_norm = nn.RMSNorm(head_dim, eps=qk_norm_eps, dtype=dtype, device=device)

--- a/src/musubi_tuner/minimax_h3_generate_video.py
+++ b/src/musubi_tuner/minimax_h3_generate_video.py
@@ -466,7 +466,7 @@ def _load_transformer(args: argparse.Namespace, device: torch.device) -> tuple[t
         args.dit,
         device="cpu" if load_on_cpu else device,
         dtype=torch.bfloat16,
-        attn_mode="torch" if args.attn_mode == "sdpa" else args.attn_mode,
+        attn_mode=args.attn_mode,
         split_attn=args.split_attn,
         disable_numpy_memmap=args.disable_numpy_memmap,
         convrot_int8=args.convrot_int8,

--- a/tests/test_ideogram4_synthetic.py
+++ b/tests/test_ideogram4_synthetic.py
@@ -631,7 +631,7 @@ class Ideogram4InputAndCacheTests(unittest.TestCase):
         args = parser.parse_args(base + ["--attn_mode", "flash", "--split_attn"])
         self.assertEqual(args.attn_mode, "flash")
         self.assertTrue(args.split_attn)
-        # "sdpa" is accepted as a choice (normalized to "torch" inside main()).
+        # "sdpa" is accepted as a choice (the shared attention dispatcher treats it as "torch").
         args_sdpa = parser.parse_args(base + ["--attn_mode", "sdpa"])
         self.assertEqual(args_sdpa.attn_mode, "sdpa")
 


### PR DESCRIPTION
## Summary

Follow-up to #1092. The shared attention dispatchers now accept `sdpa` as an alias of `torch`, so the mode vocabulary is owned in one place. This removes the four caller-side copies of that alias:

- `hv_generate_video.py` (rewrote `args.attn_mode` in place)
- `ideogram4_generate_image.py` (local `attn_mode` variable)
- `minimax_h3_generate_video.py` (at `load_h3_transformer`)
- `minimax_h3/model.py` `Attention.__init__`

Behavior is unchanged for every `--attn_mode` value; the H3 model's accepted-mode set still lists `sdpa`.

## Tests

706 passed; ruff check/format clean. No hardware run needed (pure removal of redundant remaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDFfKhCCDcKz2NRysn9A1A
